### PR TITLE
hotfix/compile_echam6_standalone

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -679,14 +679,6 @@ check_error:
 
 
 
-choose_computer.name:
-    ollie:
-        compiletime_environment_changes:
-            add_export_vars:
-                # NOTE(PG)/FIXME(KH): The mh-linux is wrong, and uses OpenIFS Flags...???
-                - 'OIFS_OASIS_BASE=$(pwd)/oasis'
-                - 'OIFS_OASIS_INCLUDE="-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
-                - 'configure_opts=--with-coupler=oasis3-mct'
 
 further_reading:
         - echam/echam.datasets.yaml

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -68,6 +68,15 @@ echam:
                         nproca: 24
                         nprocb: 18
 
+        choose_computer.name:
+            ollie:
+                compiletime_environment_changes:
+                    add_export_vars:
+                        # NOTE(PG)/FIXME(KH): The mh-linux is wrong, and uses OpenIFS Flags...???
+                        - 'OIFS_OASIS_BASE=$(pwd)/oasis'
+                        - 'OIFS_OASIS_INCLUDE="-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
+                        - 'configure_opts=--with-coupler=oasis3-mct'
+
 
 #########################################################################################
 


### PR DESCRIPTION
Due to ECHAM6.3.05p2 with Concurrent Radiation still being based on auto tools, I had some bad hacks put in to get it to find OASIS when compiling AWI-ESM. The model would configure correctly, but refuse to compile because it couldn't find OASIS

For reasons I don't understand, the procedure was only needed on Ollie. I added a variable that was activated with a choose_computer block, and injected the needed changes to the configure command.

However, this happened directly in Echam, rather than in AWI-ESM, so standalone compilation was not possible.