### PR TITLE
removed 0 and 1 which causes duplicate variable error

### DIFF
--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -9,13 +9,9 @@ use_hyperthreading: False
 choose_use_hyperthreading:
         "1":
                 hyperthreading_flag: ""
-        1:
-                hyperthreading_flag: ""
         True:
                 hyperthreading_flag: ""
         "0":
-                hyperthreading_flag: "--ntasks-per-core=1"
-        0:
                 hyperthreading_flag: "--ntasks-per-core=1"
         False:
                 hyperthreading_flag: "--ntasks-per-core=1"


### PR DESCRIPTION
Some colleagues are complaining about not being able to install their models. This has to be fixed ASAP.