### PR TITLE
overcommit feature: possibility to use less CPUs than the number of processes

### DIFF
--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -98,3 +98,14 @@ check_error:
                 method: "kill"
                 message: "SLURM ERROR: slurm probably didn't find executable"
                 file: "stdout"
+                
+# possibility to use less cores than processes. Useful for test runs / debugging                
+# can be specified in user runscript
+overcommit_nodes: None
+overcommit_rule: ""
+
+choose_overcommit_nodes:
+    "*":
+        overcommit_rule:  "--overcommit --nodes=${overcommit_nodes}"
+
+overcommit_flag: "${overcommit_rule}"


### PR DESCRIPTION
Even though MPI specification leaves the mapping of processes to physical processors to the implementors, Slurm by default sends each MPI process to an independent physical core (eg. one of the multicores of a compute node). 
This could cause long wait times on the Slurm queue when doing test runs (when simple check run is not enough). In order to solve this issue I added a feature to overcommit Slurm resources. Eg. When you submit a job like this:

`#SBATCH  ... --ntasks=100 --overcommit  --nodes=1`
Slurm will find a compute node (eg. one with 48 cores) and will send all 100 processes to 48 cores. If you omit `--overcommit` option then Slurm will print an error message and quit.

### TLDR: How can I use it?
in your runscript write
```YAML
computer:
    overcommit_nodes: 2  # number of compute nodes to use
```
`overcommit_nodes` will open the `--overcommit` flag to Slurm and add the `--nodes=<number_of_nodes>` option where `number_of_nodes` is the right hand side of the `overcommit_nodes` option in the runscript YAML file. Please note that `number_of_nodes` is not the number of CPUs but rather the compute node. Eg. a compute node may have 48 physical cores like in Mistral.

Also check: https://github.com/esm-tools/esm_runscripts/pull/91