### PR TITLE
fix(fesom2): adds GM parameters based upon selected ALE scheme

### DIFF
--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -106,10 +106,10 @@ choose_ALE_scheme:
 add_namelist_changes:
     namelist.oce:
         oce_dyn:
-			K_gm: ${K_gm}
+            K_gm: ${K_gm}
             K_gm_max: ${K_gm_max}
-		oce_tra:
-			K_hor: ${K_hor}
+        oce_tra:
+            K_hor: ${K_hor}
 
 
 choose_asforcing:

--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -89,6 +89,29 @@ namelists:
         - namelist.ice
         - namelist.io
 
+# Settings for Gent/McWilliams based upon the selected ALE scheme.
+ALE_scheme: 'linfs' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
+K_gm: 3000.0
+K_hor: 3000.0
+K_gm_max: 2000.0
+
+choose_ALE_scheme:
+    linfs:
+        K_gm: 5000.0
+        K_hor: 5000.0
+    zstar:
+        K_gm_max: 2000.0
+        K_hor: 3000.0
+
+add_namelist_changes:
+    namelist.oce:
+        oce_dyn:
+			K_gm: ${K_gm}
+            K_gm_max: ${K_gm_max}
+		oce_tra:
+			K_hor: ${K_hor}
+
+
 choose_asforcing:
         CORE2:
                 leapyear: false

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -45,6 +45,7 @@ general:
             couplings:
             - fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn
         scenario: "PALEO"
+        variant: beta
         resolution: ${echam.resolution}_${fesom.resolution}
         postprocessing: false
         post_time: "00:05:00"
@@ -163,6 +164,9 @@ fesom:
                         boundary:
                                 restore_s_surf: 0.0
 
+        choose_general.variant:
+            beta:
+                K_gm_max: "remove_from_namelist"
         leapyear: True
         asforcing: ECHAM5
 

--- a/configs/setups/awiesm/awiesm-2.2.yaml
+++ b/configs/setups/awiesm/awiesm-2.2.yaml
@@ -48,6 +48,7 @@ general:
                 couplings:
                     - fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools
         scenario: "PALEO"
+        variant: beta
         resolution: ${echam.resolution}_${fesom.resolution}
         postprocessing: false
         post_time: "00:05:00"
@@ -172,6 +173,9 @@ fesom:
                         boundary:
                                 restore_s_surf: 0.0
 
+        choose_general.variant:
+            beta:
+                K_gm_max: "remove_from_namelist"
         leapyear: True
         asforcing: ECHAM5
 


### PR DESCRIPTION
Based upon email exchange with Xiaoxu Shi (@xshi-awi), I have included the
recommended GM settings from @dsidoren based upon the user selected ALE scheme. 

Xiaoxu, could you check please if that agrees with your version?  @dbarbi, once
this checks out, can we also include a warning in the MOTD to make sure no one
is running with bad settings?
