### PR TITLE
namelist.diag removed from fesom-2.0.yaml

### DIFF
--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -221,7 +221,6 @@ config_files:
         forcing: forcing
         ice:     ice
         oce:     oce
-        diag:    diag
         io:      io
 
 config_sources:

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.0"
+__version__ = "5.1.1"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.0
+current_version = 5.1.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.1.0",
+    version="5.1.1",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Solves #335 

@koldunovn , could you please confirm that `namelist.diag` is not anymore need it in FESOM version `2.0`?