### PR TITLE
fix(awiesm): salt restoring should be off in coupled mode

### DIFF
--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -158,6 +158,8 @@ fesom:
 
         add_namelist_changes:
                 namelist.oce:
+                        oce_tra:
+                                surf_relax_s: 0.0
                         boundary:
                                 restore_s_surf: 0.0
 

--- a/configs/setups/awiesm/awiesm-2.2.yaml
+++ b/configs/setups/awiesm/awiesm-2.2.yaml
@@ -64,7 +64,7 @@ general:
                   - echam
                   - fesom
             ice_srun:
-                models: 
+                models:
                   - pism
             couple_srun:
                 models:
@@ -167,6 +167,8 @@ fesom:
 
         add_namelist_changes:
                 namelist.oce:
+                        oce_tra:
+                                surf_relax_s: 0.0
                         boundary:
                                 restore_s_surf: 0.0
 


### PR DESCRIPTION
After checking with @dsidoren and @koldunovn, the default switch for coupled mode in AWIESM should be **off**. 

Relevant FORTRAN namelist setting:
```
&oce_tra
    surf_relax_s = 0
```

This PR sets that as a default for AWI-ESM 2.1 and AWI-ESM 2.2.