### PR TITLE
Hotfix/echam standalone runscripts

### DIFF
--- a/configs/echam/echam.yaml
+++ b/configs/echam/echam.yaml
@@ -37,7 +37,7 @@ lresume: false
 dataset: "r0007"
 
 ini_parent_date: 22941231
-ini_parent_expid: khw0030
+ini_parent_exp_id: khw0030
 ini_parent_dir: "${pool_dir}/MPIESM/restart/dev/${parent_expid}/restart/echam6"
 
 pseudo_start_date: ${start_date}

--- a/configs/hdmodel/hdmodel.inherit.yaml
+++ b/configs/hdmodel/hdmodel.inherit.yaml
@@ -2,4 +2,6 @@ lresume: ${echam.lresume}
 time_step: ${echam.time_step}
 #ini_parent_exp_id: ${echam.ini_parent_exp_id}
 parent_date: ${echam.parent_date}
-parent_restart_dir: ${echam.parent_restart_dir}
+prev_date: ${echam.prev_date}
+ini_restart_dir: ${echam.parent_restart_dir}/../hdmodel/
+ini_parent_exp_id: ${echam.parent_expid}

--- a/configs/hdmodel/hdmodel.yaml
+++ b/configs/hdmodel/hdmodel.yaml
@@ -31,6 +31,7 @@ choose_lresume:
 #input_files :
 #        hdpara: hdpara
 #        rmp_hd: rmp_hd
+other_date: $(( ${next_date} - ${time_step}seconds ))
 
 input_in_work:
         #hdpara: "hdpara.nc"
@@ -47,14 +48,14 @@ restart_in_in_work:
         hdrestart: hdrestart.nc
 
 restart_in_sources:
-        hdrestart: "${parent_restart_dir}/hdrestart.nc"
+        hdrestart: restart_${parent_expid}_${parent_date!syear!smonth!sday!shour!sminute!ssecond}_hdrestart.nc
 
 
 restart_out_in_work:
         hdrestart: hdrestart.nc
 
 restart_out_sources:
-        hdrestart: "${parent_restart_dir}/hdrestart.nc"
+        hdrestart: restart_${general.expid}_${other_date!syear!smonth!sday!shour!sminute!ssecond}_hdrestart.nc
 
 log_in_work:
         outflow: hd_outflow_*.log # DIBA muss noch rausfinden was * in diesem Fall ist

--- a/configs/jsbach/jsbach.inherit.yaml
+++ b/configs/jsbach/jsbach.inherit.yaml
@@ -8,6 +8,6 @@ lresume: ${echam.lresume}
 time_step: ${echam.time_step}
 parent_date: ${echam.parent_date}
 prev_date: ${echam.prev_date}
-parent_restart_dir: ${echam.parent_restart_dir}
-#ini_parent_exp_id: ${echam.ini_parent_exp_id}
+ini_restart_dir: ${echam.parent_restart_dir}/../jsbach/
+ini_parent_exp_id: ${echam.parent_expid}
 #ini_parent_date: ${echam.ini_parent_date}

--- a/configs/jsbach/jsbach.yaml
+++ b/configs/jsbach/jsbach.yaml
@@ -336,7 +336,7 @@ restart_in_files:
         "[[streams-->STREAM]]": STREAM
 
 restart_in_sources:
-        "[[streams-->STREAM]]": restart_${general.expid}_${parent_date!syear!smonth!sday!shour!sminute!ssecond}_STREAM.nc
+        "[[streams-->STREAM]]": restart_${parent_expid}_${parent_date!syear!smonth!sday!shour!sminute!ssecond}_STREAM.nc
 
 restart_in_in_work:
         "[[streams-->STREAM]]": restart_${general.expid}_STREAM.nc

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -154,7 +154,6 @@ export_vars:
         - 'FCFLAGS="-O3 -fp-model source -fast-transcendentals -no-prec-sqrt -xHost -heap-arrays -convert big_endian -fpp"'
         - 'WLFLAG="-Wl"'
         - 'LIBS="-Wl,-rpath,$NETCDFFROOT/lib:$NETCDFROOT/lib:$HDF5ROOT/lib:$SZIPROOT/lib:$MPIROOT/lib"'
-        - 'OASIS3MCTROOT=${model_dir}'
 
         - 'DAPL_NETWORK_NODES=$SLURM_NNODES'
         - 'DAPL_NETWORK_PPN=$SLURM_NTASKS_PER_NODE'

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.1.6"
+__version__ = "4.1.7"

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "4.1.7"
+__version__ = "4.1.8"

--- a/runscripts/echam/echam-mistral-initial-monthly.yaml
+++ b/runscripts/echam/echam-mistral-initial-monthly.yaml
@@ -1,0 +1,21 @@
+general:
+        setup_name: "echam"
+        account: ab0246
+        compute_time: "00:15:00"
+        initial_date: "2000-01-01"      # Initial exp. date
+        final_date: "2000-02-29"        # Final date of the experiment
+        base_dir: /work/ab0246/a270152/default/
+        nyear: 0                        # Number of years per run
+        nmonth: 1                       # Number of months per run
+        model_dir: /pf/a/a270152/model_codes/echam-6.3.04p1/
+
+
+echam:
+        version: "6.3.04p1"
+        res: T63
+        scenario: "PI-CTRL"
+        lresume: 0
+        restart_rate: 1
+        restart_first: 1
+        restart_unit: "months"
+        post_processing: 0

--- a/runscripts/echam/echam-mistral-restart-monthly.run
+++ b/runscripts/echam/echam-mistral-restart-monthly.run
@@ -18,17 +18,18 @@ SCENARIO_echam="PI-CTRL"
 
 RES_echam=T63
 
-MODEL_DIR=/work/ab0995/a270058/modelcodes/echam-6.3.04p1//
-BASE_DIR=/work/ab0995/a270058/esm_yaml_test/
+MODEL_DIR=${HOME}/model_codes/echam-6.3.04p1/
+BASE_DIR=/work/ab0995/a270152/esm_yaml_test/
 
 NYEAR=0           # Number of years per run
 NMONTH=1          # Number of months per run
 
 LRESUME_echam=1
-INI_RESTART_DIR_echam=/work/ab0246/a270064/esm-experiments/lgm_anm/restart/echam
-INI_PARENT_DATE_echam=37991231
-INI_PARENT_EXP_ID_echam=lgm_anm
+INI_RESTART_DIR_echam=/work/ab0246/a270064/esm-experiments/lgm_anm20/restart/echam
+INI_PARENT_DATE_echam=38991231
+INI_PARENT_EXP_ID_echam=lgm_anm20
 
+further_reading="echam-old-ini_restart.yaml"
 ###############################################################################
 load_all_functions
 general_do_it_all $@

--- a/runscripts/echam/echam-mistral-restart-monthly.yaml
+++ b/runscripts/echam/echam-mistral-restart-monthly.yaml
@@ -1,0 +1,26 @@
+general:
+        setup_name: "echam"
+        account: ab0246
+        compute_time: "00:15:00"
+        initial_date: "2000-03-01"      # Initial exp. date
+        final_date: "2000-03-31"        # Final date of the experiment
+        base_dir: /work/ab0246/a270152/default/
+        nyear: 0                        # Number of years per run
+        nmonth: 1                       # Number of months per run
+        model_dir: /pf/a/a270152/model_codes/echam-6.3.04p1/
+
+
+echam:
+        version: "6.3.04p1"
+        res: T63
+        scenario: "PI-CTRL"
+        lresume: 1
+        restart_rate: 1
+        restart_first: 1
+        restart_unit: "months"
+        post_processing: 0
+
+        ini_parent_exp_id: echam_pictrl_monthly
+        ini_restart_dir: /work/ab0246/a270152/default/${ini_parent_exp_id}/restart/echam
+        ini_parent_date: "$(( ${initial_date} - ${echam.time_step}seconds ))"
+

--- a/runscripts/echam/echam-old-ini_restart.yaml
+++ b/runscripts/echam/echam-old-ini_restart.yaml
@@ -1,0 +1,17 @@
+echam:
+        choose_general.run_number:
+                1:
+                        add_restart_in_sources:
+                                "[[echam.streams-->STREAM]]": restart_${echam.ini_parent_exp_id}_STREAM_${echam.ini_parent_date}.nc
+
+jsbach:
+        choose_general.run_number:
+                1:
+                        add_restart_in_sources:
+                                "[[jsbach.streams-->STREAM]]": ${echam.ini_restart_dir}/../jsbach/restart_${echam.ini_parent_exp_id}_STREAM_${echam.ini_parent_date}.nc
+
+hdmodel:
+        choose_general.run_number:
+                1:
+                        add_restart_in_sources:
+                                hdrestart: ${echam.ini_restart_dir}/../hdmodel/restart_${echam.ini_parent_exp_id}_hd_${echam.ini_parent_date}.nc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.6
+current_version = 4.1.7
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.7
+current_version = 4.1.8
 commit = True
 tag = True
 
@@ -18,4 +18,3 @@ universal = 1
 exclude = docs
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.1.7",
+    version="4.1.8",
     zip_safe=False,
 )
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.1.6",
+    version="4.1.7",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Added yaml runscripts for echam standalone in mistral both for cold start and restart and fixed a number of issues related to the restart of `echam`, mostly for `jsbach` and `hdmodel`:

- Fixes in `jsbach.yaml`, `hdmodel.yaml`, `jsbach.inherit.yaml`, `hdmodel.inherit.yaml` for allowing restarting from another experiment with different experiment id. 

- `hdmodel` copies now the restarts into the general experiment folder inside `<base_dir>/<experiment_id>/restart/hdmodel/` with a name that includes date and time. Before it was copying them to `<base_dir>/<experiment_id>/restart/hdmodel/<parent_expid>/run_YYYYMMDD-YYYYMMDD/work/` which was likely a mistake.

- Other little changes.

This hotfix addresses most of the issues in #77.