### PR TITLE
set defaults for nproca and nprocb

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -160,6 +160,8 @@ choose_switch:
 nprocar: 0
 nprocbr: 0
 npromar: 0
+nproca: 24
+nprocb: 24
 lrad_async: false
 lrestart_from_old: false
 

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.2.10"
+__version__ = "4.2.11"
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.10
+current_version = 4.2.11
 commit = True
 tag = True
 
@@ -19,4 +19,3 @@ exclude = docs
 max-line-length = 88
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.2.10",
+    version="4.2.11",
     zip_safe=False,
 )
 


### PR DESCRIPTION
If e.g. `esm_master install-echam-6.3.05p2-foci -c` is run on a machine which has cores per node that don't match the preconfigured setting (e.g. `blogin` with 96 cores per node):
```yaml
choose_computer.cores_per_node:
                        24:
                                nproca: 24
                                nprocb: 18

                        36:
                                nproca: 24
                                nprocb: 18
```
`esm_master` will fail with
```
blogin3:~/esm/esm_tools $ esm_master install-echam-6.3.05p2 -c
Traceback (most recent call last):
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1370, in recursive_get
    result = config_to_search[this_config]
KeyError: 'nproca'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1484, in actually_find_variable
    var_result = recursive_get(full_config, config_elements)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1377, in recursive_get
    return recursive_get(result, my_config_elements)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1373, in recursive_get
    "Exactly None! Couldn't find an answer for:", my_config_elements
ValueError: ("Exactly None! Couldn't find an answer for:", [])

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1370, in recursive_get
    result = config_to_search[this_config]
KeyError: 'nproca'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1492, in actually_find_variable
    var_result = recursive_get(full_config, config_elements)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1377, in recursive_get
    return recursive_get(result, my_config_elements)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1373, in recursive_get
    "Exactly None! Couldn't find an answer for:", my_config_elements
ValueError: ("Exactly None! Couldn't find an answer for:", [])

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/shkifmsw/.local/bin/esm_master", line 10, in <module>
    sys.exit(main())
  File "/home/shkifmsw/.local/lib/python3.7/site-packages/esm_master/cli.py", line 74, in main
    main_flow(parsed_args, target)
  File "/home/shkifmsw/.local/lib/python3.7/site-packages/esm_master/esm_master.py", line 34, in main_flow
    complete_setup = SimulationSetup(user_config=user_config)
  File "/home/shkifmsw/gitlab/esm_runscripts/esm_runscripts/esm_sim_objects.py", line 50, in __init__
    self.get_total_config_from_user_config(user_config)
  File "/home/shkifmsw/gitlab/esm_runscripts/esm_runscripts/esm_sim_objects.py", line 251, in get_total_config_from_user_config
    self.config.finalize()
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 2355, in finalize
    self.run_recursive_functions(self)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 2370, in run_recursive_functions
    isblacklist=isblacklist,
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1333, in recursive_run_function
    tree + [key], value, level, func, *args, **kwargs
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1333, in recursive_run_function
    tree + [key], value, level, func, *args, **kwargs
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1333, in recursive_run_function
    tree + [key], value, level, func, *args, **kwargs
  [Previous line repeated 2 more times]
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1306, in recursive_run_function
    right = func(tree + [None], right, *args, **kwargs)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1412, in find_variable
    var_result, var_attrs = actually_find_variable(tree, var, full_config)
  File "/home/shkifmsw/gitlab/esm_parser/esm_parser/esm_parser.py", line 1495, in actually_find_variable
    raise EsmParserError("Sorry, a variable was not resolved: %s not found" % (rhs))
esm_parser.esm_parser.EsmParserError: Sorry, a variable was not resolved: nproca not found
```
Setting defaults for `nproca` and `nprocb` solves this