### PR TITLE
Adds ability for DDT debugger on Slurm systems

### DIFF
--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -24,10 +24,10 @@ choose_accounting:
 
 choose_mail_type:
         "*":
-                mail1:  "--mail_type=${mail_type}"
+                mail1:  "--mail-type=${mail_type}"
 choose_mail_user:
         "*":
-                mail2:  "--mail_user=${mail_user}"
+                mail2:  "--mail-user=${mail_user}"
 
 notification_flag: "${mail1} ${mail2}"
 single_proc_submit_flag: "--ntasks-per-node=1"
@@ -52,6 +52,9 @@ choose_debugger:
             debugger_flags_prelauncher: ""
         ddt:
             debugger_flags_prelauncher: "ddt --connect"
+            runtime_environment_changes:
+                add_module_actions:
+                  - "load arm-forge"
 
 submitted: false
 script_name: "<--methods.scriptname--"

--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -5,6 +5,7 @@
 header_start: "#SBATCH"
 submit: sbatch
 launcher: srun
+debugger: None
 mail_type: NONE
 account: None
 
@@ -46,6 +47,12 @@ choose_launcher:
         mpirun:
                 launcher_flags: "-l"
 
+choose_debugger:
+        None:
+            debugger_flags_prelauncher: ""
+        ddt:
+            debugger_flags_prelauncher: "ddt --connect"
+
 submitted: false
 script_name: "<--methods.scriptname--"
 actual_script_dir: "<--methods.script_dir--"
@@ -73,7 +80,7 @@ config_files:
         #hostfile:
         #        - "[[setup.orderedexecs-->MODEL]]<--startproc-- - MODEL<--endproc-- ./MODEL<--exe-- <--append--"
 
-execution_command: "${launcher} ${launcher_flags} --multi-prog ${config_files.hostfile}"
+execution_command: "${debugger_flags_prelauncher} ${launcher} ${launcher_flags} --multi-prog ${config_files.hostfile}"
 
 check_error:
         "srun: error:" :


### PR DESCRIPTION
Mistral has the ability to run interactive debugging on large scale Fortran or C programs. See more info here:
https://www.dkrz.de/up/services/code-tuning/debugging

By default, this is turned off. However, if you need it, you can add:

```yaml
general:
    debugger: ddt
```

This results in a slightly modified execute command:
```
time ddt --connect srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun &
```
