### PR TITLE
fixed FOCI compile after setup2models splitup

### DIFF
--- a/configs/esm_master/components/nemo.yaml
+++ b/configs/esm_master/components/nemo.yaml
@@ -1,17 +1,9 @@
 available_versions:
-- ORCA05_LIM2_KCM_AOW_FS_OASISMCT4
-- 3.6-ogcm
-- ORCA05_LIM2_KCM_AGRIF_OASISMCT4
 - ORCA05_LIM2_KCM_AOW
+- ORCA05_LIM2_KCM_AGRIF_OASISMCT4
+- ORCA05_LIM2_KCM_AOW_FS_OASISMCT4
 - GYRE_XIOS
-- 3.6foci
-branch: esm-tools
 choose_nemo.version:
-  3.6-ogcm:
-    grid: GYRE_XIOS
-  3.6foci:
-    git-repository: https://gitlab.dkrz.de/foci/src/nemo.git
-    grid: ORCA05_LIM2_KCM_AOW
   GYRE_XIOS:
     requires:
     - xios-2.0_r982_ogcm
@@ -28,13 +20,6 @@ choose_nemo.version:
     branch: esm-tools
     destination: nemo-${nemobasemodel.version}/CONFIG/${nemo.version}
     git-repository: https://git.geomar.de/foci/src/nemo_config/${nemo.version}.git
-clean_command: cd CONFIG; ./makenemo -n ${nemo.grid} clean
-comp_command: export NEMO_TOPLEVEL=${model_dir}; cd CONFIG; ./makenemo -n ${grid}
-  -m ${computer.nemoarchfile} -j 24
-destination: nemo-3.6
-git-repository: https://gitlab.dkrz.de/foci/src/NEMOGCM.git
-install_bins: CONFIG/${nemo.grid}/BLD/bin/nemo.exe
 requires:
 - xios-2.0_r982
 - nemobasemodel-3.6foci
-version: 3.6-ogcm

--- a/configs/esm_master/components/oifs.yaml
+++ b/configs/esm_master/components/oifs.yaml
@@ -1,10 +1,10 @@
 available_versions:
+- 40r1
 - 43r3-awi
 - 43r3
 - 40r1-foci
 - 43r3-foci
 - 40r1-agcm
-- 40r1
 choose_version:
   40r1:
     branch: foci_conserv
@@ -34,5 +34,3 @@ clean_command: rm -rf make/esm
 comp_command: cd make; ../fcm/bin/fcm make -v -j8 -f oifs.cfg
 git-repository: https://gitlab.dkrz.de/modular_esm/oifs-40r1.git
 install_bins: make/esm/oifs/bin/master.exe
-requires:
-- oasis3-mct-4.0

--- a/configs/esm_master/components/xios.yaml
+++ b/configs/esm_master/components/xios.yaml
@@ -1,6 +1,5 @@
 archfile: ESMTOOLS_generic_intel
 available_versions:
-- ogcm
 - 2.0_r982_ogcm
 - 2.0_r982
 branch: esm-tools
@@ -12,9 +11,6 @@ choose_version:
   2.0_r982_ogcm:
     archfile: ESMTOOLS_generic_intel
     use_oasis: ''
-  ogcm:
-    compile_command: export XIOS_TOPLEVEL=${model_dir}; ./make_xios --arch ${computer.xiosarchfile}
-      --netcdf_lib netcdf4_par --full --job 24
 clean_command: rm -rf bin lib obj ppsrc
 comp_command: export XIOS_TOPLEVEL=${model_dir}; ./make_xios --arch ${archfile} --netcdf_lib
   netcdf4_par --full ${use_oasis} --job 24; cp bin/xios_server.exe bin/xios.x

--- a/configs/esm_master/couplings/nemo-3.6foci+echam-6.3.05p2.yaml
+++ b/configs/esm_master/couplings/nemo-3.6foci+echam-6.3.05p2.yaml
@@ -1,6 +1,0 @@
-components:
-- echam-6.3.05p2
-- nemo-3.6foci
-- oasis3-mct-foci
-coupling_changes:
-- sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2/CMakeLists.txt

--- a/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci-o3.yaml
+++ b/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci-o3.yaml
@@ -1,6 +1,0 @@
-components:
-- oifs-40r1-foci
-- nemo-3.6foci
-- oasis3-mct-ec-earth
-- rnfmap-focioifs
-prepend_compile_command: export FOCI_TOPLEVEL=${setup_dir}

--- a/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci-o4.yaml
+++ b/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci-o4.yaml
@@ -1,6 +1,0 @@
-components:
-- oifs-40r1-foci
-- nemo-3.6foci
-- oasis3-mct-4.0
-- rnfmap-focioifs
-prepend_compile_command: export FOCI_TOPLEVEL=${setup_dir}

--- a/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci.yaml
+++ b/configs/esm_master/couplings/nemo-3.6foci+oifs40r1-foci.yaml
@@ -1,6 +1,0 @@
-components:
-- oifs-40r1-foci
-- nemo-3.6foci
-- oasis3-mct-foci
-- rnfmap-focioifs
-prepend_compile_command: export FOCI_TOPLEVEL=${setup_dir}

--- a/configs/esm_master/couplings/nemo-3.6foci+oifs40r1.yaml
+++ b/configs/esm_master/couplings/nemo-3.6foci+oifs40r1.yaml
@@ -1,6 +1,0 @@
-components:
-- oifs-40r1
-- nemo-3.6foci
-- oasis3-mct-foci
-- rnfmap-focioifs
-prepend_compile_command: export FOCI_TOPLEVEL=${setup_dir}

--- a/configs/esm_master/setups/foci.yaml
+++ b/configs/esm_master/setups/foci.yaml
@@ -1,10 +1,6 @@
 available_versions:
 - default
-- '1.0'
 choose_version:
-  '1.0':
-    couplings:
-    - nemo-3.6foci+echam-6.3.05p2
   default:
     couplings:
     - nemo-ORCA05_LIM2_KCM_AOW+echam-6.3.05p2-foci

--- a/configs/esm_master/setups/focioifs.yaml
+++ b/configs/esm_master/setups/focioifs.yaml
@@ -1,9 +1,5 @@
 available_versions:
-- vvl-o3
-- vvl-o3-awi3
-- vvl-o4
 - agrif
-- vvl
 - '2.0'
 choose_version:
   '2.0':
@@ -12,47 +8,3 @@ choose_version:
   agrif:
     couplings:
     - nemo-ORCA05_LIM2_KCM_AGRIF_OASISMCT4+oifs43r3-foci
-  vvl:
-    couplings:
-    - nemo-3.6foci+oifs40r1-foci
-    nemo:
-      version: 3.6foci
-    oasis3-mct:
-      version: foci
-    oifs:
-      version: 40r1-foci
-    rnfmap:
-      version: focioifs
-  vvl-o3:
-    couplings:
-    - nemo-3.6foci+oifs40r1-foci-o3
-    nemo:
-      version: 3.6foci
-    oasis3-mct:
-      version: ec-earth
-    oifs:
-      version: 40r1-foci
-    rnfmap:
-      version: focioifs
-  vvl-o3-awi3:
-    couplings:
-    - nemo-3.6foci+oifs40r1
-    nemo:
-      version: 3.6foci
-    oasis3-mct:
-      version: foci
-    oifs:
-      version: 40r1
-    rnfmap:
-      version: focioifs
-  vvl-o4:
-    couplings:
-    - nemo-3.6foci+oifs40r1-foci-o4
-    nemo:
-      version: 3.6foci
-    oasis3-mct:
-      version: '4.0'
-    oifs:
-      version: 40r1-foci
-    rnfmap:
-      version: focioifs


### PR DESCRIPTION
as the splitup was based on an old setup2models.yaml (at least w.r.t
FOCI settings)