### PR TITLE
fixes the namelist_changes inside echam.yaml

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -356,7 +356,7 @@ choose_lresume:
                                   # - ndate "<--set_dim--" ${steps_in_year_before}
         True:
                 # pseudo_start_date: $(( ${start_date} - ${time_step} ))
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 runctl:
                                         dt_start: "remove_from_namelist"
@@ -365,49 +365,49 @@ choose_lresume:
 
 choose_CO2:
         '*':
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         co2vmr: ${CO2}
 
 choose_CH4:
         '*':
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         ch4vmr: ${CH4}
 choose_N2O:
         '*':
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
-                                        c2ovmr: ${N2O}
+                                        n2ovmr: ${N2O}
 
 choose_CECC:
         '*':
                 yr_perp_off: true
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         cecc: ${CECC}
 choose_COBLD:
         '*':
                 yr_perp_off: true
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         cobld: ${COBLD}
 choose_CLONP:
         '*':
                 yr_perp_off: true
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         clonp: ${CLONP}
 
 choose_yr_perp_off:
         true:
-                namelist_changes:
+                add_namelist_changes:
                         namelist.echam:
                                 radctl:
                                         yr_perp: "remove_from_namelist"

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.2.0"
+__version__ = "4.2.1"
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.0
+current_version = 4.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.2.0",
+    version="4.2.1",
     zip_safe=False,
 )
 


### PR DESCRIPTION
This is a fix for issue #130.

Fixes the `namelist_changes` (renamed into `add_namelist_changes`) inside… the choose_<option> that were not working in echam.yaml.

I'll prepare another hotfix for the `esm_parser` where a file with two `namelist_changes` returns and error or at least asks if one should overwrite the another.