### PR TITLE
names for OpenIFS in the documentation fixed

### DIFF
--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -63,6 +63,7 @@ parent_dir: "${pool_dir}/OPENIFS43R3-TCO95/restart/${parent_expid}"
 #       but I want the expid for my run to be ECE3.
 
 metadata:
+        Name: OpenIFS
         Institute: ECMWF
         Description:
                 OpenIFS provides research institutions with an easy-to-use version
@@ -70,7 +71,7 @@ metadata:
         Authors: Glenn Carver (openifs-support@ecmwf.int)
         Website: https://www.ecmwf.int/en/research/projects/openifs
         License:
-                Please make sure you have a licence to use OIFS. In case you are
+                Please make sure you have a licence to use OpenIFS. In case you are
                 unsure, please contact redmine...
 
 compile_infos:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,7 @@ for config in configs:
                         else:
                             table.write("%s; `%s`_\n" % (key, metadata[key]))
                     elif key=="Name" or key=="name":
-                        name = key
+                        name = metadata[key]
                     else:
                         table.write("%s; %s\n" % (key, metadata[key]))
         with open("Supported_Models.rst", "a") as rst:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ for config in configs:
     with open(os.path.join("../configs/components/", config, config+".yaml")) as f:
         d = yaml.load(f, Loader=yaml.FullLoader)
         metadata = d.get("metadata")
+        name = config.upper()
         with open("metadata/"+config+".csv", "w") as table:
             if metadata:
                 for key in metadata:
@@ -57,10 +58,12 @@ for config in configs:
                             table.write(public_string+'"\n')
                         else:
                             table.write("%s; `%s`_\n" % (key, metadata[key]))
+                    elif key=="Name" or key=="name":
+                        name = key
                     else:
                         table.write("%s; %s\n" % (key, metadata[key]))
         with open("Supported_Models.rst", "a") as rst:
-            rst.write("%s\n" % config.upper())
+            rst.write("%s\n" % name)
             rst.write("-"*len(config) + "\n")
             rst.write(".. csv-table::\n")
             rst.write("   :file: %s\n" % ("metadata/"+config+".csv"))


### PR DESCRIPTION
- Added the possibility to add an specific name to the given component through the `metadata` chapter, to be used as title in the Supported Models chapter of the documentation.
- References to OIFS changed to OpenIFS
- You can check here how the OpenIFS section will look like once merged: https://esm-tools.readthedocs.io/en/latest/Supported_Models.html