### PR TITLE
re-added oasis3-mct-foci to setup2models that somehow went missing

### DIFF
--- a/configs/esm_master/setups2models.yaml
+++ b/configs/esm_master/setups2models.yaml
@@ -574,6 +574,7 @@ couplings:
     components:
     - echam-6.3.05p2-foci
     - nemo-ORCA05_LIM2_KCM_AOW
+    - oasis3-mct-foci
     coupling_changes:
     - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-foci/CMakeLists.txt
   nemo-ORCA05_LIM2_KCM_AOW_FS_OASISMCT4+oifs43r3-foci:


### PR DESCRIPTION
oasis3-mct-foci entry went missing, needed for FOCI compile