### PR TITLE
Added recipe and faq about branch-off from old FESOM restart files.

### DIFF
--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -39,3 +39,4 @@ documentation issue on `our GitHub repository <https://github.com/esm-tools/esm_
 .. include:: recipes/modify_namelists.rst
 .. include:: recipes/add_model_setup.rst
 .. include:: recipes/use_own_namelist.rst
+.. include:: recipes/branchoff_from_old_spinups.rst

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -31,6 +31,14 @@ ESM Runscripts
 
    **A**: You can safely forget about ``FUNCTION_PATH``, which was only needed in the shell script version until revision 3. Either ignore it, or better remove it from the runscript.
 
+3. **Q**: When I try to branch-off from a spinup experiment using `FESOM`, I get the following runtime error::
+
+    read ocean restart file
+    Error:
+    NetCDF: Invalid dimension ID or name
+
+
+   **A**: See :ref:`How to branch-off FESOM from old spinup restart files <target to branchoff old restart>`.
 
 ESM Master
 ----------

--- a/docs/recipes/branchoff_from_old_spinups.rst
+++ b/docs/recipes/branchoff_from_old_spinups.rst
@@ -1,0 +1,40 @@
+.. _target to branchoff old restart:
+
+How to branch-off FESOM from old spinup restart files
+=======================================================
+
+.. use = for sections, ~ for subsections and - for subsubsections
+
+.. **Feature available since version:** <version_num>
+
+When you branch-off from very old FESOM ocean restart files, you may encounter the following runtime error:
+
+.. code-block::
+
+    read ocean restart file
+    Error:
+    NetCDF: Invalid dimension ID or name
+
+
+This is because the naming of the NetCDF time dimension variable in the restart file has changed from ``T`` to ``time`` during the development of `FESOM` and the different `FESOM` versions.
+Therefore, recent versions of `FESOM` expect the name of the time dimension to be ``time``.
+
+In order to branch-off experiments from spinup restart files that use the old name for the time dimension, you need to rename this dimension before starting the branch-off experiment. 
+
+.. warning:: The following work around will change the restart file permanently. Make sure you do not apply this to the original file.
+
+
+To rename a dimension variable of a NetCDF file, you can use ``ncrename``:
+
+.. code-block:: bash
+
+    ncrename -d T,time <copy_of_restart_spinup_file>.nc
+
+where ``T`` is the old dimension and ``time`` is the new dimension.
+
+See also
+~~~~~~~~
+
+.. links to relevant parts of the documentation
+
+- :ref:`cookbook:How to run a branch-off experiment`


### PR DESCRIPTION
I added a recipe and FAQ as solution for the runtime error due to different time dimension naming in old FESOM restart files.

The cookbook section may later be placed in the 'How to do runscripts' section.