### PR TITLE
Feature more dynamic configuration update

### DIFF
--- a/configs/esm_master/components/echam.yaml
+++ b/configs/esm_master/components/echam.yaml
@@ -26,16 +26,27 @@ choose_version:
   6.3.05p2:
     branch: esm-tools
     git-repository: https://gitlab.dkrz.de/foci/src/echam.git
+
+# kh 08.07.20 as a workaround the seetings from a previoius version are used to succesfully build awicmcr-CMIP6 on Mistral (see below)
+# merge todo: bring customizations for the different models in mistral.yaml for all models and clusters under one roof
+#  6.3.05p2-concurrent_radiation:
+#    branch: concurrent_radiation
+#    clean_command: rm -rf src/echam/bin; make clean
+#    comp_command: make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin;
+#      cp  bin/echam6 src/echam/bin/echam6
+#    conf_command: export OASIS3MCT_FC_LIB=$(pwd)/../lib/; export OASIS3MCTROOT=$(pwd)/../oasis/;
+#      ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps
+#      yaxt/tests/.deps; ./configure --with-fortran=intel
+#      INSTALL='/usr/bin/install -p'
+#    git-repository: https://gitlab.dkrz.de/PalMod/echam6-PalMod.git
+
   6.3.05p2-concurrent_radiation:
-    branch: concurrent_radiation
-    clean_command: rm -rf src/echam/bin; make clean
-    comp_command: make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin;
-      cp  bin/echam6 src/echam/bin/echam6
-    conf_command: export OASIS3MCT_FC_LIB=$(pwd)/../lib/; export OASIS3MCTROOT=$(pwd)/../oasis/;
-      ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps
-      yaxt/tests/.deps; ./configure --with-coupler=oasis3-mct --with-fortran=intel
-      INSTALL='/usr/bin/install -p'
-    git-repository: https://gitlab.dkrz.de/PalMod/echam6-PalMod.git
+      git-repository: "https://gitlab.dkrz.de/PalMod/echam6-PalMod.git"
+      branch: "concurrent_radiation"
+      comp_command: "./config/createMakefiles.pl; autoreconf -i --force; ./configure --with-fortran=intel INSTALL='/usr/bin/install -p'; make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin; cp  bin/echam6 src/echam/bin/echam6"
+
+      clean_command: "rm -rf src/echam/bin; rm -rf bin; make clean"
+
   6.3.05p2-foci:
     branch: esm-tools
     git-repository: https://git.geomar.de/foci/src/echam.git

--- a/configs/esm_master/components/oasis3-mct.yaml
+++ b/configs/esm_master/components/oasis3-mct.yaml
@@ -21,14 +21,19 @@ choose_version:
     branch: fociagrif
     git-repository: https://git.geomar.de/foci/src/oasis3-mct4.git
 clean_command: ${defaults.clean_command}
-comp_command: 'mkdir -p build; cd build; cmake ..; make -j `nproc --all`; mkdir ../include;
-  [ -f ../include/oasis_os.h ] || ln -s ../lib/psmile/include/oasis_os.h ../include/;
-  cp ../build/lib/psmile/*mod ../include/; [ -f ../include/oasis_os.h ] || ln -s ../lib/psmile/include/oasis_os.h
-  ../include/; ln -s ../build/lib/psmile/libpsmile.a ../lib; ln -s ../build/lib/psmile/mct/libmct.a
-  ../lib; ln -s ../build/lib/psmile/mct/mpeu/libmpeu.a ../lib; ln -s ../build/lib/psmile/scrip/libscrip.a
-  ../lib;
+# kh 08.07.20 as a workaround the seetings from a previoius version are used to succesfully build awicmcr-CMIP6 on Mistral (see below)
+# merge todo: bring customizations for the different models in mistral.yaml for all models and clusters under one roof
+# kh 08.07.20 bugfix: avoid error if ../include already exists
+#comp_command: 'mkdir -p build; cd build; cmake ..; make -j `nproc --all`; mkdir -p ../include;
+#  [ -f ../include/oasis_os.h ] || ln -s ../lib/psmile/include/oasis_os.h ../include/;
+#  cp ../build/lib/psmile/*mod ../include/; [ -f ../include/oasis_os.h ] || ln -s ../lib/psmile/include/oasis_os.h
+#  ../include/; ln -s ../build/lib/psmile/libpsmile.a ../lib; ln -s ../build/lib/psmile/mct/libmct.a
+#  ../lib; ln -s ../build/lib/psmile/mct/mpeu/libmpeu.a ../lib; ln -s ../build/lib/psmile/scrip/libscrip.a
+#  ../lib;
 
-  '
+# kh 10.07.20
+comp_command: 'mkdir -p build; cd build; cmake ..;   make -j `nproc --all`'
+
 destination: oasis
 git-repository: https://gitlab.dkrz.de/modular_esm/oasis3-mct.git
 install_libs:

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -63,11 +63,22 @@ choose_general.setup_name:
 
 useMPI: intelmpi
 module_actions:
-        - "unload netcdf_c"
-        - "unload intel intelmpi"
+# kh 10.07.20
+#        - "unload netcdf_c"
+#        - "unload intel intelmpi"
+#        - "load python/3.5.2"
+#        - "load cmake/3.13.3"
+#        - "load autoconf/2.69"
+
+        - "purge"
+        - "load gcc/4.8.2"
+        - "unload intel"
+        - "load intel"
+        - "load cdo nco"
+        - "unload netcdf"
+        - "load netcdf_c/4.3.2-gcc48"
         - "load python/3.5.2"
         - "load cmake/3.13.3"
-        - "load autoconf/2.69"
 
 export_vars:
 
@@ -76,6 +87,14 @@ export_vars:
         - "MPIFC=${mpifc}"
         - "CC=${cc}"
         - "CXX=${cxx}"
+
+# kh 10.07.20 $$$
+#        - "FC=mpiifort"
+#        - "F77=mpiifort"
+#        - "MPIFC=mpiifort"
+#        - "CC=mpiicc"
+#        - "CXX=mpiicpc"
+
         - "MPIROOT=\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
         - "MPI_LIB=\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
 
@@ -86,14 +105,34 @@ export_vars:
         # NOTE(JK): Using wrong combination of HDF5, netCDF-C and netCDF-F libs can lead to
         # undefined symbol: __intel_skx_avx512_memcpy
         # This combination was recommended by DKRZ support
-        - "HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/"
-        - "HDF5_ROOT=$HDF5ROOT"
-        - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
-        - "NETCDFFROOT=/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/"
-        - "LD_LIBRARY_PATH=$NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH"
+
+# kh 10.07.20
+#       - "HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/"
+#       - "HDF5_ROOT=$HDF5ROOT"
+
+# kh 10.07.20 used from previous version
+        - "HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.14-threadsafe-gcc48"
+        - "HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include"
+        - "ESM_HDF5_DIR=sw/rhel6-x64/hdf5/hdf5-1.8.16-parallel-impi-intel14/"
+        # NOTE(PG): The version of HDF5ROOT **WITH** an underscore is used by PISM Cmake:
+        - "HDF5_ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/"
+
+# kh 10.07.20
+#       - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
+#       - "NETCDFFROOT=/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/"
+
+# kh 10.07.20 used from previous version
+        - "NETCDFFROOT=/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.3-intel14"
+        - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
+
+# kh 10.07.20 tweaked to previous version
+#       - "LD_LIBRARY_PATH=$NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH"
+
         # avoid GLIBCXX_3.4.15 not found error
-        - "LD_LIBRARY_PATH=/sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH"
-        - 'HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include'
+# kh 10.07.20 tweaked to previous version
+#       - "LD_LIBRARY_PATH=/sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH"
+
+        - "HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include"
         - "NETCDF_Fortran_INCLUDE_DIRECTORIES=$NETCDFFROOT/include"
         - "NETCDF_C_INCLUDE_DIRECTORIES=$NETCDFROOT/include"
         - "NETCDF_CXX_INCLUDE_DIRECTORIES=/sw/rhel6-x64/netcdf/netcdf_cxx-4.2.1-gcc48/include"
@@ -102,7 +141,7 @@ export_vars:
         - "SZIPROOT=/sw/rhel6-x64/sys/libaec-0.3.2-gcc48"
         - "LAPACK_LIB='-mkl=sequential'"
         - "LAPACK_LIB_DEFAULT='-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
-        - 'OASIS3MCT_FC_LIB="-L$NETCDFFROOT/lib -lnetcdff"'
+        - "OASIS3MCT_FC_LIB='-L$NETCDFFROOT/lib -lnetcdff'"
 
         # mostly OpenIFS stuff
         - "ESM_NETCDF_C_DIR=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
@@ -114,7 +153,11 @@ export_vars:
         - "PROJ4_ROOT=/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
         - "PETSC_DIR=/sw/rhel6-x64/numerics/PETSc-3.12.2-impi2018-intel18/"
         - "PATH=/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
-        - "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$SZIPROOT/lib:$PROJ4_ROOT/lib"
+
+# kh 10.07.20
+#       - "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$SZIPROOT/lib:$PROJ4_ROOT/lib"
+        - "LD_LIBRARY_PATH=/sw/rhel6-x64/grib_api/grib_api-1.15.0-intel14/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$NETCDFROOT/lib:$SZIPROOT/lib:$PROJ4_ROOT/lib:$LD_LIBRARY_PATH"
+
         - 'GRIB_SAMPLES_PATH="$GRIBAPIROOT/share/grib_api/ifs_samples/grib1_mlgrib2/"'
         - 'PATH=$PATH:/mnt/lustre01/sw/rhel6-x64/devtools/fcm-2017.10.0/bin/'
         - 'OIFS_GRIB_API_INCLUDE="-I$GRIBAPIROOT/include"'
@@ -141,32 +184,33 @@ export_vars:
         - 'OIFS_CFLAGS="-fp-model precise -O3 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
         - 'OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
 
+# kh 10.07.20
         # MPI environent variables important at runtime
-        - 'I_MPI_FABRICS=shm:dapl'
-        - 'I_MPI_FALLBACK=disable'
-        - 'I_MPI_SLURM_EXT=1'
-        - 'I_MPI_LARGE_SCALE_THRESHOLD=8192'
-        - 'I_MPI_DYNAMIC_CONNECTION=1'
+#        - 'I_MPI_FABRICS=shm:dapl'
+#        - 'I_MPI_FALLBACK=disable'
+#        - 'I_MPI_SLURM_EXT=1'
+#        - 'I_MPI_LARGE_SCALE_THRESHOLD=8192'
+#        - 'I_MPI_DYNAMIC_CONNECTION=1'
 
         # MPIOM vars
-        - 'ARFLAGS=crv'
-        - 'CFLAGS="-O2 -DgFortran -std=gnu99"'
-        - 'FCFLAGS="-O3 -fp-model source -fast-transcendentals -no-prec-sqrt -xHost -heap-arrays -convert big_endian -fpp"'
-        - 'WLFLAG="-Wl"'
-        - 'LIBS="-Wl,-rpath,$NETCDFFROOT/lib:$NETCDFROOT/lib:$HDF5ROOT/lib:$SZIPROOT/lib:$MPIROOT/lib"'
-        - 'OASIS3MCTROOT=${model_dir}'
+#        - 'ARFLAGS=crv'
+#        - 'CFLAGS="-O2 -DgFortran -std=gnu99"'
+#        - 'FCFLAGS="-O3 -fp-model source -fast-transcendentals -no-prec-sqrt -xHost -heap-arrays -convert big_endian -fpp"'
+#        - 'WLFLAG="-Wl"'
+#        - 'LIBS="-Wl,-rpath,$NETCDFFROOT/lib:$NETCDFROOT/lib:$HDF5ROOT/lib:$SZIPROOT/lib:$MPIROOT/lib"'
+#        - 'OASIS3MCTROOT=${model_dir}'
 
-        - 'DAPL_NETWORK_NODES=$SLURM_NNODES'
-        - 'DAPL_NETWORK_PPN=$SLURM_NTASKS_PER_NODE'
-        - 'DAPL_WR_MAX=500'
+#        - 'DAPL_NETWORK_NODES=$SLURM_NNODES'
+#        - 'DAPL_NETWORK_PPN=$SLURM_NTASKS_PER_NODE'
+#        - 'DAPL_WR_MAX=500'
 
-        - 'OMPI_MCA_pml=cm'
-        - 'OMPI_MCA_mtl=mxm'
-        - 'OMPI_MCA_coll=^ghc'
-        - 'OMPI_MCA_mtl_mxm_np=0'
+#        - 'OMPI_MCA_pml=cm'
+#        - 'OMPI_MCA_mtl=mxm'
+#        - 'OMPI_MCA_coll=^ghc'
+#        - 'OMPI_MCA_mtl_mxm_np=0'
 
-        - 'MXM_RDMA_PORTS=mlx5_0:1'
-        - 'MXM_LOG_LEVEL=FATAL'
+#        - 'MXM_RDMA_PORTS=mlx5_0:1'
+#        - 'MXM_LOG_LEVEL=FATAL'
 
 choose_useMPI:
         intelmpi:
@@ -174,6 +218,9 @@ choose_useMPI:
                         - "unload intel intelmpi"
                         - "load intel/18.0.4 intelmpi/2018.5.288"
                         - "load libtool/2.4.6"
+# kh 11.07.20        
+                        - "load autoconf/2.69"
+
                         - "load automake/1.14.1"
                 fc: mpiifort
                 f77: mpiifort
@@ -181,8 +228,24 @@ choose_useMPI:
                 cc: mpiicc
                 cxx: mpiicpc
 
-                add_export_vars:
-                        - "LAPACK_LIB_DEFAULT='-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
+# kh 10.07.20
+#               add_export_vars:
+#                       - "LAPACK_LIB_DEFAULT='-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
+
+        intel18_bullxmpi:
+                add_module_actions:
+                        - "unload intel intelmpi"
+                        - "load intel/18.0.4"
+                        - "load libtool/2.4.6"
+                        - "load autoconf/2.69"
+                        - "load automake/1.14.1"
+                        - "load bullxmpi_mlx/bullxmpi_mlx-1.2.9.2"
+                fc: mpif90
+                f77: mpif90
+                mpifc: mpif90
+                cc: mpicc
+                cxx: mpicxx
+
         intelmpi17:
                 add_module_actions:
                         - "unload intel intelmpi"

--- a/runscripts/awicmcr/awicmcr-mistral-initial-monthly.run
+++ b/runscripts/awicmcr/awicmcr-mistral-initial-monthly.run
@@ -19,7 +19,7 @@ SCENARIO_awicmcr="PI-CTRL"
 
 RES_fesom=CORE2
 
-MODEL_DIR_awicm=${HOME}/esm-master/awicmcr-test/
+MODEL_DIR_awicmcr=${HOME}/esm-master/awicmcr-test/
 
 BASE_DIR=/work/ab0995/a270058/esm_yaml_test/
 

--- a/runscripts/awicmcr/awicmcr-ollie-initial-monthly.run
+++ b/runscripts/awicmcr/awicmcr-ollie-initial-monthly.run
@@ -1,0 +1,45 @@
+#! /bin/ksh -l
+set -e 
+
+
+setup_name="awicmcr"
+#check=1
+
+account=ab0995
+compute_time="00:15:00"
+###############################################################################
+
+INITIAL_DATE_awicmcr=2000-01-01       # Initial exp. date
+FINAL_DATE_awicmcr=2000-02-29         # Final date of the experiment
+
+awicmcr_VERSION="CMIP6"
+POST_PROCESSING_awicmcr=0
+SCENARIO_awicmcr="PI-CTRL"
+
+RES_fesom=CORE2
+
+MODEL_DIR_awicmcr=/work/ollie/dbarbi/modelcodes/awicmcr-CMIP6/
+BASE_DIR=/work/ollie/dbarbi/esm_yaml_test/
+
+POOL_DIR_fesom=/work/ollie/pool/FESOM/
+MESH_DIR_fesom=/work/ollie/pool/FESOM/meshes_default/core/
+
+NYEAR_awicmcr=0           # Number of years per run
+NMONTH_awicmcr=1          # Number of months per run
+
+LRESUME_echam=0
+LRESUME_fesom=0
+LRESUME_oasis3mct=0
+
+RESTART_RATE_fesom=1
+RESTART_FIRST_fesom=1
+RESTART_UNIT_fesom='m'
+
+
+
+further_reading_fesom="fesom_output_control.yaml"
+
+
+###############################################################################
+load_all_functions
+general_do_it_all $@


### PR DESCRIPTION
# Short Preface

There were many recent changes in the mistral.yaml machine file in the branch "develop" on which this feature branch is based on, and as a consequence the build step for awicmcr-CMIP6 was broken. As a workaround the settings from a previous version of mistral.yaml are used here to succesfully build awicmcr-CMIP6 on Mistral.

Additionally affected files:

... /esm_tools/configs/esm_master/components/echam.yaml
... /esm_tools/configs/esm_master/components/oasis3-mct.yaml

A step-by-step approach during the merge is probably the best way to find out what change has initially broken the ECHAM Concurrent Radiation build process with the ESM-Tools and to bring all different models and clusters under one roof.

# Feature Description

With this feature, typical configuration changes can be made by users more dynamically and at a central location (e.g. selecting the MPI environment, building a debug version of a program, selecting the hyperthreading mode or specifying launcher flags).
For this purpose, the esm_master or esm_runscripts command is given an additional configuration yaml file as argument (--modify-config), for example usermods.yaml (if needed with relative or absolute path specification).


Example content of usermods.yaml:

```yaml
build_and_run_modifications:
  machine:
    chooseable_settings:
      computer.useMPI: intel18_bullxmpi

build_only_modifications:
  machine:
    environment_settings:
     computer.export_vars.ESM_DEBUG_ECHAM: 'TRUE'
     computer.export_vars.ESM_DEBUG_FESOM: 'TRUE'

run_only_modifications:
  machine:
    chooseable_settings:
#     general.use_hyperthreading: '0'

  batch_system:
    direct_settings:
#     computer.launcher_flags: "-l --kill-on-bad-exit=1 --cpu_bind=cores --distribution=cyclic:cyclic"

# kh 22.07.20 can be used as a "low level" alternative to general.use_hyperthreading: '0' (see above)
      computer.hyperthreading_flag: "--ntasks-per-core=1"
```

There are three main sections in usermods.yaml:
a)
build_and_run_modifications refers to changes that are relevant for the build step as well as for the run step (e.g. the selection of the MPI environment)

b)
build_only_modifications refers to changes that are relevant for the build step (such as building a debug or release version)

c)
run_only_modifications refers to changes that are relevant for the run step (such as selecting hyperthreading or launcher flags)

The structure of a leaf-level entry that contains the path to the appropriate dictionary or list object is more or less self-explanatory (e.g. computer.useMPI: intel18_bullxmpi).
Basically, these modifications could also be made in the existing configuration files, which, apart from the runscripts, are rather static in nature (i.e. typically not necessarily modified by the user). The intermediate level items (machine, batch_system) in usermods.yaml - redundant in principle - give an indication of the configuration section in which an entry is originally set.



In addition, --ignore-errors is another new argument for esm_master or esm_runscripts to avoid an early abort in case of an error. This can sometimes be helpful especially during the development of the ESM-Tools.
