### PR TITLE
sample component added

### DIFF
--- a/configs/components/sample/sample.yaml
+++ b/configs/components/sample/sample.yaml
@@ -1,0 +1,51 @@
+# SAMPLE CONFIGURATION FILE
+# An example configuration file for testing of ESM-Tools
+# without the use of models
+
+model: sample
+version: '1.0'
+
+available_versions:
+- '1.0'
+choose_version:
+  '1.0':
+    branch: master
+
+git-repository: "https://github.com/mandresm/esm_sample.git"
+install_bins: _build/sample
+clean_command: ${defaults.clean_command}
+comp_command: mkdir -p _build; gcc -Wall src/sample.c -o _build/sample
+
+executable: sample
+
+nproc: 1
+
+setup_dir: "${model_dir}"
+bin_dir: "${setup_dir}/bin"
+
+bin_sources:
+    sample: "${bin_dir}/${executable}"
+
+# Moves the restart files from <expid>/run.../work/ to <expid>/restart/<component>/
+restart_out_files:
+    rfile: rfile
+restart_out_in_work:
+    rfile: restart_work
+restart_out_sources:
+    rfile: restart_work
+
+# Moves the outdata files from <expid>/run.../work/ to <expid>/outdata/<component>/
+outdata_files:
+    ofile: ofile
+outdata_in_work:
+    ofile: outdata_work
+outdata_sources:
+    ofile: outdata_work
+
+# Copies the sample_forcing file at the beginning of the run
+forcing_files:
+    ffile: ffile
+forcing_in_work:
+    ffile: sample_forcing
+forcing_sources:
+    ffile: /home/ollie/mandresm/my_scripts/sample_forcing


### PR DESCRIPTION
The sample component is a simple C script that generates files with different names inside the same folder the binary is run. It can be installed using the standard `esm_master install-sample-1.0` and run with `esm_runscripts <runscript_name> -e <experiment_id>`. Its main purpose is to debug file dictionaries (testing of esm-tools/esm_runscripts#37) with minimal resources, but could be also used in the future for workshops. 