### PR TITLE
Feature/general.yaml

### DIFF
--- a/configs/defaults/general.yaml
+++ b/configs/defaults/general.yaml
@@ -1,2 +1,1 @@
-general:
-    use_database: false
+use_database: false

--- a/configs/defaults/general.yaml
+++ b/configs/defaults/general.yaml
@@ -1,0 +1,2 @@
+general:
+    use_database: false


### PR DESCRIPTION
This pull request (together with the corresponding PR in the `esm_parser`: https://github.com/esm-tools/esm_parser/pull/65) adds a default `general` section to the `config`.

This is a feature that @dbarbi requested from me some time ago to add `use_database: false` by default. It looks like `general` section is added later on by the `esm_runscripts`. So far, `esm_parser` only adds a `default` section.

Now, `esm_parser` also adds a `general` section which is provided in the `DEFAULTS_DIR/general.yaml`. Any further default setting that should go into the `general` section can be added to this file.

When `use_database` is `true` in the user runscript, it successfully overwrites that field in the finished config yaml file.