### PR TITLE
PISM Compile Fixes

### DIFF
--- a/configs/machines/ollie.yaml
+++ b/configs/machines/ollie.yaml
@@ -57,6 +57,15 @@ hyper_flag: "" # No hyperthreading on ollie
 #- "load pism_externals"
 #- "I_MPI_FABRICS=shm:tmi"
 
+choose_general.setup_name:
+        pism:
+                add_module_actions:
+                    - "unload netcdf"
+                    - "unload intel.compiler"
+                    - "load pism_externals"
+                add_export_vars:
+                    - "I_MPI_FABRICS=shm:tmi"
+
 useMPI: intelmpi
 
 module_actions:

--- a/configs/pism/pism.yaml
+++ b/configs/pism/pism.yaml
@@ -34,12 +34,6 @@ domain: "greenland"
 resolution: 20km
 lresume: false
 
-parent_date: 22941231
-parent_expid: khw0030
-parent_dir: "${pool_dir}/MPIESM/restart/dev/${parent_expid}/restart/echam6"
-
-
-# default directories
 
 model_dir: "${general.esm_master.dir}/pism-${version}"
 setup_dir: "${model_dir}"
@@ -60,29 +54,6 @@ choose_domain:
                                 - a
                                 - b
                                 - b
-choose_resolution:
-        T63:
-                levels: "L47"
-                time_step: 450
-                _nx: 192
-                _ny: 96
-                choose_computer.cores_per_node:
-                        24:
-                                nproca: 24
-                                nprocb: 18
-                        36:
-                                nproca: 24
-                                nprocb: 18
-        T31:
-                levels: "L19"
-                time_step: 450
-                _nx: 96
-                _ny: 48
-        T127:
-                levels: "L47"
-                time_step: 200
-                _nx: 384
-                _ny: 192
 
 bin_files:
         "pism_bin": "pism_bin"
@@ -90,100 +61,3 @@ bin_sources:
         "pism_bin": "${bin_dir}/pismr"
 bin_in_work:
         "pism_bin": "pismr"
-
-input_files:
-        "cldoptprops": "cldoptprops"
-        "janspec": "janspec"
-        "jansurf": "jansurf"
-        "rrtmglw": "rrtmglw"
-        "rrtmgsw": "rrtmgsw"
-        "tslclim": "tslclim"
-        "vgratclim": "vgratclim"
-        "vltclim": "vltclim"
-
-input_in_work:
-        "cldoptprops": "ECHAM6_CldOptProps.nc"
-        "janspec": "unit.23"
-        "jansurf": "unit.24"
-        "rrtmglw": "rrtmg_lw.nc"
-        "rrtmgsw": "rrtmg_sw.nc"
-        "tslclim": "unit.92"
-        "vgratclim": "unit.91"
-        "vltclim": "unit.90"
-        "MAC-SP": "MAC-SP.nc"
-
-forcing_in_work:
-        sic: "unit.96"
-        sst: "unit.20"
-        aerocoarse: "aero_coarse_@YEAR@.nc"
-        aerofin: "aero_fine_@YEAR@.nc"
-        aerofarir: "aero_farir_@YEAR@.nc"
-        ozone: "ozon@YEAR@"
-        greenhouse: "greenhouse_gases.nc"
-        volcir: "strat_aerosol_ir_@YEAR@.nc"
-        volcsw: "strat_aerosol_sw_@YEAR@.nc"
-        volcsw: "strat_aerosol_sw_@YEAR@.nc"
-        swflux: "swflux_@YEAR@.nc"
-
-ignore_files:
-        "[[streams-->STREAM]]": STREAM
-        "[[streams-->STREAM]]_restart": STREAM_restart
-        "[[streams-->STREAM]]_codes": STREAM_codes
-
-ignore_sources:
-        "[[streams-->STREAM]]": ${general.expid}_${next_date!syear!smonth}.${next_date!sday}_STREAM
-        "[[streams-->STREAM]]_restart": restart_${general.expid}_STREAM.nc
-        "[[streams-->STREAM]]_codes": ${general.expid}_${next_date!syear!smonth}.${next_date!sday}_STREAM.codes
-
-ignore_in_workdir:
-        "[[streams-->STREAM]]": ${general.expid}_${next_date!syear!smonth}.${next_date!sday}_STREAM
-        "[[streams-->STREAM]]_restart": restart_${general.expid}_STREAM.nc
-        "[[streams-->STREAM]]_codes": ${general.expid}_${next_date!syear!smonth}.${next_date!sday}_STREAM.codes
-
-outdata_files:
-        "[[streams-->STREAM]]": STREAM
-        "[[streams-->STREAM]]_codes": STREAM_codes
-
-outdata_sources:
-        "[[streams-->STREAM]]": ${general.expid}_${start_date!syear!smonth}.${start_date!sday}_STREAM
-        "[[streams-->STREAM]]_codes": ${general.expid}_${start_date!syear!smonth}.${start_date!sday}_STREAM.codes
-
-outdata_in_workdir:
-        "[[streams-->STREAM]]": ${general.expid}_${start_date!syear!smonth}.${start_date!sday}_STREAM
-        "[[streams-->STREAM]]_codes": ${general.expid}_${start_date!syear!smonth}.${start_date!sday}_STREAM.codes
-
-restart_out_files:
-        "[[streams-->STREAM]]": STREAM
-
-restart_out_sources:
-        "[[streams-->STREAM]]": restart_${general.expid}_${other_date!syear!smonth!sday!shour!sminute!ssecond}_STREAM.nc
-
-restart_out_in_workdir:
-        "[[streams-->STREAM]]": restart_${general.expid}_${other_date!syear!smonth!sday!shour!sminute!ssecond}_STREAM.nc
-
-# Configuration Files:
-config_sources:
-        "pism_config.nc": "${namelist_dir}/namelist.echam"
-
-config_generate:
-        "pism_overrides.nc": null
-
-errors:
-        mo_exception:
-                check_frequency: 300
-                detection_method: "<--grep(mo_exeption.f90)-- standard_out"
-                error_message: |
-                        !!! DETECTED ERROR !!!
-                        Problem with echam >> mo_exception.f90 << has occured. Killing your job, sorry.
-                action_method:
-                        - "<--kill_job--"
-
-        wind_speed:
-                check_frequency: 300
-                detection_method: "<--grep(wind speed)-- standard_out"
-                error_message: |
-                        !!! DETECTED ERROR !!!
-                        high wind speed was found during your run, applying wind speed fix and resubmitting...
-                action_method:
-                        - "<--repair_job_after_windspeed--"
-

--- a/configs/pism/pism.yaml
+++ b/configs/pism/pism.yaml
@@ -26,13 +26,15 @@ license_text: |
 
 choose_computer.name:
     ollie:
-        add_module_actions:
+        add_computer.module_actions:
             - "load pism_externals"
-        add_export_vars:
+        add_computer.export_vars:
             - "I_MPI_FABRICS=shm:tmi"
     "*":
         add_module_actions:
+            - "None"
         add_export_vars:
+            - "None"
 
 executable: pismr
 version: 1.1.4
@@ -51,15 +53,17 @@ choose_domain:
         "greenland":
                 choose_resolution:
                         20km:
-                                - a
-                                - b
-                                - c
+                                nx: 50
+                                ny: 30
+                                nz: 100
+
+
         "nhem":
                 choose_resolution:
                         20km:
-                                - a
-                                - b
-                                - b
+                                nx: 50
+                                ny: 30
+                                nz: 100
 
 bin_files:
         "pism_bin": "pism_bin"

--- a/configs/pism/pism.yaml
+++ b/configs/pism/pism.yaml
@@ -24,9 +24,15 @@ license_text: |
         "GPL 3.0"
 
 
-module_actions:
-    - load pism_externals
-    - I_MPI_FABRICS=shm:tmi
+choose_computer.name:
+    ollie:
+        add_module_actions:
+            - "load pism_externals"
+        add_export_vars:
+            - "I_MPI_FABRICS=shm:tmi"
+    "*":
+        add_module_actions:
+        add_export_vars:
 
 executable: pismr
 version: 1.1.4

--- a/configs/pism/pism.yaml
+++ b/configs/pism/pism.yaml
@@ -24,17 +24,18 @@ license_text: |
         "GPL 3.0"
 
 
-choose_computer.name:
-    ollie:
-        add_computer.module_actions:
-            - "load pism_externals"
-        add_computer.export_vars:
-            - "I_MPI_FABRICS=shm:tmi"
-    "*":
-        add_module_actions:
-            - "None"
-        add_export_vars:
-            - "None"
+# PG: BUG!! This doesn't work, but should:
+#choose_computer.name:
+#    ollie:
+#        computer.module_actions:
+#            - "load pism_externals"
+#        computer.export_vars:
+#            - "I_MPI_FABRICS=shm:tmi"
+#    "*":
+#        add_module_actions:
+#            - "None"
+#        add_export_vars:
+#            - "None"
 
 executable: pismr
 version: 1.1.4


### PR DESCRIPTION
Several fixes to allow PISM to compile on Ollie. Requires that the yaml changes for PISM are defined in `ollie.yaml`, which isn't really what we want to have..

Also cleans out old ECHAM stuff from the `pism.yaml`; which was used as an initial template.