### PR TITLE
Feature/add support for hlrn4 goettingen

### DIFF
--- a/configs/components/oifs/oifs-43r3-preprocess.sh
+++ b/configs/components/oifs/oifs-43r3-preprocess.sh
@@ -7,7 +7,6 @@
 ## DIR is the location of the original data. 
 ##
 
-machine=$1
 indir=$1
 inexpid=$2
 outexpid=$3
@@ -28,8 +27,10 @@ if [[ "$(hostname -f)" =~ dkrz.de ]] ; then
     module load cdo
 
 elif [[ "$(hostname -f)" =~ hlrn.de ]] ; then
-    module load eccodes
-	 module load cdo
+    #module load eccodes # eccodes only available on blogin :-(
+	 #module load cdo
+	 module load intel/19.0.5 impi/2019.5
+	 export PATH=/home/shkifmsw/sw/HPC_libraries/intel2019.0.5_impi2019.5_20200811/bin:$PATH
 else
    echo
 	echo $0 has not been adapted for $(hostname)

--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -134,6 +134,14 @@ runtime_environment_changes:
         - 'OIFS_FFIXED=""'
         - 'GRIB_SAMPLES_PATH="$IO_LIB_ROOT/share/eccodes/ifs_samples/grib1_mlgrib2/"'
         - 'DR_HOOK_IGNORE_SIGNALS="-1"'
+    glogin:
+      #add_module_actions:
+      #  - "load eccodes/intel/2.15.1"
+      add_export_vars:
+        - 'OIFS_FFIXED=""'
+        - 'GRIB_SAMPLES_PATH="$IO_LIB_ROOT/share/eccodes/ifs_samples/grib1_mlgrib2/"'
+        - 'DR_HOOK_IGNORE_SIGNALS="-1"'
+
 
     mistral:    
       add_export_vars:
@@ -152,6 +160,53 @@ runtime_environment_changes:
 compiletime_environment_changes:
   choose_computer.name:
     blogin:
+      #add_module_actions:
+      #  - "load eccodes/intel/2.15.1"
+      add_export_vars:
+
+        - "LAPACK_LIB='-mkl=sequential'"
+        - "LAPACK_LIB_DEFAULT='-L$MKLROOT/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
+        - "ESM_NETCDF_C_DIR=$IO_LIB_ROOT"
+        - "ESM_NETCDF_F_DIR=$IO_LIB_ROOT"
+
+        # ECCODES stuff
+        # OIFS_GRIB_API_LIB is used by OpenIFS CY40, OIFS_GRIB_LIB is used by CY43
+        #- "LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$ECCODES_DIR/lib"
+        - 'ECCODES_DIR="$IO_LIB_ROOT"'
+        - 'GRIB_SAMPLES_PATH="$ECCODES_DIR/share/eccodes/ifs_samples/grib1_mlgrib2/"'
+        - 'OIFS_GRIB_API_INCLUDE="-I$ECCODES_DIR/include"'
+        - 'OIFS_GRIB_API_LIB="-L$ECCODES_DIR/lib -leccodes_f90 -leccodes"'
+        - 'OIFS_GRIB_INCLUDE="$OIFS_GRIB_API_INCLUDE"'
+        - 'OIFS_GRIB_LIB="$OIFS_GRIB_API_LIB"'
+        - 'OIFS_GRIB_API_BIN="$ECCODES_DIR/bin"'
+
+        # OASIS
+        - 'OIFS_OASIS_BASE=$(pwd)/oasis'
+        - 'OIFS_OASIS_INCLUDE="-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
+        - 'OIFS_OASIS_LIB="-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
+
+        # NetCDF
+        - 'OIFS_NETCDF_INCLUDE="-I$NETCDFROOT/include"'
+        - 'OIFS_NETCDF_LIB="-L$NETCDFROOT/lib -lnetcdf"'
+        - 'OIFS_NETCDFF_INCLUDE="-I$NETCDFFROOT/include"'
+        - 'OIFS_NETCDFF_LIB="-L$NETCDFFROOT/lib -lnetcdff"'
+
+        # compiler and compile flags
+        # this doesn't work but should
+        # - 'OIFS_FC=${mpifc}'
+        - 'OIFS_FC=mpiifort'
+        - 'OIFS_FFLAGS="-r8 -fp-model precise -align array32byte -O3 -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
+        - 'OIFS_FFIXED=""'
+        - 'OIFS_FCDEFS="BLAS LITTLE LINUX INTEGER_IS_INT"'
+        - 'OIFS_LFLAGS=$OIFS_MPI_LIB'
+        # this doesn't work but should
+        # - 'OIFS_CC=${cc}'
+        - 'OIFS_CC=mpiicc'
+        - 'OIFS_CFLAGS="-fp-model precise -O3 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
+        - 'OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
+        - 'DR_HOOK_IGNORE_SIGNALS="-1"'
+
+    glogin:
       #add_module_actions:
       #  - "load eccodes/intel/2.15.1"
       add_export_vars:

--- a/configs/components/rnfmap/rnfmap.yaml
+++ b/configs/components/rnfmap/rnfmap.yaml
@@ -135,6 +135,36 @@ compiletime_environment_changes:
         - 'OIFS_CFLAGS="-fp-model precise -O3 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
         - 'OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
 
+    glogin:
+
+      add_export_vars:
+
+        # OASIS
+        - 'OIFS_OASIS_BASE=$(pwd)/oasis'
+        - 'OIFS_OASIS_INCLUDE="-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
+        - 'OIFS_OASIS_LIB="-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
+
+        # NetCDF
+        - 'OIFS_NETCDF_INCLUDE="-I$NETCDFROOT/include"'
+        - 'OIFS_NETCDF_LIB="-L$NETCDFROOT/lib -lnetcdf"'
+        - 'OIFS_NETCDFF_INCLUDE="-I$NETCDFFROOT/include"'
+        - 'OIFS_NETCDFF_LIB="-L$NETCDFFROOT/lib -lnetcdff"'
+
+        # compiler and compile flags
+        # this doesn't work but should
+        # - 'OIFS_FC=${mpifc}'
+        - 'OIFS_FC=mpiifort'
+        - 'OIFS_FFLAGS="-r8 -fp-model precise -align array32byte -O3 -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
+        - 'OIFS_FFIXED=""'
+        - 'OIFS_FCDEFS="BLAS LITTLE LINUX INTEGER_IS_INT"'
+        - 'OIFS_LFLAGS=$OIFS_MPI_LIB'
+        # this doesn't work but should
+        # - 'OIFS_CC=${cc}'
+        - 'OIFS_CC=mpiicc'
+        - 'OIFS_CFLAGS="-fp-model precise -O3 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
+        - 'OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
+
+
     mistral:
 
       add_export_vars:

--- a/configs/components/xios/xios.yaml
+++ b/configs/components/xios/xios.yaml
@@ -50,9 +50,12 @@ use_oasis: ''
 #
 # Setup up compile and runtime environment i.e. what needs
 # to be changed w.r.t the default config/machines/<computer>.yaml
-choose_computer.name:
-  blogin:
-    runtime_environment_changes:
+runtime_environment_changes:
+  choose_computer.name:
+    blogin:
+      add_module_actions:
+        - "source /sw/comm/impi/compilers_and_libraries_2019.5.281/linux/mpi/intel64/bin/mpivars.sh release_mt"
+    glogin:
       add_module_actions:
         - "source /sw/comm/impi/compilers_and_libraries_2019.5.281/linux/mpi/intel64/bin/mpivars.sh release_mt"
         

--- a/configs/machines/all_machines.yaml
+++ b/configs/machines/all_machines.yaml
@@ -17,3 +17,8 @@ blogin:
         login_nodes: 'blogin*'
         compute_nodes: '^b[A-Za-z0-9]+\.usr\.hlrn\.de$'
         post_nodes: 'blogin*'
+
+glogin:
+        login_nodes: 'glogin*'
+        compute_nodes: '^g[A-Za-z0-9]+\.usr\.hlrn\.de$'
+        post_nodes: 'glogin*'

--- a/configs/machines/glogin.yaml
+++ b/configs/machines/glogin.yaml
@@ -1,5 +1,107 @@
-# GLOGIN YAML CONFIGURATION FILE
+# BLOGIN YAML CONFIGURATION FILES
 
-batch_system: slurm
+name: blogin
+account: None
+
+choose_general.use_hyperthreading:
+        "0":
+                hyperthreading_flag: "--ntasks-per-core=1"
+        "*":
+                hyperthreading_flag: ""
+
 accounting: true
 
+"batch_system": "slurm"
+
+jobtype: compute
+sh_interpreter: "/bin/bash"
+
+choose_jobtype:
+        tidy_and_resubmit:
+                partition: medium40
+        post:
+                partition: medium40
+        compute:
+                partition: medium40
+
+
+choose_partition:
+        medium40:
+                cores_per_node: 96
+
+logical_cpus_per_core: 2
+
+threads_per_core: 1
+
+pool_directories:
+        pool: "/scratch/usr/hbkawi"
+        focipool: "/scratch/usr/shkifmsw/foci_input2"
+
+pool_dir:  "/scratch/usr/hbkawi"
+
+
+useMPI: intelmpi
+
+# standard environment setup
+#
+module_actions:
+        - "purge"
+        - "load slurm"
+        - "load HLRNenv"
+        - "load sw.skl"
+        - "load cmake"
+        - "load intel/19.0.5"
+        - "load cdo nco"
+
+choose_useMPI:
+        intelmpi:
+                add_module_actions:
+                        - "unload impi"
+                        - "load impi/2019.5"
+                fc: mpiifort
+                f77: mpiifort
+                mpifc: mpiifort
+                mpicc: mpiicc
+                cc: mpiicc
+                cxx: mpiicpc
+
+                add_export_vars:
+                        # Recommended by HLNR support when using an MPI binary and srun
+                        - "SLURM_CPU_BIND=none"
+
+                launcher_flags: "--mpi=pmi2 -l --kill-on-bad-exit=1 --cpu_bind=cores"
+
+export_vars:
+
+        - "FC=${fc}"
+        - "F77=${f77}"
+        - "MPIFC=${mpifc}"
+        - "MPICC=${mpicc}"
+        - "CC=${cc}"
+        - "CXX=${cxx}"
+        - "MPIROOT=\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
+        - "MPI_LIB=\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+
+        # Replace in the future when system provided modules and libraries are reliable
+        - "IO_LIB_ROOT=/home/shkifmsw/sw/HPC_libraries/intel2019.0.5_impi2019.5_20200811"
+        - "LD_LIBRARY_PATH=$IO_LIB_ROOT/lib:$LD_LIBRARY_PATH"
+
+        - "ZLIBROOT=$IO_LIB_ROOT"
+        - "SZIPROOT=$IO_LIB_ROOT"
+        - "HDF5ROOT=$IO_LIB_ROOT"
+        - "HDF5_ROOT=$HDF5ROOT"
+        - "NETCDFROOT=$IO_LIB_ROOT"
+        - "NETCDFFROOT=$IO_LIB_ROOT"
+        - "HDF5_C_INCLUDE_DIRECTORIES=$HDF5_ROOT/include"
+        - "NETCDF_Fortran_INCLUDE_DIRECTORIES=$NETCDFFROOT/include"
+        - "NETCDF_C_INCLUDE_DIRECTORIES=$NETCDFROOT/include"
+        - "NETCDF_CXX_INCLUDE_DIRECTORIES=$NETCDFROOT/include"
+        # seems to be ECHAM specific, leave it here for now
+        - 'OASIS3MCT_FC_LIB="-L$NETCDFFROOT/lib -lnetcdff"'
+
+        # seb-wahl: removed as NetCDF libraries are already in the LD_LIBRARY_PATH (see above)
+        #- "NETCDF_DIR=/sw/dataformats/netcdf/intel.18/4.7.3/skl/"
+        #- "LD_LIBRARY_PATH=$NETCDF_DIR/lib/:$LD_LIBRARY_PATH"
+
+further_reading:
+        - batch_system/slurm.yaml

--- a/stuff/test_setups/test_setups.sh
+++ b/stuff/test_setups/test_setups.sh
@@ -69,7 +69,7 @@ for configuration in ${configurations} ; do
     module load anaconda3/2019.10
   elif [[ "$HOSTNAME" =~ glogin ]] ; then
     module load git
-    module load anaconda3/2019.10
+    module load anaconda3
   elif [[ "$HOSTNAME" =~ mlogin ]] ; then
     #module load git
     module unload netcdf_c/4.3.2-gcc48 


### PR DESCRIPTION
add support for HLRN4 Goettingen (glogin.hlrn.de) which re-opened last week.
Only additions, so no negative side-effects will occur.
Tested on blogin and glogin with foci-default and oifs-43r3-foci