### PR TITLE
Hotfix for Missing CDO in MISTRAL.yaml

### DIFF
--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -55,6 +55,7 @@ module_actions:
         - "load cmake/3.13.3"
         - "load autoconf/2.69"
         - "load nco"
+        - "load cdo"
 
 export_vars:
         #########################################################################

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.2.8"
+__version__ = "4.2.9"
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.8
+current_version = 4.2.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.2.8",
+    version="4.2.9",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Why is there no CDO in the mistral.yaml file?

It is needed to generate the o2a_flux and a2o_flux so oasis can restart.