### PR TITLE
Version Unification in Monorepo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,63 @@ tag = True
 search = version="{current_version}"
 replace = version="{new_version}"
 
-[bumpversion:file:esm_tools/__init__.py]
+[bumpversion:file:src/esm_archiving/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_calendar/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_cleanup/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_database/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_environment/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_master/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_motd/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_parser/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_plugin_manager/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_profile/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_rcfile/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_runscripts/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_tests/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_tools/__init__.py]
+search = __version__ = "{current_version}"
+replace = __version__ = "{new_version}"
+
+[bumpversion:file:src/esm_utilities/__init__.py]
 search = __version__ = "{current_version}"
 replace = __version__ = "{new_version}"
 
@@ -17,5 +73,6 @@ universal = 1
 [flake8]
 exclude = docs
 max-line-length = 88
+
 
 [aliases]

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
             "esm_plugins=esm_plugin_manager.cli:main",
             "esm_runscripts=esm_runscripts.cli:main",
             "esm_tests=esm_tests.cli:main",
+            "esm_tools=esm_tools.cli:main",
             "esm_utilities=esm_utilities.cli:main",
         ],
     },

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "5.0.0"
+__version__ = "5.1.21"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.0"
+__version__ = "5.1.21"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,5 +2,5 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "0.1.0"
+__version__ = "5.1.21"
 

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for ESM Database."""
 
 __author__ = """Dirk Barbi"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = '5.0.0'
+__email__ = "dirk.barbi@awi.de"
+__version__ = "5.1.21"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.3"
+__version__ = "5.1.21"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.1.6"
+__version__ = "5.1.21"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for ESM Motd"""
 
 __author__ = """Dirk Barbi"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = '5.0.2'
+__email__ = "dirk.barbi@awi.de"
+__version__ = "5.1.21"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -1,8 +1,8 @@
 """Top-level package for ESM Parser."""
 
 __author__ = """Dirk Barbi"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.11"
+__email__ = "dirk.barbi@awi.de"
+__version__ = "5.1.21"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "5.0.1"
+__version__ = "5.1.21"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for ESM Profile."""
 
 __author__ = """Dirk Barbi"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = "5.0.0"
+__email__ = "dirk.barbi@awi.de"
+__version__ = "5.1.21"
 
 from .esm_profile import *

--- a/src/esm_rcfile/__init__.py
+++ b/src/esm_rcfile/__init__.py
@@ -1,8 +1,8 @@
 """Top-level package for ESM RCFile."""
 
 __author__ = """Dirk Barbi"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.0"
+__email__ = "dirk.barbi@awi.de"
+__version__ = "5.1.21"
 
 from .esm_rcfile import *
 

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.31"
+__version__ = "5.1.21"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -1,7 +1,7 @@
 """Top-level package for ESM Tests."""
 
 __author__ = """Miguel Andres-Martinez"""
-__email__ = 'dirk.barbi@awi.de'
-__version__ = "5.1.0"
+__email__ = "miguel.andres-martinez@awi.de"
+__version__ = "5.1.21"
 
 from .esm_tests import *

--- a/src/esm_tools/cli.py
+++ b/src/esm_tools/cli.py
@@ -1,0 +1,16 @@
+"""
+Functionality for displaying the version number
+"""
+import sys
+import click
+
+
+@click.version_option()
+@click.group()
+def main(args=None):
+    """Console script for esm_tools"""
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -1,5 +1,5 @@
 """Top-level package for ESM Utilities."""
 
 __author__ = """Paul Gierz"""
-__email__ = 'pgierz@awi.de'
-__version__ = '5.0.0'
+__email__ = "pgierz@awi.de"
+__version__ = "5.1.21"


### PR DESCRIPTION
## Unifies versions across all tools

Many of the `__init__.py` files had separate version, all of which have been unified now. I also repaired the `setup.cfg` file to automatically bump everything together if you do:

```
$ bumpversion patch
```

##  Adds version flag from CLI

To replace `esm_versions`, there is now a new command line:
```
$ esm_tools --version
```

In the future, it may be possible to integrate the other command line tools as well:
```
$ esm_tools master get-awiesm-2.1
```

The old command line interfaces would still work, but the new "main" command line tool would just call the other ones, and it would be one option for users. At some point, I would like to unify all the command line interfaces to use a single package: some get `sys.argv` directly, someuse argparse, some use click, but that is for future work.