### PR TITLE
changed the stderr and stdout file paths in slurm.yaml from <exp_id>/…

### DIFF
--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -34,7 +34,8 @@ tasks_flag: "--ntasks=@tasks@"
 partition_flag: "--partition=${partition}"
 time_flag: "--time=${compute_time}"
 additional_flags: ""
-output_flags: "--output=${expid}_${jobtype}_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_%j.log --error=${expid}_${jobtype}_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_%j.log"
+output_path: "${experiment_dir}/scripts/"
+output_flags: "--output=${output_path}${expid}_${jobtype}_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_%j.log --error=${output_path}${expid}_${jobtype}_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_%j.log"
 name_flag: "--job-name=${expid}"
 
 choose_launcher:


### PR DESCRIPTION
changed the stderr and stdout file paths in slurm.yaml from <exp_id>/run_<date>/scripts to <exp_id>/scripts. In this way cleanups (esm-tools/esm_runscripts#37) don't delete these files, and logging can continue after the cleanup