### PR TITLE
fix(awiesm): sets nproca/b to 24/24 and turns off fast rad

### DIFF
--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -80,18 +80,20 @@ echam:
         choose_general.resolution:
                 T63_CORE2:
                         nproca: 24
-                        nprocb: 18
-                        nprocar: 24
-                        nprocbr: 18
+                        nprocb: 24
+                        # NOTE(PG): These should be set to 24/24 once DKRZ
+                        # gives us a working fast-radiation version.
+                        nprocar: 0
+                        nprocbr: 0
                         npromar: 8
                         lrad_async: true
                         lrestart_from_old: false
                 T63_REF87K:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
                 T63_REF:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
 
         add_compiletime_environment_changes:
             add_export_vars:

--- a/configs/setups/awiesm/awiesm-2.2.yaml
+++ b/configs/setups/awiesm/awiesm-2.2.yaml
@@ -94,18 +94,18 @@ echam:
         choose_general.resolution:
                 T63_CORE2:
                         nproca: 24
-                        nprocb: 18
-                        nprocar: 24
-                        nprocbr: 18
+                        nprocb: 24
+                        nprocar: 0
+                        nprocbr: 0
                         npromar: 8
                         lrad_async: true
                         lrestart_from_old: false
                 T63_REF87K:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
                 T63_REF:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
 
         compiletime_environment_changes:
             add_export_vars:

--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -62,13 +62,13 @@ echam:
         choose_general.resolution:
                 T63_CORE2:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
                 T63_REF87K:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
                 T63_REF:
                         nproca: 24
-                        nprocb: 18
+                        nprocb: 24
 
         add_compiletime_environment_changes:
             add_export_vars:
@@ -93,7 +93,7 @@ jsbach:
         choose_jsbach.dataset:
                 "r0009":
                         cover_fract_dir: "${fesom.mesh_dir}/tarfiles${echam.resolution}/input/jsbach"
-                "r0008":        
+                "r0008":
                         cover_fract_dir: "${fesom.mesh_dir}/tarfiles${echam.resolution}/input/jsbach"
         namelist_changes:
                 namelist.jsbach:


### PR DESCRIPTION
We have found that the nproca/b settings of 24/18 yield non-reproducible results. This changes the default to a safer 24/24 variant, and turns off the (as of now) broken fast radiation by setting the number of processors to 0 for the radiation cores
