### PR TITLE
sample component added

### DIFF
--- a/configs/components/sample/sample.yaml
+++ b/configs/components/sample/sample.yaml
@@ -1,0 +1,51 @@
+# SAMPLE CONFIGURATION FILE
+# An example configuration file for testing of ESM-Tools
+# without the use of models
+
+model: sample
+version: '1.0'
+
+available_versions:
+- '1.0'
+choose_version:
+  '1.0':
+    branch: master
+
+git-repository: "https://github.com/mandresm/esm_sample.git"
+install_bins: _build/sample
+clean_command: ${defaults.clean_command}
+comp_command: mkdir -p _build; gcc -Wall src/sample.c -o _build/sample
+
+executable: sample
+
+nproc: 1
+
+setup_dir: "${model_dir}"
+bin_dir: "${setup_dir}/bin"
+
+bin_sources:
+    sample: "${bin_dir}/${executable}"
+
+# Moves the restart files from <expid>/run.../work/ to <expid>/restart/<component>/
+restart_out_files:
+    rfile: rfile
+restart_out_in_work:
+    rfile: restart_work
+restart_out_sources:
+    rfile: restart_work
+
+# Moves the outdata files from <expid>/run.../work/ to <expid>/outdata/<component>/
+outdata_files:
+    ofile: ofile
+outdata_in_work:
+    ofile: outdata_work
+outdata_sources:
+    ofile: outdata_work
+
+# Copies the sample_forcing file at the beginning of the run
+forcing_files:
+    ffile: ffile
+forcing_in_work:
+    ffile: sample_forcing
+forcing_sources:
+    ffile: /home/ollie/mandresm/my_scripts/sample_forcing

--- a/configs/components/sample/sample.yaml
+++ b/configs/components/sample/sample.yaml
@@ -18,6 +18,8 @@ comp_command: mkdir -p _build; gcc -Wall src/sample.c -o _build/sample
 
 executable: sample
 
+time_step: 1800
+
 nproc: 1
 
 setup_dir: "${model_dir}"
@@ -32,7 +34,15 @@ restart_out_files:
 restart_out_in_work:
     rfile: restart_work
 restart_out_sources:
-    rfile: restart_work
+    rfile: restart_work${end_date!syear!smonth!sday}
+
+# Moves the restart files from <expid>/restart/<component>/ to <expid>/run.../work/
+restart_in_files:
+    rfile: rfile
+restart_in_in_work:
+    rfile: restart_work${parent_date!syear!smonth}
+restart_in_sources:
+    rfile: restart_work${parent_date!syear!smonth!sday}
 
 # Moves the outdata files from <expid>/run.../work/ to <expid>/outdata/<component>/
 outdata_files:
@@ -40,7 +50,7 @@ outdata_files:
 outdata_in_work:
     ofile: outdata_work
 outdata_sources:
-    ofile: outdata_work
+    ofile: outdata_work${start_date!syear!smonth!sday}
 
 # Copies the sample_forcing file at the beginning of the run
 forcing_files:
@@ -48,4 +58,4 @@ forcing_files:
 forcing_in_work:
     ffile: sample_forcing
 forcing_sources:
-    ffile: /home/ollie/mandresm/my_scripts/sample_forcing
+    ffile: sample_forcing

--- a/runscripts/sample/sample-ollie-initial-monthly.yaml
+++ b/runscripts/sample/sample-ollie-initial-monthly.yaml
@@ -2,10 +2,13 @@ general:
         setup_name: sample
         compute_time: "00:01:00"
         initial_date: "2000-01-01"
-        final_date: "2000-01-31"
+        final_date: "2001-01-01"
         base_dir: /work/ollie/mandresm/esm_yaml_test/
         nmonth: 1
+        clean_old_rundirs_keep_every: 5
+        clean_old_rundirs_except: 2
 
 sample:
         version: 1.0
         model_dir: /home/ollie/mandresm/model_codes/sample-1.0/
+        lresume: 0

--- a/runscripts/sample/sample-ollie-initial-monthly.yaml
+++ b/runscripts/sample/sample-ollie-initial-monthly.yaml
@@ -1,0 +1,11 @@
+general:
+        setup_name: sample
+        compute_time: "00:01:00"
+        initial_date: "2000-01-01"
+        final_date: "2000-01-31"
+        base_dir: /work/ollie/mandresm/esm_yaml_test/
+        nmonth: 1
+
+sample:
+        version: 1.0
+        model_dir: /home/ollie/mandresm/model_codes/sample-1.0/


### PR DESCRIPTION
The sample component is a simple C script that generates files with different names inside the same folder the binary is run. It can be installed using the standard `esm_master install-sample-1.0` and run with `esm_runscripts <runscript_name> -e <experiment_id>`. Its main purpose is to debug file dictionaries (testing of esm-tools/esm_runscripts#37) with minimal resources, but could be also used in the future for workshops. 