### PR TITLE
fix: rad streams in echam and hyper off on DKRZ

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -89,18 +89,6 @@ include_models:
         - hdmodel
 
 
-choose_computer.name:
-        mistral:
-            choose_version:
-                6.3.05p2-concurrent_radiation-paleodyn:
-                    add_add_compiletime_environment_changes:
-                        add_add_export_vars:
-                            - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
-                            - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
-                    add_add_runtime_environment_changes:
-                        add_add_export_vars:
-                            - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
-                            - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
 
 executable: echam6
 version: 6.3.04p1
@@ -209,6 +197,16 @@ choose_version:
                 lrad_async: "remove_from_namelist"
 
         6.3.05p2-concurrent_radiation-paleodyn:
+                choose_computer.name:
+                    mistral:
+                        add_add_compiletime_environment_changes:
+                            add_add_export_vars:
+                                - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
+                                - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
+                        add_add_runtime_environment_changes:
+                            add_add_export_vars:
+                                - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
+                                - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
                 repo_tag: not_applicable
                 dataset: r0007
                 add_streams:
@@ -226,6 +224,7 @@ choose_version:
                                 radctl:
                                         lrad_async: "${lrad_async}"
                                         lrestart_from_old: "${lrestart_from_old}"
+
         6.3.05p2-concurrent_radiation:
                 repo_tag: not_applicable
                 dataset: r0007

--- a/configs/esm_software/esm_runscripts/esm_runscripts.yaml
+++ b/configs/esm_software/esm_runscripts/esm_runscripts.yaml
@@ -38,8 +38,8 @@ choose_job_type:
                         - "start_post_job"
                         - "_increment_date_and_run_number"
                         - "_write_date_file"
-                        - "maybe_resubmit"
                         - "signal_tidy_completion"
+                        - "maybe_resubmit"
 
 
         compute:

--- a/configs/esm_software/esm_runscripts/esm_runscripts.yaml
+++ b/configs/esm_software/esm_runscripts/esm_runscripts.yaml
@@ -36,9 +36,9 @@ choose_job_type:
                         - "copy_all_results_to_exp"
                         - "clean_run_dir"
                         - "start_post_job"
+                        - "signal_tidy_completion"
                         - "_increment_date_and_run_number"
                         - "_write_date_file"
-                        - "signal_tidy_completion"
                         - "maybe_resubmit"
 
 

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -5,6 +5,7 @@ name: mistral
 additional_flags: "--mem=0"
 account: None
 
+hyperthreading_flag: "--ntasks-per-core=1"
 choose_general.use_hyperthreading:
         "1":
                 hyperthreading_flag: ""
@@ -12,7 +13,11 @@ choose_general.use_hyperthreading:
                 hyperthreading_flag: ""
         True:
                 hyperthreading_flag: ""
-        "*":
+        "0":
+                hyperthreading_flag: "--ntasks-per-core=1"
+        0:
+                hyperthreading_flag: "--ntasks-per-core=1"
+        "False":
                 hyperthreading_flag: "--ntasks-per-core=1"
 
 accounting: true

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -6,14 +6,14 @@ additional_flags: "--mem=0"
 account: None
 
 choose_general.use_hyperthreading:
-        "0":
-                hyperthreading_flag: "--ntasks-per-core=1"
-        0:
-                hyperthreading_flag: "--ntasks-per-core=1"
-        False:
-                hyperthreading_flag: "--ntasks-per-core=1"
-        "*":
+        "1":
                 hyperthreading_flag: ""
+        1:
+                hyperthreading_flag: ""
+        True:
+                hyperthreading_flag: ""
+        "*":
+                hyperthreading_flag: "--ntasks-per-core=1"
 
 accounting: true
 

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -17,7 +17,7 @@ choose_use_hyperthreading:
                 hyperthreading_flag: "--ntasks-per-core=1"
         0:
                 hyperthreading_flag: "--ntasks-per-core=1"
-        "False":
+        False:
                 hyperthreading_flag: "--ntasks-per-core=1"
 
 accounting: true

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -5,8 +5,8 @@ name: mistral
 additional_flags: "--mem=0"
 account: None
 
-hyperthreading_flag: "--ntasks-per-core=1"
-choose_general.use_hyperthreading:
+use_hyperthreading: False
+choose_use_hyperthreading:
         "1":
                 hyperthreading_flag: ""
         1:

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.6"
+__version__ = "5.0.7"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.6
+current_version = 5.0.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.0.6",
+    version="5.0.7",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Rad streams where not properly moved to next compute job, led to model crash after first year.

Also, hyper threading is off now on MISTRAL by default, as it induces longer wall times.

@mandresm, can you please put this in develop too?