### PR TITLE
Feature/awicm3 juwels intel2020 impi2020

### DIFF
--- a/configs/components/oifs/oifs.env.yaml
+++ b/configs/components/oifs/oifs.env.yaml
@@ -42,7 +42,7 @@ runtime_environment_changes:
         - "unload gribapi"
       add_export_vars:
         GRIBAPIROOT: "/home/ollie/jstreffi/ecmwf/grib_api_intel_hdf5_1.10.2_gnu"
-        LD_LIBRARY_PATH: '"$LD_LIBRARY_PATH:$GRIBAPIROOT/lib"'
+        LD_LIBRARY_PATH: '"$LD_LIBRARY_PATH:$GRIBAPIROOT/lib64"'
         OIFS_FFIXED: '""'
         GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/grib_api/ifs_samples/grib1_mlgrib2"'
         DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'

--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -92,6 +92,7 @@ choose_compiler_mpi:
         NETCDF_Fortran_INCLUDE_DIRECTORIES: $EBROOTNETCDFMINFORTRAN/include
         NETCDF_Fortran_LIBRARIES: $EBROOTNETCDFMINFORTRAN/lib
         ECCODESROOT: /p/project/chhb19/jstreffi/ecmwf/eccodes_intel2020_psi2020
+        LD_LIBRARY_PATH: $ECCODESROOT/lib:$LD_LIBRARY_PATH
 
    intel2019_impi2019:
       add_module_actions:

--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -7,10 +7,10 @@ jobtype: compute
 accounting: true
 
 # default settings for compiler, mpi and I/O libs
-#compiler_mpi: intel2019_impi2019
+compiler_mpi: intel_2019a_impi2019
 #iolibraries: system_libs
 # for FOCI/FOCIOIFS use
-compiler_mpi: intel2020_psmpi2020
+#compiler_mpi: intel2019_impi2019 #intel2020_psmpi2020
 iolibraries: geomar_libs
 
 # slurm setup
@@ -20,9 +20,9 @@ threads_per_core: 1
 launcher_flags: "-l "
 
 # set default for hyperthreading_flag
-hyperthreading_flag: "--ntasks-per-core=1"
+hyperthreading_flag: ""
 
-use_hyperthreading: False
+use_hyperthreading: True
 choose_use_hyperthreading:
         "1":
                 hyperthreading_flag: ""
@@ -65,9 +65,36 @@ module_actions:
 
 export_vars:
         LC_ALL: en_US.UTF-8
+        TMPDIR: /tmp
 
 # choose compiler and MPI implementation
 choose_compiler_mpi:
+
+   intel2020_impi2020:
+      add_module_actions:
+        - "load Stages/2020"
+        - "load Intel/2020.2.254-GCC-9.3.0"
+        - "load IntelMPI/2019.8.254"
+        - "load CMake/3.18.0"
+        - "load Python/3.8.5"
+        - "load imkl/2020.2.254"
+        - "load netCDF-Fortran/4.5.3"
+        - "load netCDF/4.7.4"
+        - "load Perl/5.32.0"
+      add_export_vars:
+        FC: mpiifort
+        F77: mpiifort
+        MPIFC: mpiifort
+        FCFLAGS: -free
+        CC: mpiicc
+        CXX: mpiicpc
+        MPIROOT: "\"$($FC -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
+        MPI_LIB: "\"$($FC -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+        NETCDF_Fortran_INCLUDE_DIRECTORIES: $EBROOTNETCDFMINFORTRAN/include
+        NETCDF_Fortran_LIBRARIES: $EBROOTNETCDFMINFORTRAN/lib
+        ECCODESROOT: /p/project/chhb19/jstreffi/ecmwf/eccodes_intel2020_impi2020
+        LD_LIBRARY_PATH: $ECCODESROOT/lib64:$LD_LIBRARY_PATH
+
 
    intel2020_psmpi2020:
       add_module_actions:
@@ -92,18 +119,20 @@ choose_compiler_mpi:
         NETCDF_Fortran_INCLUDE_DIRECTORIES: $EBROOTNETCDFMINFORTRAN/include
         NETCDF_Fortran_LIBRARIES: $EBROOTNETCDFMINFORTRAN/lib
         ECCODESROOT: /p/project/chhb19/jstreffi/ecmwf/eccodes_intel2020_psi2020
-        LD_LIBRARY_PATH: $ECCODESROOT/lib:$LD_LIBRARY_PATH
+        LD_LIBRARY_PATH: $ECCODESROOT/lib64:$LD_LIBRARY_PATH
 
-   intel2019_impi2019:
+   intel_2019a_impi2019:
       add_module_actions:
-         - "load Stages/Devel-2019a"
-         - "load Intel/2019.5.281-GCC-8.3.0"
-         - "load IntelMPI/2019.6.154"
+         - "load Stages/2019a"
+         - "load Intel/2019.3.199-GCC-8.3.0"
+         - "load IntelMPI/2018.5.288"
          - "load CMake"
          - "load Python/3.6.8"
          - "load imkl/2019.3.199"
-         #TODO check if we need perl
-         #- "load Perl/5.28.1"
+         - "load Perl/5.28.1"
+         - "load netCDF/4.6.3"
+         - "load netCDF-Fortran/4.4.5"
+         - "unload grib_api"
       # FOCI needs the release_mt version of intel mpi
       choose_general.setup_name:
          foci:
@@ -118,6 +147,40 @@ choose_compiler_mpi:
          CXX: mpiicpc
          MPIROOT: "\"$(mpiifort -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
          MPI_LIB: "\"$(mpiifort -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+         NETCDF_Fortran_INCLUDE_DIRECTORIES: $EBROOTNETCDFMINFORTRAN/include
+         NETCDF_Fortran_LIBRARIES: $EBROOTNETCDFMINFORTRAN/lib
+         ECCODESROOT: /p/project/chhb19/jstreffi/ecmwf/eccodes_intel2019_impi2019
+         LD_LIBRARY_PATH: $ECCODESROOT/lib64:$LD_LIBRARY_PATH
+         CMAKE_LIBRARY_PATH: $EBROOTNETCDF/lib64:$CMAKE_LIBRARY_PATH
+         CMAKE_PREFIX_PATH: $EBROOTNETCDF:$CMAKE_PREFIX_PATH
+
+   intel_Develop_2019a_impi2019:
+      add_module_actions:
+         - "load Stages/Devel-2019a"
+         - "load Intel/2019.5.281-GCC-8.3.0"
+         - "load IntelMPI/2019.6.154"
+         - "load CMake"
+         - "load Python/3.6.8"
+         - "load imkl/2019.3.199"
+         - "load Perl/5.28.1"
+      # FOCI needs the release_mt version of intel mpi
+      choose_general.setup_name:
+         foci:
+            add_module_actions:
+               - "source /gpfs/software/juwels/stages/Devel-2019a/software/impi/2019.6.154-iccifort-2019.3.199-GCC-8.3.0/bin/mpivars.sh release_mt"
+      add_export_vars:
+         FC: mpiifort
+         F77: mpiifort
+         MPIFC: mpiifort
+         FCFLAGS: -free
+         CC: mpiicc
+         CXX: mpiicpc
+         MPIROOT: "\"$(mpiifort -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
+         MPI_LIB: "\"$(mpiifort -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+         NETCDF_Fortran_INCLUDE_DIRECTORIES: $EBROOTNETCDFMINFORTRAN/include
+         NETCDF_Fortran_LIBRARIES: $EBROOTNETCDFMINFORTRAN/lib
+         ECCODESROOT: /p/project/chhb19/jstreffi/ecmwf/eccodes_intel2020_psi2020
+         LD_LIBRARY_PATH: $ECCODESROOT/lib64:$LD_LIBRARY_PATH
 
    intel2019_parastation:
       add_module_actions:
@@ -127,8 +190,7 @@ choose_compiler_mpi:
          - "load CMake"
          - "load Python/3.6.8"
          - "load imkl/2019.3.199"
-         #TODO check if we need perl
-         #- "load Perl/5.28.1"
+         - "load Perl/5.28.1"
       add_export_vars:
          FC: mpifort
          F77: mpifort

--- a/runscripts/awicm3/awicm3-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/awicm3-juwels-TL159L60-CORE2.yaml
@@ -19,7 +19,7 @@ awicm3:
 fesom:
     resolution: "CORE2"
     pool_dir: "/p/project/chhb19/jstreffi/input/fesom2/"
-    #mesh_dir: "${pool_dir}/core2_meanz/"
+    mesh_dir: "${pool_dir}/core2_meanz/"
     restart_rate: 1
     restart_unit: "m"
     restart_first: 1

--- a/runscripts/awicm3/awicm3-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/awicm3-juwels-TL159L60-CORE2.yaml
@@ -2,10 +2,11 @@ general:
     setup_name: "awicm3"
     version: "1.0-deck"
     account: "esmtst"
-    compute_time: "00:30:00"
+    taskset: true
+    compute_time: "00:05:00"
     initial_date: "1990-01-01"
-    final_date: "1990-01-02"
-    base_dir: "/p/scratch/chhb19/jstreffi/runtime/awicm-3.1"
+    final_date: "1990-01-03"
+    base_dir: "/p/scratch/chhb20/jstreffi/runtime/awicm-3.1"
     nday: 0
     nmonth: 1
     nyear: 0
@@ -24,16 +25,18 @@ fesom:
     restart_first: 1
     lresume: false
     time_step: 1800
-    nproc: 72
+    nproc: 144
 
 oifs:
     resolution: "TL159"
     levels: "L60"
     prepifs_expid: h6mv
     input_expid: awi3
-    wam: false
+    wam: true
     lresume: false
     time_step: 3600
+    nproc: 48
+    omp_num_threads: 2
 
 oasis3mct:
     lresume: false # Set to false to generate the rst files for first leg


### PR DESCRIPTION
This works for AWI but will break some stuff for GEOMAR. We will have to work on this once we merge again with GEOMAR.
In the long run I suggest we try to include eccodes as a library in the default OpenIFS installation. Installing eccodes is actually way faster than I remember from grib_api. It takes about 3-4 min extra during compiling and it would save lots of headache on machines like Juwels where users have no cross project read permissions.