### PR TITLE
Hotfix/standalone runscripts

### DIFF
--- a/docs/esm_master.rst
+++ b/docs/esm_master.rst
@@ -61,3 +61,15 @@ The download and installation will always occur in the **current working directo
 You can get further help with::
 
     $ esm_master --help
+    
+ 
+Configuring esm-master for Compile-Time Overrides
+-------------------------------------------------
+
+It is possible that some models have special compile-time settings that need to be included, overriding the machine defaults. Rather than placing these changes in ``configs/machines/NAME.yaml``, they can be instead placed in special blocks of the component or model configurations, e.g.:
+
+.. code-block:: yaml
+    
+    runtime_environment_changes:
+            add_export_vars:
+                    [ ... ]

--- a/docs/esm_master.rst
+++ b/docs/esm_master.rst
@@ -70,6 +70,8 @@ It is possible that some models have special compile-time settings that need to 
 
 .. code-block:: yaml
     
-    runtime_environment_changes:
+    compiletime_environment_changes:
             add_export_vars:
                     [ ... ]
+
+The same is also possible for specifying ``runtime_environment_changes``.

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.1.5"
+__version__ = "4.1.6"

--- a/runscripts/awicm/echam-mistral-restart-monthly.run
+++ b/runscripts/awicm/echam-mistral-restart-monthly.run
@@ -18,7 +18,7 @@ SCENARIO_echam="PI-CTRL"
 
 RES_echam=T63
 
-MODEL_DIR_echam=/work/ab0995/a270058/modelcodes/echam-6.3.04p1//
+MODEL_DIR=/work/ab0995/a270058/modelcodes/echam-6.3.04p1//
 BASE_DIR=/work/ab0995/a270058/esm_yaml_test/
 
 NYEAR=0           # Number of years per run

--- a/runscripts/echam/echam-mistral-restart-monthly.run
+++ b/runscripts/echam/echam-mistral-restart-monthly.run
@@ -18,7 +18,7 @@ SCENARIO_echam="PI-CTRL"
 
 RES_echam=T63
 
-MODEL_DIR_echam=/work/ab0995/a270058/modelcodes/echam-6.3.04p1//
+MODEL_DIR=/work/ab0995/a270058/modelcodes/echam-6.3.04p1//
 BASE_DIR=/work/ab0995/a270058/esm_yaml_test/
 
 NYEAR=0           # Number of years per run

--- a/runscripts/echam/echam-ollie-initial-monthly.run
+++ b/runscripts/echam/echam-ollie-initial-monthly.run
@@ -18,7 +18,7 @@ SCENARIO_echam="PI-CTRL"
 
 RES_echam=T63
 
-MODEL_DIR_echam=/work/ollie/dbarbi/modelcodes/echam-6.3.04p1//
+MODEL_DIR=/work/ollie/dbarbi/modelcodes/echam-6.3.04p1//
 BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
 
 NYEAR=0           # Number of years per run

--- a/runscripts/echam/echam-ollie-restart-monthly.run
+++ b/runscripts/echam/echam-ollie-restart-monthly.run
@@ -18,7 +18,7 @@ SCENARIO_echam="PI-CTRL"
 
 RES_echam=T63
 
-MODEL_DIR_echam=/work/ollie/dbarbi/modelcodes/echam-6.3.04p1//
+MODEL_DIR=/work/ollie/dbarbi/modelcodes/echam-6.3.04p1//
 BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
 
 NYEAR=0           # Number of years per run

--- a/runscripts/fesom/fesom-mistral-initial-monthly.run
+++ b/runscripts/fesom/fesom-mistral-initial-monthly.run
@@ -18,7 +18,7 @@ SCENARIO_fesom="PI-CTRL"
 
 RES_fesom=CORE2
 
-MODEL_DIR_fesom=${HOME}/esm-tools/fesom-1.4/
+MODEL_DIR=${HOME}/esm-tools/fesom-1.4/
 BASE_DIR=/mnt/lustre02/work/ab0995/a270058/esm_yaml_test/
 
 POOL_DIR_fesom=/mnt/lustre02//work/bm0944/input/

--- a/runscripts/fesom/fesom-ollie-initial-monthly.run
+++ b/runscripts/fesom/fesom-ollie-initial-monthly.run
@@ -17,7 +17,7 @@ SCENARIO_fesom="PI-CTRL"
 
 RES_fesom=CORE2
 
-MODEL_DIR_fesom=/work/ollie/dbarbi/modelcodes/fesom-1.4/
+MODEL_DIR=/work/ollie/dbarbi/modelcodes/fesom-1.4/
 BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
 
 POOL_DIR_fesom=/work/ollie/pool/FESOM/

--- a/runscripts/fesom2/fesom2-ollie-initial-monthly.run
+++ b/runscripts/fesom2/fesom2-ollie-initial-monthly.run
@@ -17,7 +17,7 @@ SCENARIO_fesom="PI-CTRL"
 
 RES_fesom=CORE2
 
-MODEL_DIR_fesom=/work/ollie/dbarbi/modelcodes/fesom-2.0/
+MODEL_DIR=/work/ollie/dbarbi/modelcodes/fesom-2.0/
 BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
 
 POOL_DIR_fesom=/work/ollie/pool/FESOM/

--- a/runscripts/fesom2/fesom2-ollie-initial-yearly.run
+++ b/runscripts/fesom2/fesom2-ollie-initial-yearly.run
@@ -17,7 +17,7 @@ SCENARIO_fesom2="PI-CTRL"
 
 RES_fesom2=CORE2
 
-MODEL_DIR_fesom2=/work/ollie/dbarbi/modelcodes/fesom-2.0/
+MODEL_DIR=/work/ollie/dbarbi/modelcodes/fesom-2.0/
 BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
 
 POOL_DIR_fesom2=/work/ollie/pool/FESOM/

--- a/runscripts/untested_runs/echam/echam_mistral.run
+++ b/runscripts/untested_runs/echam/echam_mistral.run
@@ -25,11 +25,11 @@ FINAL_DATE_echam_standalone=1853-12-31          # Final date of the experiment
 
 SCENARIO_echam="PI-CTRL"
 
-MODEL_DIR_echam_standalone=${HOME}/esm-master/echam-6.3.04p1/
+MODEL_DIR=${HOME}/esm-master/echam-6.3.04p1/
 
-LCTLIBDEF_jsbach=${MODEL_DIR_echam_standalone}/lctlib_nlct21.def
+LCTLIBDEF_jsbach=${MODEL_DIR}/lctlib_nlct21.def
 
-BIN_DIR_echam_standalone=${MODEL_DIR_echam_standalone}/src/echam/bin/
+BIN_DIR_echam_standalone=${MODEL_DIR}/src/echam/bin/
 
 BASE_DIR=${WORK}/esm-experiments/
 

--- a/runscripts/untested_runs/fesom2/fesom-2.0_MR_spinup_mistral.run
+++ b/runscripts/untested_runs/fesom2/fesom-2.0_MR_spinup_mistral.run
@@ -25,9 +25,9 @@ fesom_VERSION="2.0"
 EXE_fesom=fesom.x
 use_hyperthreading=0
 
-MODEL_DIR_fesom_standalone=${HOME}/esm-master/fesom-2.0/
+MODEL_DIR=${HOME}/esm-master/fesom-2.0/
 
-BIN_DIR_fesom=${MODEL_DIR_fesom_standalone}/bin/
+BIN_DIR_fesom=${MODEL_DIR}/bin/
 
 BASE_DIR=/mnt/lustre01/work/ba1035/a270092/runtime/FESOM2/
 

--- a/runscripts/untested_runs/fesom2/fesom-2.0_mistral.run
+++ b/runscripts/untested_runs/fesom2/fesom-2.0_mistral.run
@@ -25,9 +25,9 @@ fesom_VERSION="2.0"
 EXE_fesom=fesom.x
 use_hyperthreading=0
 
-MODEL_DIR_fesom_standalone=${HOME}/esm-master/fesom-2.0/
+MODEL_DIR=${HOME}/esm-master/fesom-2.0/
 
-BIN_DIR_fesom=${MODEL_DIR_fesom_standalone}/bin/
+BIN_DIR_fesom=${MODEL_DIR}/bin/
 
 BASE_DIR=/mnt/lustre01/work/ba1035/a270092/runtime/
 

--- a/runscripts/untested_runs/nemo/nemo_3.6_standalone_test.run
+++ b/runscripts/untested_runs/nemo/nemo_3.6_standalone_test.run
@@ -26,9 +26,9 @@ INITIAL_DATE_nemo_standalone=0001-01-01 # initial exp. date
 FINAL_DATE_nemo_standalone=0001-01-31   # final date of the experiment
 CURRENT_DATE_nemo_standalone=date_file  # final date of the experiment
 
-MODEL_DIR_nemo_standalone=${HOME}/esm-tools/esm-master/nemo-3.6-ogcm/
+MODEL_DIR=${HOME}/esm-tools/esm-master/nemo-3.6-ogcm/
 
-BIN_DIR_nemo_standalone=${MODEL_DIR_nemo_standalone}/bin/
+BIN_DIR_nemo_standalone=${MODEL_DIR}/bin/
 
 BASE_DIR=/work/bb0519/${USER}/esm-experiments/
 

--- a/runscripts/untested_runs/oifsamip/oifsamip.run
+++ b/runscripts/untested_runs/oifsamip/oifsamip.run
@@ -30,10 +30,10 @@ use_hyperthreading=0
 LRESUME_oifs=0
 LRESUME_oasis3mct=0
 
-MODEL_DIR_oifsamip=/pf/a/a270092/testbed/esm-master/oifsamip
+MODEL_DIR=/pf/a/a270092/testbed/esm-master/oifsamip
 
-BIN_DIR_oifs=${MODEL_DIR_oifsamip}/bin/
-BIN_DIR_amip=${MODEL_DIR_oifsamip}/bin/
+BIN_DIR_oifs=${MODEL_DIR}/bin/
+BIN_DIR_amip=${MODEL_DIR}/bin/
 
 BASE_DIR=/mnt/lustre01/work/ba1035/a270092/runtime/oifsamip
 

--- a/runscripts/untested_runs/pism/pi_awicm.run
+++ b/runscripts/untested_runs/pism/pi_awicm.run
@@ -14,7 +14,7 @@ machine_name="ollie"   					# only ollie supported yet
 setup_name="pism_standalone"				# mpiesm, pism_mpiesm, echam. mpiom, or pism
 
 ###############################################################################
-MODEL_DIR_pism_standalone=/home/ollie/dbarbi/mpiesm/branches/withPISM/src/pism0.7
+MODEL_DIR=/home/ollie/dbarbi/mpiesm/branches/withPISM/src/pism0.7
 BIN_DIR_pism_standalone=/global/AWIsoft/tkleiner/pism/snowflake_intel_impi/bin
 BASE_DIR=/work/ollie/pgierz/PISM
 POOL_DIR_pism_standalone=/work/ollie/pgierz/pool_pism/

--- a/runscripts/untested_runs/pism/pism.run
+++ b/runscripts/untested_runs/pism/pism.run
@@ -45,7 +45,7 @@ check=0
 BASE_DIR=
 
 # PISM Settings
-MODEL_DIR_pism_standalone=$PISM_ROOT
+MODEL_DIR=$PISM_ROOT
 BIN_DIR_pism_standalone=$PISM_BIN
 POOL_DIR_pism_standalone=/work/ollie/pgierz/pool_pism
 

--- a/runscripts/untested_runs/pism/pism_ant16km.run
+++ b/runscripts/untested_runs/pism/pism_ant16km.run
@@ -89,10 +89,10 @@ CURRENT_DATE_pism_standalone=date_file
 if [ "${PATH_TO_pismr:-NotDefinedVariable}" != "NotDefinedVariable" ] ; then
     # If $PATH_TO_pismr is defined, use its value
     BIN_DIR_pism_standalone=${PATH_TO_pismr:-$(dirname $(which pismr))} # Explicit plus fallback
-    MODEL_DIR_pism_standalone=${MODEL_DIR_pism_standalone:-$(dirname ${BIN_DIR_pism_standalone})}
+    MODEL_DIR=${MODEL_DIR:-$(dirname ${BIN_DIR_pism_standalone})}
 else
     BIN_DIR_pism_standalone=${PISM_BIN%%/pismr}                         # $PISM_BIN set by the module
-    MODEL_DIR_pism_standalone=${PISM_ROOT:?Unknown variable}            # $PISM_ROOT set by the module
+    MODEL_DIR=${PISM_ROOT:?Unknown variable}            # $PISM_ROOT set by the module
 fi
 POOL_DIR_pism_standalone=/work/ollie/projects/PISM/ANTARCTIC_16km_PISMv07_Eq1old  # CHECK
 DOMAIN_pism='Antarctica'                                                          # CHECK
@@ -181,7 +181,7 @@ echo "[$0] PISM_POOL_INPUT0_LONLAT        = ${PISM_POOL_INPUT0_LONLAT}"
 echo "[$0] PISM_POOL_INPUT0_XY            = ${PISM_POOL_INPUT0_XY}"
 echo "[$0]"
 echo "[$0] BASE_DIR                       = ${BASE_DIR}"
-echo "[$0] MODEL_DIR_pism_standalone      = ${MODEL_DIR_pism_standalone}"
+echo "[$0] MODEL_DIR                      = ${MODEL_DIR}"
 echo "[$0] BIN_DIR_pism_standalone        = ${BIN_DIR_pism_standalone}"
 echo "[$0] POOL_DIR_pism_standalone       = ${POOL_DIR_pism_standalone}"
 echo "[$0] DOMAIN_pism                    = ${DOMAIN_pism}"

--- a/runscripts/untested_runs/pism/pism_example.run
+++ b/runscripts/untested_runs/pism/pism_example.run
@@ -17,7 +17,7 @@ ACCOUNT=shinck
 BASE_DIR=/work/ollie/pgierz/esm-experiments/
 
 # PISM Settings
-MODEL_DIR_pism_standalone=/global/AWIsoft/tkleiner/pism/0.7.3_intel_impi/
+MODEL_DIR=/global/AWIsoft/tkleiner/pism/0.7.3_intel_impi/
 BIN_DIR_pism_standalone=/global/AWIsoft/tkleiner/pism/0.7.3_intel_impi/bin/
 POOL_DIR_pism_standalone=/work/ollie/pgierz/pool_pism/
 

--- a/runscripts/untested_runs/pism/pism_nhemtest.run
+++ b/runscripts/untested_runs/pism/pism_nhemtest.run
@@ -14,7 +14,7 @@ setup_name="pism_standalone"				# mpiesm, pism_mpiesm, echam. mpiom, or pism
 check=1
 
 ###############################################################################
-MODEL_DIR_pism_standalone=/home/ollie/dbarbi/mpiesm/branches/withPISM/src/pism0.7
+MODEL_DIR=/home/ollie/dbarbi/mpiesm/branches/withPISM/src/pism0.7
 BIN_DIR_pism_standalone=/work/ollie/pgierz/pism0.7/bin/
 BASE_DIR_pism_standalone=/work/ollie/pgierz/PISM
 #POOL_DIR_pism_standalone=/work/ollie/pgierz/pool_pism/input/examples_greenland/

--- a/runscripts/untested_runs/vilma/vilma_standalone_longrun.run
+++ b/runscripts/untested_runs/vilma/vilma_standalone_longrun.run
@@ -16,17 +16,17 @@ ESM_USE_C_CALENDAR=1
 INITIAL_DATE_vilma_standalone=-123000-01-01        # Initial exp. date
 FINAL_DATE_vilma_standalone=-1-01-01          # Final date of the experiment
 
-MODEL_DIR_vilma_standalone=${HOME}/esm-master/vilma/
+MODEL_DIR=${HOME}/esm-master/vilma/
 
 OUTPUT_INTERVAL_vilma="1.0"
 
 LRESUME_vilma=0
 
-BIN_DIR_vilma=${MODEL_DIR_vilma_standalone}/bin/
+BIN_DIR_vilma=${MODEL_DIR}/bin/
 
 BASE_DIR=/work/ab0995/a270058/esm-experiments/vilma/
 
-POOL_DIR_vilma_standalone=${MODEL_DIR_vilma_standalone}
+POOL_DIR_vilma_standalone=${MODEL_DIR}
 
 NYEAR_vilma_standalone=1000          # Number of years per run
 

--- a/runscripts/untested_runs/vilma/vilma_standalone_shortrun.run
+++ b/runscripts/untested_runs/vilma/vilma_standalone_shortrun.run
@@ -16,17 +16,17 @@ ESM_USE_C_CALENDAR=1
 INITIAL_DATE_vilma_standalone=-123000-01-01        # Initial exp. date
 FINAL_DATE_vilma_standalone=-122801-01-01          # Final date of the experiment
 
-MODEL_DIR_vilma_standalone=${HOME}/esm-master/vilma/
+MODEL_DIR=${HOME}/esm-master/vilma/
 
 #OUTPUT_INTERVAL_vilma="1.0"
 
 LRESUME_vilma=0
 
-BIN_DIR_vilma=${MODEL_DIR_vilma_standalone}/bin/
+BIN_DIR_vilma=${MODEL_DIR}/bin/
 
 BASE_DIR=/work/ab0995/a270058/esm-experiments/vilma/
 
-POOL_DIR_vilma_standalone=${MODEL_DIR_vilma_standalone}
+POOL_DIR_vilma_standalone=${MODEL_DIR}
 
 NYEAR_vilma_standalone=100          # Number of years per run
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.5
+current_version = 4.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.1.5",
+    version="4.1.6",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Substitute MODEL_DIR_ by MODEL_DIR in the standalone bash runscritps to avoid a model_dir error when running esm_runscripts