### PR TITLE
hotffix/fesom restart date

### DIFF
--- a/configs/components/fesom/fesom.yaml
+++ b/configs/components/fesom/fesom.yaml
@@ -128,9 +128,9 @@ restart_in_in_work:
         oce_restart: fesom.${parent_date!syear}.oce.nc
         ice_restart: fesom.${parent_date!syear}.ice.nc
 restart_in_sources:
-        oce_diag: fesom.${parent_date!syear!smonth!sday}.oce.diag.nc
-        oce_restart: fesom.${parent_date!syear!smonth!sday}.oce.nc
-        ice_restart: fesom.${parent_date!syear!smonth!sday}.ice.nc
+        oce_diag: fesom.${parent_date!syear}.oce.diag.nc
+        oce_restart: fesom.${parent_date!syear}.oce.nc
+        ice_restart: fesom.${parent_date!syear}.ice.nc
 
 restart_out_files:
         oce_diag: oce_diag
@@ -143,9 +143,9 @@ restart_out_in_work:
         ice_restart: fesom.${end_date!syear}.ice.nc
 
 restart_out_sources:
-        oce_diag: fesom.${end_date!syear!smonth!sday}.oce.diag.nc
-        oce_restart: fesom.${end_date!syear!smonth!sday}.oce.nc
-        ice_restart: fesom.${end_date!syear!smonth!sday}.ice.nc
+        oce_diag: fesom.${end_date!syear}.oce.diag.nc
+        oce_restart: fesom.${end_date!syear}.oce.nc
+        ice_restart: fesom.${end_date!syear}.ice.nc
 
 
 

--- a/configs/components/fesom/fesom.yaml
+++ b/configs/components/fesom/fesom.yaml
@@ -117,6 +117,7 @@ choose_resolution:
         CAVCORE2:
                 nx: 72411
 
+ini_restart_date_in: ${parent_date!syear!smonth!sday}
 
 restart_in_files:
         oce_restart: oce_restart
@@ -128,9 +129,9 @@ restart_in_in_work:
         oce_restart: fesom.${parent_date!syear}.oce.nc
         ice_restart: fesom.${parent_date!syear}.ice.nc
 restart_in_sources:
-        oce_diag: fesom.${parent_date!syear!smonth!sday}.oce.diag.nc
-        oce_restart: fesom.${parent_date!syear!smonth!sday}.oce.nc
-        ice_restart: fesom.${parent_date!syear!smonth!sday}.ice.nc
+        oce_diag: fesom.${restart_date_in}.oce.diag.nc
+        oce_restart: fesom.${restart_date_in}.oce.nc
+        ice_restart: fesom.${restart_date_in}.ice.nc
 
 restart_out_files:
         oce_diag: oce_diag
@@ -221,13 +222,16 @@ choose_lresume:
                         fesom.clock:
                                 - "<--append-- ${lasttime} ${parent_date!sdoy} ${parent_date!syear}"
                                 - "<--append-- ${starttime} ${startday} ${start_date!syear}"
+
 # Is it a branchoff experiment?
 branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
 choose_branchoff:
         true:
                 yearnew: "$(( ${initial_date!syear} - 1 ))"
+                restart_date_in: ${ini_restart_date_in}
         false:
                 yearnew: "${initial_date!syear}"
+                restart_date_in: ${parent_date!syear!smonth!sday}
 
 
 

--- a/configs/components/fesom/fesom.yaml
+++ b/configs/components/fesom/fesom.yaml
@@ -117,7 +117,6 @@ choose_resolution:
         CAVCORE2:
                 nx: 72411
 
-ini_restart_date_in: ${parent_date!syear!smonth!sday}
 
 restart_in_files:
         oce_restart: oce_restart
@@ -129,9 +128,9 @@ restart_in_in_work:
         oce_restart: fesom.${parent_date!syear}.oce.nc
         ice_restart: fesom.${parent_date!syear}.ice.nc
 restart_in_sources:
-        oce_diag: fesom.${restart_date_in}.oce.diag.nc
-        oce_restart: fesom.${restart_date_in}.oce.nc
-        ice_restart: fesom.${restart_date_in}.ice.nc
+        oce_diag: fesom.${parent_date!syear!smonth!sday}.oce.diag.nc
+        oce_restart: fesom.${parent_date!syear!smonth!sday}.oce.nc
+        ice_restart: fesom.${parent_date!syear!smonth!sday}.ice.nc
 
 restart_out_files:
         oce_diag: oce_diag
@@ -222,16 +221,13 @@ choose_lresume:
                         fesom.clock:
                                 - "<--append-- ${lasttime} ${parent_date!sdoy} ${parent_date!syear}"
                                 - "<--append-- ${starttime} ${startday} ${start_date!syear}"
-
 # Is it a branchoff experiment?
 branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
 choose_branchoff:
         true:
                 yearnew: "$(( ${initial_date!syear} - 1 ))"
-                restart_date_in: ${ini_restart_date_in}
         false:
                 yearnew: "${initial_date!syear}"
-                restart_date_in: ${parent_date!syear!smonth!sday}
 
 
 

--- a/configs/components/recom/recom.yaml
+++ b/configs/components/recom/recom.yaml
@@ -118,7 +118,7 @@ restart_in_in_work:
         bio_restart: fesom.${parent_date!syear}.bio.nc
 
 restart_in_sources:
-        bio_restart: fesom.${parent_date!syear!smonth!sday}.bio.nc
+        bio_restart: fesom.${parent_date!syear}.bio.nc
 
 restart_out_files:
         bio_restart: bio_restart
@@ -127,7 +127,7 @@ restart_out_in_work:
         bio_restart: fesom.${end_date!syear}.bio.nc
 
 restart_out_sources:
-        bio_restart: fesom.${end_date!syear!smonth!sday}.bio.nc
+        bio_restart: fesom.${end_date!syear}.bio.nc
 
 
 yearly_outputs: []

--- a/configs/components/recom/recom.yaml
+++ b/configs/components/recom/recom.yaml
@@ -39,6 +39,7 @@ metadata:
 setup_dir: "${model_dir}"
 bin_dir: "${setup_dir}/bin"
 data_path: ""
+ini_restart_date_in: ${parent_date!syear!smonth!sday}
 
 scenario: "preindustrial"
 
@@ -103,6 +104,13 @@ choose_lresume:
                         namelist.recom:
                                 pavariables:
                                         recom_restart: false
+# Is it a branchoff experiment?
+branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
+choose_branchoff:
+        true:
+                restart_date_in: ${ini_restart_date_in}
+        false:
+                restart_date_in: ${parent_date!syear!smonth!sday}
 
 config_files:
         recom:  recom
@@ -118,7 +126,7 @@ restart_in_in_work:
         bio_restart: fesom.${parent_date!syear}.bio.nc
 
 restart_in_sources:
-        bio_restart: fesom.${parent_date!syear!smonth!sday}.bio.nc
+        bio_restart: fesom.${restart_date_in}.bio.nc
 
 restart_out_files:
         bio_restart: bio_restart

--- a/configs/components/recom/recom.yaml
+++ b/configs/components/recom/recom.yaml
@@ -39,7 +39,6 @@ metadata:
 setup_dir: "${model_dir}"
 bin_dir: "${setup_dir}/bin"
 data_path: ""
-ini_restart_date_in: ${parent_date!syear!smonth!sday}
 
 scenario: "preindustrial"
 
@@ -104,13 +103,6 @@ choose_lresume:
                         namelist.recom:
                                 pavariables:
                                         recom_restart: false
-# Is it a branchoff experiment?
-branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
-choose_branchoff:
-        true:
-                restart_date_in: ${ini_restart_date_in}
-        false:
-                restart_date_in: ${parent_date!syear!smonth!sday}
 
 config_files:
         recom:  recom
@@ -126,7 +118,7 @@ restart_in_in_work:
         bio_restart: fesom.${parent_date!syear}.bio.nc
 
 restart_in_sources:
-        bio_restart: fesom.${restart_date_in}.bio.nc
+        bio_restart: fesom.${parent_date!syear!smonth!sday}.bio.nc
 
 restart_out_files:
         bio_restart: bio_restart

--- a/esm_tools/__init__.py
+++ b/esm_tools/__init__.py
@@ -22,7 +22,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.15"
+__version__ = "5.1.16"
 
 import os
 import shutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.1.15
+current_version = 5.1.16
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm_tools/esm_tools",
-    version="5.1.15",
+    version="5.1.16",
     zip_safe=False,
 )
 


### PR DESCRIPTION
This is the fix we talk about it yesterday in Slack, that should also solve #390. I'm not so convinced anymore that is a good fix, therefore I'd like to get some feedback. The disadvantages of this fix in contrast with Paul's 3b7c824bab65fbc5f5a377dd2bbaeaea805555dc:

1. Too complex, in comparison to the standard naming convention (just using the year) and letting ESM-Tools to time stamp repetitions in its own way (`fesom.YYYY.restart.oce.nc_YYYYMMDD-YYYYMMDD`).
2. The user needs to take care of one extra step if using an old simulation.
3. This only happens for FESOM-1 and RECOM, FESOM-2 still copies with the normal names.

The only advantage I see from keeping the naming convention in the general restart directory as it currently is, is that we won't generate a problem for people already using that. I don't think there are many though and, now that I am more experienced, I really don't like what I did with the fesom and recom restarts renaming... At this point I prefer Paul's solution.