### PR TITLE
fix(install.sh): allows the install to work inside of venv

### DIFF
--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.14"
+__version__ = "5.1.15"
 
 import os
 import shutil

--- a/install.sh
+++ b/install.sh
@@ -56,5 +56,12 @@ else
 	echo "No installed git version found."
 fi
 
-
-pip install --user -e .
+# See here: https://tinyurl.com/5b57knvx
+if [ ! -z ${VIRTUAL_ENV+x} ]; then
+    echo "Detected virtual environment $VIRTUAL_ENV"
+    pip install -e .
+#FIXME(PG): We might still need a case for Conda virtual environments
+else
+    echo "Standard install to user directory (likely ${HOME}/.local)"
+    pip install --user -e .
+fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.14
+current_version = 5.1.15
 commit = True
 tag = True
 
@@ -19,4 +19,3 @@ exclude = docs
 max-line-length = 88
 
 [aliases]
-

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.1.14",
+    version="5.1.15",
     zip_safe=False,
 )
 


### PR DESCRIPTION
If you are using a virtual environment, `./install.sh` breaks. This checks and fixes that.