### PR TITLE
Default output in awiesm

### DIFF
--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -66,6 +66,11 @@ echam:
         namelist_changes:
                 namelist.echam:
                         runctl:
+                                # NOTE(PG): Almost no one in paleodyn uses the
+                                # stream-style output, and most people expect a
+                                # ${EXPID}_echam_${DATE} file. Turning default
+                                # output on does that:
+                                default_output: True
                                 lcouple: .true.
         adj_input_dir: "${fesom.mesh_dir}/tarfiles${echam.resolution}/input/echam6"
         model_dir: ${general.model_dir}/echam-${echam.version}

--- a/configs/setups/awiesm/awiesm-2.2.yaml
+++ b/configs/setups/awiesm/awiesm-2.2.yaml
@@ -80,6 +80,11 @@ echam:
         namelist_changes:
                 namelist.echam:
                         runctl:
+                                # NOTE(PG): Almost no one in paleodyn uses the
+                                # stream-style output, and most people expect a
+                                # ${EXPID}_echam_${DATE} file. Turning default
+                                # output on does that:
+                                default_output: True
                                 lcouple: .true.
         adj_input_dir: "${fesom.mesh_dir}/tarfiles${echam.resolution}/input/echam6"
         model_dir: ${general.model_dir}/echam-${echam.version}

--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -48,6 +48,11 @@ echam:
         namelist_changes:
                 namelist.echam:
                         runctl:
+                                # NOTE(PG): Almost no one in paleodyn uses the
+                                # stream-style output, and most people expect a
+                                # ${EXPID}_echam_${DATE} file. Turning default
+                                # output on does that:
+                                default_output: True
                                 lcouple: .true.
         adj_input_dir: "${fesom.mesh_dir}/tarfiles${echam.resolution}/input/echam6"
         model_dir: ${general.model_dir}/echam-${echam.version}


### PR DESCRIPTION
There has always been ongoing discussion regarding the "default output".

At least for AWI-ESM, the department internal recommendation is to set the following in `namelist.echam`:

```fortran
&runctl
    ...
    default_output = .true.
    ...
/
```
To avoid me needing to fix that by hand for each of the students, it could be default (at least for AWIESM). Clever people can turn it back off again.