### PR TITLE
message of the day for minor release 5.1

### DIFF
--- a/docs/esm_environment.rst
+++ b/docs/esm_environment.rst
@@ -132,5 +132,5 @@ General environment for setups
 To define a general ``environment_changes`` **for all the components of a setup**,
 include the ``environment_changes`` inside the ``general`` section of the setup
 file. **This will ignore all the** ``environment_changes`` **defined by the standalone
-files**. It still possible to add component-specific ``environment_changes`` **from
+files**. It is still possible to add component-specific ``environment_changes`` **from
 the component chapter inside the setup file**.

--- a/esm_tools/motd/motd.yaml
+++ b/esm_tools/motd/motd.yaml
@@ -49,10 +49,32 @@ release5_esm_plugin_manager:
 
 hosing_esm_tools:
         package: "esm_tools"
-        versions: ">=5.0.5"
+        versions: "==5.0.5"
         message: |
                 "ESM Tools version 5.0.5 allows for the generation of hosing files in AWI-ESM-2.1 and AWI-ESM-2.2
                 To use that, you still need to install a plugin. Please run:
 
                 $ pip install --user gfw_creator"
         action: DELAY(1)
+
+release5.1_esm_tools:
+        package: "esm_tools"
+        versions: "<5.1.0"
+        message: |
+                "The new minor release 5.1 is now available!
+                This minor release include no new models or couple setups but new features to the following packages:
+                    - esm_master
+                    - esm_parser
+                    - esm_environment
+                    - esm_rcfiles
+                    - esm_version_checker
+                    - esm_tools
+                To get this updates simply run 'esm_versions upgrade'.
+
+                NOTE TO DEVELOPERS AND ADVANCE USERS: if you intend to use an branch of 'esm_tools' that is not 'release'
+                you might face conflicts with the new 'esm_environment'. These conflicts are easily solved by copying the
+                new machine files into your 'esm_tools' branch (make sure you commit the changes in your branch before
+                copying the machine files over). Feel free to contact us if you need any assistance with this issue.
+                "
+        action: DELAY(1)
+

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ requirements = [
     "esm_runscripts @ git+https://github.com/esm-tools/esm_runscripts.git",
     "esm_rcfile @ git+https://github.com/esm-tools/esm_rcfile.git",
     "esm_version_checker @ git+https://github.com/esm-tools/esm_version_checker.git",
+    "gfw-creator",
 ]
 
 setup_requirements = []


### PR DESCRIPTION
- Removes the hosing MOTD for versions of `esm_tools` that are not 5.0.12. This message was asking the user to `pip install gfw-creator`. Now this is a requirement inside `setup.py` so that it gets automatically installed when installing `esm_tools`.

- A new message is added advertising versions 5.1.0. The new message displays this:
```
************************************************************************************
Message found for package esm_tools version 5.0.12:

"The new minor release 5.1 is now available!
This minor release include no new models or couple setups but new features to the following packages:
    - esm_master
    - esm_parser
    - esm_environment
    - esm_rcfiles
    - esm_version_checker
    - esm_tools
To get this updates simply run 'esm_versions upgrade'.

NOTE TO DEVELOPERS AND ADVANCE USERS: if you intend to use an branch of 'esm_tools' that is not 'release'
you might face conflicts with the new 'esm_environment'. These conflicts are easily solved by copying the
new machine files into your 'esm_tools' branch (make sure you commit the changes in your branch before
copying the machine files over). Feel free to contact us if you need any assistance with this issue.
"

Upgrade this package by typing:              esm_versions upgrade esm_tools
Upgrade all packages by typing:              esm_versions upgrade
************************************************************************************
```