### PR TITLE
awicm3 cmake flags

### DIFF
--- a/configs/couplings/fesom-2.0+oifs-43r3+xios-2.5/fesom-2.0+oifs-43r3+xios-2.5.yaml
+++ b/configs/couplings/fesom-2.0+oifs-43r3+xios-2.5/fesom-2.0+oifs-43r3+xios-2.5.yaml
@@ -5,8 +5,6 @@ components:
 - oasis3mct-4.0-oifsdeck
 - xios-2.5
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
-- sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLENEMOFOCI = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/configs/couplings/fesom-2.0+oifs-43r3/fesom-2.0+oifs-43r3.yaml
+++ b/configs/couplings/fesom-2.0+oifs-43r3/fesom-2.0+oifs-43r3.yaml
@@ -4,8 +4,6 @@ components:
 - fesom-2.0-jio
 - oasis3mct-4.0-oifsdeck
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
-- sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLENEMOFOCI = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/configs/couplings/fesom-2.0-frontiers+oifs-43r3-awi-frontiers-xios+xios-2.5/fesom-2.0-frontiers+oifs-43r3-awi-frontiers-xios+xios-2.5.yaml
+++ b/configs/couplings/fesom-2.0-frontiers+oifs-43r3-awi-frontiers-xios+xios-2.5/fesom-2.0-frontiers+oifs-43r3-awi-frontiers-xios+xios-2.5.yaml
@@ -5,8 +5,6 @@ components:
 - fesom-2.0-frontiers
 - oasis3mct-4.0-awicm3-frontiers
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
-- sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLENEMOFOCI = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/configs/couplings/fesom-2.0-frontiers+oifs-43r3-awi-frontiers/fesom-2.0-frontiers+oifs-43r3-awi-frontiers.yaml
+++ b/configs/couplings/fesom-2.0-frontiers+oifs-43r3-awi-frontiers/fesom-2.0-frontiers+oifs-43r3-awi-frontiers.yaml
@@ -4,8 +4,6 @@ components:
 - fesom-2.0-frontiers
 - oasis3mct-4.0-awicm3-frontiers
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
-- sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLENEMOFOCI = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/configs/couplings/fesom-2.0-master+oifs-43r3-master/fesom-2.0-master+oifs-43r3-master.yaml
+++ b/configs/couplings/fesom-2.0-master+oifs-43r3-master/fesom-2.0-master+oifs-43r3-master.yaml
@@ -4,8 +4,6 @@ components:
 - fesom-2.0-master
 - oasis3mct-4.0-awicm3-frontiers
 coupling_changes:
-- sed -i '/FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
-- sed -i '/OIFS_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-43r3/src/ifs/module/yommcc.F90
 - sed -i '/COUPLENEMOFOCI = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/configs/setups/awicm3/awicm3.yaml
+++ b/configs/setups/awicm3/awicm3.yaml
@@ -189,6 +189,8 @@ fesom:
                 TL159_CORE2:
                         nproc: 72
 
+        comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON ..;   make install -j `nproc --all`
+
         opbnd_dir: ""
         tide_forcing_dir: ""
         forcing_data_dir: ""


### PR DESCRIPTION
Added the cmake flags for coupling into the `comp_command` as suggested by @hegish , and removed the `set` commands from the AWICM3 coupling files. The `set` commands in OpenIFS are left after discussion with @JanStreffing , because in order to get rid of them, changes in the OpenIFS source code will be needed, and at the moment that's low priority.