### PR TITLE
fix(configs/couplings): specifies replacement for FESOM_COUPLED in se…

### DIFF
--- a/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
@@ -5,5 +5,5 @@ components:
 - pism-github1.2
 - scope-dev
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn/fesom-1.4+echam-6.3.04p1-paleodyn.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn/fesom-1.4+echam-6.3.04p1-paleodyn.yaml
@@ -3,5 +3,5 @@ components:
 - fesom-1.4
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-1.4+echam-6.3.04p1/fesom-1.4+echam-6.3.04p1.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.04p1/fesom-1.4+echam-6.3.04p1.yaml
@@ -3,5 +3,5 @@ components:
 - fesom-1.4
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
@@ -6,6 +6,6 @@ components:
 - scope-dev
 - debm-esm_tools
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn/configure.ac

--- a/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
@@ -3,6 +3,6 @@ components:
 - fesom-1.4
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn/configure.ac

--- a/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation/fesom-1.4+echam-6.3.05p2-concurrent_radiation.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation/fesom-1.4+echam-6.3.05p2-concurrent_radiation.yaml
@@ -4,5 +4,5 @@ components:
 - oasis3mct-2.8
 coupling_changes:
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation/config/mh-linux
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation/configure.ac

--- a/configs/couplings/fesom-1.4+recom-2.0+echam-6.3.04p1/fesom-1.4+recom-2.0+echam-6.3.04p1.yaml
+++ b/configs/couplings/fesom-1.4+recom-2.0+echam-6.3.04p1/fesom-1.4+recom-2.0+echam-6.3.04p1.yaml
@@ -4,7 +4,7 @@ components:
   - fesom-1.4-recom-awicm
   - oasis3mct-2.8
 coupling_changes:
-  - sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
+  - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
   - sed -i '/FESOM_RECOM/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
   - sed -i '/RECOM_LIBRARY/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
   - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-1.4+recom-2.0/fesom-1.4+recom-2.0.yaml
+++ b/configs/couplings/fesom-1.4+recom-2.0/fesom-1.4+recom-2.0.yaml
@@ -2,6 +2,6 @@ components:
   - recom-2.0
   - fesom-1.4-recom-mocsy-slp
 coupling_changes:
-  - sed -i '/FESOM_COUPLED/s/ON/OFF/g' fesom-1.4/CMakeLists.txt
+  - sed -i '/set(FESOM_COUPLED/s/ON/OFF/g' fesom-1.4/CMakeLists.txt
   - sed -i '/FESOM_RECOM/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
   - sed -i '/RECOM_LIBRARY/s/OFF/ON/g' fesom-1.4/CMakeLists.txt

--- a/configs/couplings/fesom-2.0+echam-6.3.04p1/fesom-2.0+echam-6.3.04p1.yaml
+++ b/configs/couplings/fesom-2.0+echam-6.3.04p1/fesom-2.0+echam-6.3.04p1.yaml
@@ -3,5 +3,5 @@ components:
 - fesom-2.0
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0+echam-6.3.05p2-concurrent_radiation/fesom-2.0+echam-6.3.05p2-concurrent_radiation.yaml
+++ b/configs/couplings/fesom-2.0+echam-6.3.05p2-concurrent_radiation/fesom-2.0+echam-6.3.05p2-concurrent_radiation.yaml
@@ -4,5 +4,5 @@ components:
 - oasis3mct-2.8
 coupling_changes:
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation/config/mh-linux
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation/configure.ac

--- a/configs/couplings/fesom-2.0+oifs-43r3-awi/fesom-2.0+oifs-43r3-awi.yaml
+++ b/configs/couplings/fesom-2.0+oifs-43r3-awi/fesom-2.0+oifs-43r3-awi.yaml
@@ -4,5 +4,5 @@ components:
 - fesom-2.0-o
 - oasis3mct-3.0
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0-o/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0-o/CMakeLists.txt
 - sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0-o/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-esm-interface+echam-6.3.04p1-esm-interface/fesom-2.0-esm-interface+echam-6.3.04p1-esm-interface.yaml
+++ b/configs/couplings/fesom-2.0-esm-interface+echam-6.3.04p1-esm-interface/fesom-2.0-esm-interface+echam-6.3.04p1-esm-interface.yaml
@@ -4,5 +4,5 @@ components:
 - fesom-2.0-esm-interface
 - echam-6.3.04p1-esm-interface
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-esm-interface-yac+echam-6.3.04p1-esm-interface-yac/fesom-2.0-esm-interface-yac+echam-6.3.04p1-esm-interface-yac.yaml
+++ b/configs/couplings/fesom-2.0-esm-interface-yac+echam-6.3.04p1-esm-interface-yac/fesom-2.0-esm-interface-yac+echam-6.3.04p1-esm-interface-yac.yaml
@@ -5,5 +5,5 @@ components:
 - echam-6.3.04p1-esm-interface-yac
 - fesom-2.0-esm-interface-yac
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
@@ -5,5 +5,5 @@ components:
 - pism-github1.2
 - scope-dev
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn.yaml
@@ -3,5 +3,5 @@ components:
 - fesom-2.0-paleodyn
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
@@ -6,6 +6,6 @@ components:
 - scope-dev
 - debm-esm_tools
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux
   #- sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn/configure.ac

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools.yaml
@@ -6,7 +6,7 @@ components:
 - scope-dev
 - debm-esm_tools
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 #- sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn/configure.ac

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
@@ -3,6 +3,6 @@ components:
 - fesom-2.0-paleodyn
 - oasis3mct-2.8
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn/configure.ac

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "4.2.11"
+__version__ = "4.2.12"
 
 import os
 import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.2.11
+current_version = 4.2.12
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="4.2.11",
+    version="4.2.12",
     zip_safe=False,
 )
 


### PR DESCRIPTION
…d replacements of cmakelists

Due to how sed works, if the FESOM 2.0 CMakeLists contained both
FESOM_COUPLED and OIFS_COUPLED, both were turned on as Jan Streffing had
a comment that OIFS_COUPLED also required FESOM_COUPLED. See disucssion
here: https://github.com/FESOM/fesom2/issues/30