### PR TITLE
Hotfix/fesom yearnew branchoff

### DIFF
--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -160,13 +160,20 @@ log_sources:
         mesh_diag: fesom.mesh.diag.nc
 
 
+# Is it a branchoff experiment?
+branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
+choose_branchoff:
+        true:
+                yearnew: "$(( ${initial_date!syear} - 1 ))"
+        false:
+                yearnew: "${initial_date!syear}"
 
 
 
 namelist_changes:
         namelist.config:
                 clockinit:
-                        yearnew: "${initial_date!syear}"
+                        yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"
                 paths:

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -150,6 +150,13 @@ log_sources:
         mesh_diag: fesom.mesh.diag.nc
 
 
+# Is it a branchoff experiment?
+branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
+choose_branchoff:
+        true:
+                yearnew: "$(( ${initial_date!syear} - 1 ))"
+        false:
+                yearnew: "${initial_date!syear}"
 
 
 

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -163,7 +163,7 @@ choose_branchoff:
 namelist_changes:
         namelist.config:
                 clockinit:
-                        yearnew: "${initial_date!syear}"
+                        yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"
                 paths:

--- a/configs/components/fesom/fesom.yaml
+++ b/configs/components/fesom/fesom.yaml
@@ -165,7 +165,7 @@ log_sources:
 namelist_changes:
         namelist.config:
                 clockinit:
-                        yearnew: "${initial_date!syear}"
+                        yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"
                 paths:
@@ -221,15 +221,14 @@ choose_lresume:
                         fesom.clock:
                                 - "<--append-- ${lasttime} ${parent_date!sdoy} ${parent_date!syear}"
                                 - "<--append-- ${starttime} ${startday} ${start_date!syear}"
-                choose_general.run_number:
-                        # MAM: If it is a restart triggered from a runscript
-                        # it is necessary to specify the year of the initial
-                        # date of the experiment that is to be continued
-                        1:
-                                add_namelist_changes:
-                                        namelist.config:
-                                                clockinit:
-                                                        yearnew: "${first_initial_year}"
+# Is it a branchoff experiment?
+branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
+choose_branchoff:
+        true:
+                yearnew: "$(( ${initial_date!syear} - 1 ))"
+        false:
+                yearnew: "${initial_date!syear}"
+
 
 
 

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.12"
+__version__ = "5.1.13"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.12
+current_version = 5.1.13
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.1.12",
+    version="5.1.13",
     zip_safe=False,
 )
 


### PR DESCRIPTION
Fixes for restarting fesom as a branchoff experiment. When branching off `yearnew` in the `namelist.config` cannot be equal to the last number in the `fesom.clock`, otherwise it ignores the fesom restart files and does a spinup.