### PR TITLE
hotfix/fesom newday

### DIFF
--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -163,9 +163,13 @@ log_sources:
 # Is it a branchoff experiment?
 branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
 choose_branchoff:
+        # Makes sure the <units>new in the namelist make an earlier date than that of
+        # of the clock to avoid cold starts for branching off experiments
         true:
+                daynew: 1
                 yearnew: "$(( ${initial_date!syear} - 1 ))"
         false:
+                daynew: "${initial_date!sdoy}"
                 yearnew: "${initial_date!syear}"
 
 
@@ -173,6 +177,7 @@ choose_branchoff:
 namelist_changes:
         namelist.config:
                 clockinit:
+                        daynew: "${daynew}"
                         yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -153,9 +153,13 @@ log_sources:
 # Is it a branchoff experiment?
 branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
 choose_branchoff:
+        # Makes sure the <units>new in the namelist make an earlier date than that of
+        # of the clock to avoid cold starts for branching off experiments
         true:
+                daynew: 1
                 yearnew: "$(( ${initial_date!syear} - 1 ))"
         false:
+                daynew: "${initial_date!sdoy}"
                 yearnew: "${initial_date!syear}"
 
 
@@ -163,6 +167,7 @@ choose_branchoff:
 namelist_changes:
         namelist.config:
                 clockinit:
+                        daynew: "${daynew}"
                         yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"

--- a/configs/components/fesom/fesom.yaml
+++ b/configs/components/fesom/fesom.yaml
@@ -165,6 +165,7 @@ log_sources:
 namelist_changes:
         namelist.config:
                 clockinit:
+                        daynew: "${daynew}"
                         yearnew: "${yearnew}"
                 calendar:
                         include_fleapyear: "${leapyear}"
@@ -224,9 +225,13 @@ choose_lresume:
 # Is it a branchoff experiment?
 branchoff: "$(( ${lresume} and ${general.run_number}==1 ))"
 choose_branchoff:
+        # Makes sure the <units>new in the namelist make an earlier date than that of
+        # of the clock to avoid cold starts for branching off experiments
         true:
+                daynew: 1
                 yearnew: "$(( ${initial_date!syear} - 1 ))"
         false:
+                daynew: "${initial_date!sdoy}"
                 yearnew: "${initial_date!syear}"
 
 


### PR DESCRIPTION
Allows FESOM to do a cold start in the middle of a year.

`daynew` in `fesom*.yaml`, only needs to be defined if the run is a cold start. In that case both `daynew` and `yearnew` should coincide with the clock.

In a restart run (`lresume: true` and `run_number > 1`), the date defined by `daynew` and `yearnew` should be prior to the one defined by the `fesom.clock`. In the yamls it is configured that `daynew` and `yearnew` remain the same, as `initial_date` represents the date in which the whole experiment begins.

In a branchoff experiment (`lresume: true` and `run_number: 1`) `initial_date` matches the `fesom.clock` created by the configuration file which has the potential to run a cold start. To avoid that `yearnew` is defined to be the previous year to the current simulation so that restart occurs.

This follows up on a previous fix #394 for branchoff experiments.
