### PR TITLE
remove top-level `include_models`

### DIFF
--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -13,9 +13,6 @@ type: atmosphere
 with_xios: False
 xml_dir: ''
 
-include_models:
-        - xios
-
 description: |
         The OpenIFS atmosphere model based on ECMWF IFS
         Carver et al., in prep.

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.2"
+__version__ = "5.0.3"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.2
+current_version = 5.0.3
 commit = True
 tag = True
 
@@ -19,4 +19,3 @@ exclude = docs
 max-line-length = 88
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.0.2",
+    version="5.0.3",
     zip_safe=False,
 )
 


### PR DESCRIPTION
removed top-level include_models which was a workaround needed for esm_parser
with esm_parser version 5.0.1 this is not required anymore.