### PR TITLE
added pipe support for curl but can also be used in other packages

### DIFF
--- a/configs/components/yaxt/yaxt.yaml
+++ b/configs/components/yaxt/yaxt.yaml
@@ -1,0 +1,26 @@
+model: "yaxt"
+environment_changes:
+    choose_computer.name:
+        mistral:
+            add_module_actions:
+                - "load autoconf/2.69"
+                - "load automake/1.16.1"
+            ollie:
+                add_module_actions:
+                    - "load automake"
+available_versions:
+- "0.9.0"
+choose_version:
+    "0.9.0":
+        curl-repository: "https://www.dkrz.de/redmine/attachments/download/498/yaxt-0.9.0.tar.gz"
+        repo_options: "--silent"
+clean_command: ""
+comp_command: ""
+conf_command: "autoreconf -iv"
+pipe_options: "| tar xz"    # deniz: added extraction via pipe
+metadata:
+    Information: "For more information about YAXT please ..."
+    Description: "yaxt"
+    Authors: ""
+    Publications: ""
+    License: ""

--- a/configs/other_software/vcs/curl.yaml
+++ b/configs/other_software/vcs/curl.yaml
@@ -1,9 +1,12 @@
 # Support for the codes that are not hosted in a repository but in a URL, eg.
 # in a tarball
-get_command: "curl ${define_options}  --url ${curl-repository}"
+get_command: "curl ${define_options}  --url ${curl-repository} ${pipe_options}"
 update_command: ""   # these need to be empty so that esm_master does not crash
 status_command: ""
 log_command: ""
 
 # options for wget. repo_options can be defined in the model yaml file
 define_options: "${repo_options}"
+
+# provided in the model yaml file. Eg. | tar xz
+pipe_options: ""

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.16"
+__version__ = "5.0.17"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.16
+current_version = 5.0.17
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.0.16",
+    version="5.0.17",
     zip_safe=False,
 )
 


### PR DESCRIPTION
It is now possible to use `tar zx` pipe in the curl command. It is also possible to pipes in other commands as well. It only supports two commands now (eg. `curl--silent foo.tar.gz | tar xz`). Please don't even think about something like `ps aux | grep conky | grep -v grep | awk '{print $2}' | xargs kill` 😆 

You also need the pull request from `esm_master`.

You can test it with: 
`esm_master get-yaxt-0.9.0`