### PR TITLE
added curl support for codes that are not hosted in repositories

### DIFF
--- a/configs/components/tux/tux.yaml
+++ b/configs/components/tux/tux.yaml
@@ -1,0 +1,34 @@
+model: "tux"
+version: "1.0"
+type: figure
+
+available_versions:
+- "1.0"
+
+choose_version:
+    "1.0":
+        destination: "tux-1.0"
+        choose_computer.name:
+            mistral:
+                add_compiletime_environment_changes:
+                    add_module_actions:
+                        - "load imagemagick/6.9.1-7-gcc48"
+
+curl-repository: "https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png"
+
+# options to pass to curl. Eg. --silent, --verbose, ...
+repo_options: "--silent  --create-dirs  --output ${destination}/${install_bins}"   
+
+install_bins: "img/tux.svg"
+clean_command: "rm -fr ${install_bins}"
+comp_command: "display ${install_bins}"
+
+metadata:
+        Institute: wiki
+        Description:
+            "Tux image"
+        Authors: "who knows"
+        Publications:
+            - "are you serious?"
+        License:
+            GPL

--- a/configs/other_software/vcs/curl.yaml
+++ b/configs/other_software/vcs/curl.yaml
@@ -1,0 +1,9 @@
+# Support for the codes that are not hosted in a repository but in a URL, eg.
+# in a tarball
+get_command: "curl ${define_options}  --url ${curl-repository}"
+update_command: ""   # these need to be empty so that esm_master does not crash
+status_command: ""
+log_command: ""
+
+# options for wget. repo_options can be defined in the model yaml file
+define_options: "${repo_options}"

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.15"
+__version__ = "5.0.16"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.15
+current_version = 5.0.16
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.0.15",
+    version="5.0.16",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Together with the pull request in the `esm_master`, it is now possible to download codes that are not hosted in repositories (eg. GitHub, GitLab, svn, mercurial, ...). Here is a quick example:

``` 
esm_master get-tux-1.0
esm_master comp-tux-1.0
esm_master clean-tux-1.0
```
or `esm_master install-tux-1.0`. 

Make sure that your X11 settings are on 😄 
![image](https://user-images.githubusercontent.com/51913535/110391285-8d90dc80-8067-11eb-8a43-ec2352a23e7d.png)
 