### PR TITLE
fix(pism): Sets default to 4 cores on 24 cores per node machines

### DIFF
--- a/configs/components/pism/pism.yaml
+++ b/configs/components/pism/pism.yaml
@@ -80,6 +80,10 @@ cold_start_file: "${pool_dir}/input/${domain}/pismr_${domain}_${resolution}.nc"
 spinup_file: "/no/default/was/set"
 
 choose_computer.cores_per_node:
+    24:
+        nnodes: 4
+        nproca: 96
+        nprocb: 1
     36:
         nnodes: 2
         nproca: 72

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.11"
+__version__ = "5.0.12"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.11
+current_version = 5.0.12
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.0.11",
+    version="5.0.12",
     zip_safe=False,
 )
 


### PR DESCRIPTION
PISM didn't have a default for 24 cores per node machines. Now, the default is to use 4 nodes.