### PR TITLE
Mistral openmpi

### DIFF
--- a/configs/components/oifs/oifs.env.yaml
+++ b/configs/components/oifs/oifs.env.yaml
@@ -53,12 +53,7 @@ runtime_environment_changes:
         # ENV vars used in OIFS's source code during runtime
         OIFS_FFIXED: '""'
         GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
-        DR_HOOK: 1
         DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
-        DR_HOOK_OPT: prof
-        DR_HOOK_PROFILE_LIMIT: 0.5
-        OIFS_DUMMY_ACTION: ABORT
-        HDF5_DISABLE_VERSION_CHECK: 1
         # OpenMP
         MPI_BUFS_PER_PROC: '256'
         OMP_SCHEDULE: 'STATIC'
@@ -233,12 +228,7 @@ compiletime_environment_changes:
         OIFS_FFTW_DIR: '"$FFTW_ROOT"'
         OIFS_FFTW_INCLUDE: '"-I$OIFS_FFTW_DIR/include/"'
         OIFS_FFTW_LIB: '"-L$OIFS_FFTW_DIR/lib/ -lfftw3f"'
-        DR_HOOK: 1
         DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
-        DR_HOOK_OPT: prof
-        DR_HOOK_PROFILE_LIMIT: 0.5
-        OIFS_DUMMY_ACTION: ABORT
-        HDF5_DISABLE_VERSION_CHECK: 1
 
     ollie:
       add_module_actions:
@@ -311,6 +301,9 @@ environment_changes:
   GribApiRoot: none
   GribApiLib: none
   GribSamples: none
+  #====================================================================================
+  # MPI choice
+  #====================================================================================
   choose_computer.useMPI:
     intelmpi:
       c++_lib: stdc++
@@ -327,5 +320,11 @@ environment_changes:
           GribApiRoot: "/pf/a/a270092/ecmwf/grib_api_intel_modulegcc"
           GribApiLib: "-L$GRIBAPIROOT/lib -lgrib_api_f90 -lgrib_api"
           GribSamples: "grib_api"
+          add_export_vars:
+            DR_HOOK: 1
+            DR_HOOK_OPT: prof
+            DR_HOOK_PROFILE_LIMIT: 0.5
+            OIFS_DUMMY_ACTION: ABORT
+            HDF5_DISABLE_VERSION_CHECK: 1
     "*":
       c++_lib: none

--- a/configs/components/oifs/oifs.env.yaml
+++ b/configs/components/oifs/oifs.env.yaml
@@ -325,7 +325,7 @@ environment_changes:
       choose_computer.name:
         mistral:
           GribApiRoot: "/pf/a/a270092/ecmwf/grib_api_intel_modulegcc"
-          GribApiLib: "-L$GRIBAPIROOT/lib -leccodes_f90 -leccodes"
-          GribSamples: "eccodes"
+          GribApiLib: "-L$GRIBAPIROOT/lib -lgrib_api_f90 -lgrib_api"
+          GribSamples: "grib_api"
     "*":
       c++_lib: none

--- a/configs/components/oifs/oifs.env.yaml
+++ b/configs/components/oifs/oifs.env.yaml
@@ -43,22 +43,26 @@ runtime_environment_changes:
 
     mistral:
       add_export_vars:
-        DUMMY: 0
-        #GRIBAPIROOT: "${computer.GribApiRoot}"
-        #PATH[(2)]: "$GRIBAPIROOT/bin:${PATH}"
-        #UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
-        #FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
-        #PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
-        #PATH[(3)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
-        #LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
-        ## ENV vars used in OIFS's source code during runtime
-        #OIFS_FFIXED: '""'
-        #GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
-        #DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
-        ## OpenMP
-        #MPI_BUFS_PER_PROC: '256'
-        #OMP_SCHEDULE: 'STATIC'
-        #OMP_STACKSIZE: '128M'
+        GRIBAPIROOT: "${computer.GribApiRoot}"
+        PATH[(2)]: "$GRIBAPIROOT/bin:${PATH}"
+        UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
+        FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
+        PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
+        PATH[(3)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
+        LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
+        # ENV vars used in OIFS's source code during runtime
+        OIFS_FFIXED: '""'
+        GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
+        DR_HOOK: 1
+        DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
+        DR_HOOK_OPT: prof
+        DR_HOOK_PROFILE_LIMIT: 0.5
+        OIFS_DUMMY_ACTION: ABORT
+        HDF5_DISABLE_VERSION_CHECK: 1
+        # OpenMP
+        MPI_BUFS_PER_PROC: '256'
+        OMP_SCHEDULE: 'STATIC'
+        OMP_STACKSIZE: '128M'
 
     ollie:
       add_module_actions:
@@ -185,50 +189,56 @@ compiletime_environment_changes:
 
     mistral:
       add_export_vars:
-        DUMMY: 0
-        #MKLROOT: '/sw/rhel6-x64/intel/intel-18.0.4/compilers_and_libraries_2018/linux/mkl/lib/intel64/'
-        #LAPACK_LIB_DEFAULT[(1)]: '"-L$MKLROOT -lmkl_intel_lp64 -lmkl_core -lmkl_sequential"'
-        #ESM_NETCDF_C_DIR: "$NETCDFROOT"
-        #ESM_NETCDF_F_DIR: "$NETCDFFROOT"
-        #GRIBAPIROOT: "${computer.GribApiRoot}"
-        #UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
-        #FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
-        #PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
-        ##PETSC_DIR: "/sw/rhel6-x64/numerics/PETSc-3.12.2-impi2018-intel18/"
-        #PATH[(2)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
-        #LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
+        MKLROOT: '/sw/rhel6-x64/intel/intel-18.0.4/compilers_and_libraries_2018/linux/mkl/lib/intel64/'
+        LAPACK_LIB_DEFAULT[(1)]: '"-L$MKLROOT -lmkl_intel_lp64 -lmkl_core -lmkl_sequential"'
+        ESM_NETCDF_C_DIR: "$NETCDFROOT"
+        ESM_NETCDF_F_DIR: "$NETCDFFROOT"
+        GRIBAPIROOT: "${computer.GribApiRoot}"
+        GRIBROOT: "${computer.GribApiRoot}"
+        UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
+        FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
+        PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
+        #PETSC_DIR: "/sw/rhel6-x64/numerics/PETSc-3.12.2-impi2018-intel18/"
+        PATH[(2)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
+        LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib:$SZIPROOT/lib"
 
-        #GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
-        #PATH[(3)]: '$PATH:/mnt/lustre01/sw/rhel6-x64/devtools/fcm-2017.10.0/bin/'
+        GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
+        PATH[(3)]: '$PATH:/mnt/lustre01/sw/rhel6-x64/devtools/fcm-2017.10.0/bin/'
 
-        #OIFS_GRIB_API_INCLUDE: '"-I$GRIBAPIROOT/include"'
-        #OIFS_GRIB_API_LIB: '"${computer.GribApiLib}"'
-        ## OIFS_GRIB_API_LIB is used by OpenIFS CY40, OIFS_GRIB_LIB is used by CY43
-        #OIFS_GRIB_INCLUDE: '"$OIFS_GRIB_API_INCLUDE"'
-        #OIFS_GRIB_LIB: '"$OIFS_GRIB_API_LIB"'
-        #OIFS_GRIB_API_BIN: '"$GRIBAPIROOT/bin"'
-        #OIFS_OASIS_BASE: '$(pwd)/oasis'
-        #OIFS_OASIS_INCLUDE: '"-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
-        #OIFS_OASIS_LIB: '"-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
-        #OIFS_NETCDF_INCLUDE: '"-I$NETCDFROOT/include"'
-        #OIFS_NETCDF_LIB: '"-L$NETCDFROOT/lib -lnetcdf"'
-        #OIFS_NETCDFF_INCLUDE: '"-I$NETCDFFROOT/include"'
-        #OIFS_NETCDFF_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
-        #OIFS_FC: '$FC'
-        #OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O3 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
-        ##OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O0 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -check all,noarg_temp_created,bounds -fpe0"'
-        #OIFS_FFIXED: '""'
-        #OIFS_FCDEFS: '"BLAS LITTLE LINUX INTEGER_IS_INT"'
-        #OIFS_LFLAGS: '"$OIFS_MPI_LIB -qopenmp"'
-        #OIFS_CC: '$CC'
-        #OIFS_CFLAGS: '"-fp-model precise -O3 -qopenmp -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
-        #OIFS_CCDEFS: '"LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
-        ## Build OpenIFS with FFTW. Use Intel MKL interfaces
-        ## WARNING: FFTW does not work yet. Wait for patch from ECMWF
-        ## OIFS_FFTW: '"enable"'
-        #OIFS_FFTW_DIR: '"$FFTW_ROOT"'
-        #OIFS_FFTW_INCLUDE: '"-I$OIFS_FFTW_DIR/include/"'
-        #OIFS_FFTW_LIB: '"-L$OIFS_FFTW_DIR/lib/ -lfftw3f"'
+        OIFS_GRIB_API_INCLUDE: '"-I$GRIBAPIROOT/include"'
+        OIFS_GRIB_API_LIB: '"${computer.GribApiLib}"'
+        # OIFS_GRIB_API_LIB is used by OpenIFS CY40, OIFS_GRIB_LIB is used by CY43
+        OIFS_GRIB_INCLUDE: '"$OIFS_GRIB_API_INCLUDE"'
+        OIFS_GRIB_LIB: '"$OIFS_GRIB_API_LIB"'
+        OIFS_GRIB_API_BIN: '"$GRIBAPIROOT/bin"'
+        OIFS_OASIS_BASE: '$(pwd)/oasis'
+        OIFS_OASIS_INCLUDE: '"-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
+        OIFS_OASIS_LIB: '"-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
+        OIFS_NETCDF_INCLUDE: '"-I$NETCDFROOT/include"'
+        OIFS_NETCDF_LIB: '"-L$NETCDFROOT/lib -lnetcdf"'
+        OIFS_NETCDFF_INCLUDE: '"-I$NETCDFFROOT/include"'
+        OIFS_NETCDFF_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
+        OIFS_FC: '$FC'
+        OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O3 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
+        #OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O0 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -check all,noarg_temp_created,bounds -fpe0"'
+        OIFS_FFIXED: '""'
+        OIFS_FCDEFS: '"BLAS LITTLE LINUX INTEGER_IS_INT"'
+        OIFS_LFLAGS: '"$OIFS_MPI_LIB -qopenmp"'
+        OIFS_CC: '$CC'
+        OIFS_CFLAGS: '"-fp-model precise -O3 -qopenmp -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
+        OIFS_CCDEFS: '"LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
+        # Build OpenIFS with FFTW. Use Intel MKL interfaces
+        # WARNING: FFTW does not work yet. Wait for patch from ECMWF
+        # OIFS_FFTW: '"enable"'
+        OIFS_FFTW_DIR: '"$FFTW_ROOT"'
+        OIFS_FFTW_INCLUDE: '"-I$OIFS_FFTW_DIR/include/"'
+        OIFS_FFTW_LIB: '"-L$OIFS_FFTW_DIR/lib/ -lfftw3f"'
+        DR_HOOK: 1
+        DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
+        DR_HOOK_OPT: prof
+        DR_HOOK_PROFILE_LIMIT: 0.5
+        OIFS_DUMMY_ACTION: ABORT
+        HDF5_DISABLE_VERSION_CHECK: 1
 
     ollie:
       add_module_actions:
@@ -306,7 +316,7 @@ environment_changes:
       c++_lib: stdc++
       choose_computer.name:
         mistral:
-          GribApiRoot: "/sw/rhel6-x64/grib_api/grib_api-1.15.0-intel14/"
+          GribApiRoot: "/sw/rhel6-x64/grib_api/grib_api-1.15.0-intel14"
           GribApiLib: "-L$GRIBAPIROOT/lib -lgrib_api_f90 -lgrib_api"
           GribSamples: "grib_api"
     cray_mpich:
@@ -314,7 +324,7 @@ environment_changes:
     openmpi:
       choose_computer.name:
         mistral:
-          GribApiRoot: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
+          GribApiRoot: "/pf/a/a270092/ecmwf/grib_api_intel_modulegcc"
           GribApiLib: "-L$GRIBAPIROOT/lib -leccodes_f90 -leccodes"
           GribSamples: "eccodes"
     "*":

--- a/configs/components/oifs/oifs.env.yaml
+++ b/configs/components/oifs/oifs.env.yaml
@@ -43,21 +43,22 @@ runtime_environment_changes:
 
     mistral:
       add_export_vars:
-        GRIBAPIROOT: "${computer.GribApiRoot}"
-        PATH[(2)]: "$GRIBAPIROOT/bin:${PATH}"
-        UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
-        FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
-        PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
-        PATH[(3)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
-        LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
-        # ENV vars used in OIFS's source code during runtime
-        OIFS_FFIXED: '""'
-        GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
-        DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
-        # OpenMP
-        MPI_BUFS_PER_PROC: '256'
-        OMP_SCHEDULE: 'STATIC'
-        OMP_STACKSIZE: '128M'
+        DUMMY: 0
+        #GRIBAPIROOT: "${computer.GribApiRoot}"
+        #PATH[(2)]: "$GRIBAPIROOT/bin:${PATH}"
+        #UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
+        #FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
+        #PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
+        #PATH[(3)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
+        #LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
+        ## ENV vars used in OIFS's source code during runtime
+        #OIFS_FFIXED: '""'
+        #GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
+        #DR_HOOK_IGNORE_SIGNALS: '${dr_hook_ignore_signals}'
+        ## OpenMP
+        #MPI_BUFS_PER_PROC: '256'
+        #OMP_SCHEDULE: 'STATIC'
+        #OMP_STACKSIZE: '128M'
 
     ollie:
       add_module_actions:
@@ -184,49 +185,50 @@ compiletime_environment_changes:
 
     mistral:
       add_export_vars:
-        MKLROOT: '/sw/rhel6-x64/intel/intel-18.0.4/compilers_and_libraries_2018/linux/mkl/lib/intel64/'
-        LAPACK_LIB_DEFAULT[(1)]: '"-L$MKLROOT -lmkl_intel_lp64 -lmkl_core -lmkl_sequential"'
-        ESM_NETCDF_C_DIR: "$NETCDFROOT"
-        ESM_NETCDF_F_DIR: "$NETCDFFROOT"
-        GRIBAPIROOT: "${computer.GribApiRoot}"
-        UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
-        FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
-        PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
-        #PETSC_DIR: "/sw/rhel6-x64/numerics/PETSc-3.12.2-impi2018-intel18/"
-        PATH[(2)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
-        LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
+        DUMMY: 0
+        #MKLROOT: '/sw/rhel6-x64/intel/intel-18.0.4/compilers_and_libraries_2018/linux/mkl/lib/intel64/'
+        #LAPACK_LIB_DEFAULT[(1)]: '"-L$MKLROOT -lmkl_intel_lp64 -lmkl_core -lmkl_sequential"'
+        #ESM_NETCDF_C_DIR: "$NETCDFROOT"
+        #ESM_NETCDF_F_DIR: "$NETCDFFROOT"
+        #GRIBAPIROOT: "${computer.GribApiRoot}"
+        #UDUNITS2_ROOT: "/sw/rhel6-x64/util/udunits-2.2.26-gcc64"
+        #FFTW_ROOT: "/sw/rhel6-x64/numerics/fftw-3.3.7-openmp-gcc64"
+        #PROJ4_ROOT: "/sw/rhel6-x64/graphics/proj4-4.9.3-gcc48"
+        ##PETSC_DIR: "/sw/rhel6-x64/numerics/PETSc-3.12.2-impi2018-intel18/"
+        #PATH[(2)]: "/sw/rhel6-x64/gcc/binutils-2.24-gccsys/bin:${PATH}"
+        #LD_LIBRARY_PATH[(2)]: "$LD_LIBRARY_PATH:$GRIBAPIROOT/lib:$PROJ4_ROOT/lib:$FFTW_ROOT/lib"
 
-        GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
-        PATH[(3)]: '$PATH:/mnt/lustre01/sw/rhel6-x64/devtools/fcm-2017.10.0/bin/'
+        #GRIB_SAMPLES_PATH: '"$GRIBAPIROOT/share/${computer.GribSamples}/ifs_samples/grib1_mlgrib2/"'
+        #PATH[(3)]: '$PATH:/mnt/lustre01/sw/rhel6-x64/devtools/fcm-2017.10.0/bin/'
 
-        OIFS_GRIB_API_INCLUDE: '"-I$GRIBAPIROOT/include"'
-        OIFS_GRIB_API_LIB: '"${computer.GribApiLib}"'
-        # OIFS_GRIB_API_LIB is used by OpenIFS CY40, OIFS_GRIB_LIB is used by CY43
-        OIFS_GRIB_INCLUDE: '"$OIFS_GRIB_API_INCLUDE"'
-        OIFS_GRIB_LIB: '"$OIFS_GRIB_API_LIB"'
-        OIFS_GRIB_API_BIN: '"$GRIBAPIROOT/bin"'
-        OIFS_OASIS_BASE: '$(pwd)/oasis'
-        OIFS_OASIS_INCLUDE: '"-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
-        OIFS_OASIS_LIB: '"-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
-        OIFS_NETCDF_INCLUDE: '"-I$NETCDFROOT/include"'
-        OIFS_NETCDF_LIB: '"-L$NETCDFROOT/lib -lnetcdf"'
-        OIFS_NETCDFF_INCLUDE: '"-I$NETCDFFROOT/include"'
-        OIFS_NETCDFF_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
-        OIFS_FC: '$FC'
-        OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O3 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
-        #OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O0 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -check all,noarg_temp_created,bounds -fpe0"'
-        OIFS_FFIXED: '""'
-        OIFS_FCDEFS: '"BLAS LITTLE LINUX INTEGER_IS_INT"'
-        OIFS_LFLAGS: '"$OIFS_MPI_LIB -qopenmp"'
-        OIFS_CC: '$CC'
-        OIFS_CFLAGS: '"-fp-model precise -O3 -qopenmp -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
-        OIFS_CCDEFS: '"LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
-        # Build OpenIFS with FFTW. Use Intel MKL interfaces
-        # WARNING: FFTW does not work yet. Wait for patch from ECMWF
-        # OIFS_FFTW: '"enable"'
-        OIFS_FFTW_DIR: '"$FFTW_ROOT"'
-        OIFS_FFTW_INCLUDE: '"-I$OIFS_FFTW_DIR/include/"'
-        OIFS_FFTW_LIB: '"-L$OIFS_FFTW_DIR/lib/ -lfftw3f"'
+        #OIFS_GRIB_API_INCLUDE: '"-I$GRIBAPIROOT/include"'
+        #OIFS_GRIB_API_LIB: '"${computer.GribApiLib}"'
+        ## OIFS_GRIB_API_LIB is used by OpenIFS CY40, OIFS_GRIB_LIB is used by CY43
+        #OIFS_GRIB_INCLUDE: '"$OIFS_GRIB_API_INCLUDE"'
+        #OIFS_GRIB_LIB: '"$OIFS_GRIB_API_LIB"'
+        #OIFS_GRIB_API_BIN: '"$GRIBAPIROOT/bin"'
+        #OIFS_OASIS_BASE: '$(pwd)/oasis'
+        #OIFS_OASIS_INCLUDE: '"-I$OIFS_OASIS_BASE/build/lib/psmile -I$OIFS_OASIS_BASE/build/lib/psmile/scrip -I$OIFS_OASIS_BASE/build/lib/psmile/mct -I$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu"'
+        #OIFS_OASIS_LIB: '"-L$OIFS_OASIS_BASE/build/lib/psmile -L$OIFS_OASIS_BASE/build/lib/psmile/scrip -L$OIFS_OASIS_BASE/build/lib/psmile/mct -L$OIFS_OASIS_BASE/build/lib/psmile/mct/mpeu -lpsmile -lmct -lmpeu -lscrip"'
+        #OIFS_NETCDF_INCLUDE: '"-I$NETCDFROOT/include"'
+        #OIFS_NETCDF_LIB: '"-L$NETCDFROOT/lib -lnetcdf"'
+        #OIFS_NETCDFF_INCLUDE: '"-I$NETCDFFROOT/include"'
+        #OIFS_NETCDFF_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
+        #OIFS_FC: '$FC'
+        #OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O3 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -fpe0"'
+        ##OIFS_FFLAGS: '"-r8 -fp-model precise -align array32byte -O0 -qopenmp -xCORE_AVX2 -g -traceback -convert big_endian -check all,noarg_temp_created,bounds -fpe0"'
+        #OIFS_FFIXED: '""'
+        #OIFS_FCDEFS: '"BLAS LITTLE LINUX INTEGER_IS_INT"'
+        #OIFS_LFLAGS: '"$OIFS_MPI_LIB -qopenmp"'
+        #OIFS_CC: '$CC'
+        #OIFS_CFLAGS: '"-fp-model precise -O3 -qopenmp -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"'
+        #OIFS_CCDEFS: '"LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
+        ## Build OpenIFS with FFTW. Use Intel MKL interfaces
+        ## WARNING: FFTW does not work yet. Wait for patch from ECMWF
+        ## OIFS_FFTW: '"enable"'
+        #OIFS_FFTW_DIR: '"$FFTW_ROOT"'
+        #OIFS_FFTW_INCLUDE: '"-I$OIFS_FFTW_DIR/include/"'
+        #OIFS_FFTW_LIB: '"-L$OIFS_FFTW_DIR/lib/ -lfftw3f"'
 
     ollie:
       add_module_actions:

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -72,11 +72,10 @@ pool_dir:  "/pool/data"
 useMPI: intelmpi
 module_actions:
         - "purge"
-        #- "source /pf/a/a270152/shell-intel+openmpi"
         - "unload netcdf_c"
         - "unload intel intelmpi"
         - "load python/3.5.2"
-        - "load cmake"
+        - "load cmake/3.13.3"
         - "load autoconf/2.69"
         - "load nco"
         - "load cdo"
@@ -103,8 +102,8 @@ export_vars:
         # MPI Settings
         #########################################################################
         #
-        #MPIROOT: "\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
-        #MPI_LIB: "\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+        MPIROOT: "\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
+        MPI_LIB: "\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
 
         #########################################################################
         # HDF5 Defaults
@@ -185,16 +184,16 @@ export_vars:
         I_MPI_LARGE_SCALE_THRESHOLD: 8192
         I_MPI_DYNAMIC_CONNECTION: 1
 
-        #DAPL_NETWORK_NODES: $SLURM_NNODES
-        #DAPL_NETWORK_PPN: $SLURM_NTASKS_PER_NODE
-        #DAPL_WR_MAX: 500
+        DAPL_NETWORK_NODES: $SLURM_NNODES
+        DAPL_NETWORK_PPN: $SLURM_NTASKS_PER_NODE
+        DAPL_WR_MAX: 500
 
-        #OMPI_MCA_pml: cm
-        #OMPI_MCA_mtl: mxm
-        #OMPI_MCA_coll: ^ghc
-        #OMPI_MCA_mtl_mxm_np: 0
+        OMPI_MCA_pml: cm
+        OMPI_MCA_mtl: mxm
+        OMPI_MCA_coll: ^ghc
+        OMPI_MCA_mtl_mxm_np: 0
 
-        #MXM_RDMA_PORTS: mlx5_0:1
+        MXM_RDMA_PORTS: mlx5_0:1
         MXM_LOG_LEVEL: FATAL
         ################################################
 
@@ -240,18 +239,15 @@ choose_useMPI:
         openmpi:
                 add_module_actions:
                         - "load intel/18.0.4"
+                        - "unload cmake"
+                        - "load cmake"
                         - "load openmpi/2.0.2p2_hpcx-intel14"
                         - "unload netcdf"
                         - "load netcdf_c/4.3.2-gcc48"
                 add_export_vars:
                         I_MPI_SLURM_EXT: 0
 
-                        #OMPI_MCA_pml: cm          # sets the point-to-point management layer
-                        #OMPI_MCA_mtl: mxm         # sets the matching transport layer
-                        #MXM_RDMA_PORTS: mlx5_0:1
                         MXM_LOG_LEVEL: ERROR
-                        #MXM_HANDLE_ERRORS: bt
-                        #UCX_HANDLE_ERRORS: bt
                         I_MPI_CHECK_DAPL_PROVIDER_COMPATIBILITY: 0
                         I_MPI_HARD_FINALIZE: 1
                         I_MPI_ADJUST_GATHER: 1 # do not use =3 (Shumilin's algorithm)
@@ -260,14 +256,13 @@ choose_useMPI:
                         HDF5_C_INCLUDE_DIRECTORIES: "/sw/rhel6-x64/hdf5/hdf5-1.8.14-threadsafe-intel14/include"
                         NETCDFFROOT: "/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.3-intel14"
                         NETCDFROOT: "/sw/rhel6-x64/netcdf/netcdf_c-4.4.0-gcc48"
-                        #NETCDF_Fortran_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-intel14/include # REMOVE_THIS!
-                        #NETCDF_C_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-intel14/include # REMOVE THIS!
 
                 fc: mpif90
                 f77: mpif90
                 mpifc: mpif90
                 cc: mpicc
                 cxx: mpicxx
+                remove_computer.export_vars: [MPIROOT, MPI_LIB, DAPL_NETWORK_NODES, DAPL_NETWORK_PPN, DAPL_WR_MAX, OMPI_MCA_pml, OMPI_MCA_mtl, OMPI_MCA_coll, OMPI_MCA_mtl_mxm_np, MXM_RDMA_PORTS]
 
         bullxmpi:
                 add_module_actions:

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -71,15 +71,16 @@ pool_dir:  "/pool/data"
 
 useMPI: intelmpi
 module_actions:
-        - "purge"
-        - "unload netcdf_c"
-        - "unload intel intelmpi"
-        - "load python/3.5.2"
-        - "load cmake/3.13.3"
-        - "load autoconf/2.69"
-        - "load nco"
-        - "load cdo"
-        - "load gcc/4.8.2"
+        #- "purge"
+        - "source /pf/a/a270152/shell-intel+openmpi"
+        #- "unload netcdf_c"
+        #- "unload intel intelmpi"
+        #- "load python/3.5.2"
+        #- "load cmake/3.13.3"
+        #- "load autoconf/2.69"
+        #- "load nco"
+        #- "load cdo"
+        #- "load gcc/4.8.2"
 
 export_vars:
         #########################################################################
@@ -88,114 +89,114 @@ export_vars:
         #
         LC_ALL: en_US.UTF-8
 
-        #########################################################################
-        # Compiler Settings
-        #########################################################################
-        #
-        FC: ${fc}
-        F77: ${f77}
-        MPIFC: ${mpifc}
-        CC: ${cc}
-        CXX: ${cxx}
+        ##########################################################################
+        ## Compiler Settings
+        ##########################################################################
+        ##
+        #FC: ${fc}
+        #F77: ${f77}
+        #MPIFC: ${mpifc}
+        #CC: ${cc}
+        #CXX: ${cxx}
 
-        #########################################################################
-        # MPI Settings
-        #########################################################################
-        #
-        MPIROOT: "\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
-        MPI_LIB: "\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
+        ##########################################################################
+        ## MPI Settings
+        ##########################################################################
+        ##
+        #MPIROOT: "\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
+        #MPI_LIB: "\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
 
-        #########################################################################
-        # HDF5 Defaults
-        #########################################################################
-        #
-        # Why are we not using MPI HDF5?
-        #- 'HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.16-parallel-impi-intel14/'
-        #- 'HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include'
-        # NOTE(JK): Using wrong combination of HDF5, netCDF-C and netCDF-F libs can lead to
-        #           undefined symbol: __intel_skx_avx512_memcpy
-        #           This combination was recommended by DKRZ support
-        HDF5ROOT: /sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/
-        HDF5_C_INCLUDE_DIRECTORIES: $HDF5ROOT/include
-        # NOTE(PG): The version of HDF5_ROOT **WITH** an underscore is used by PISM Cmake.
-        #           Moved to PISM yamls, but doesn't show up??
-        HDF5_ROOT: $HDF5ROOT
+        ##########################################################################
+        ## HDF5 Defaults
+        ##########################################################################
+        ##
+        ## Why are we not using MPI HDF5?
+        ##- 'HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.16-parallel-impi-intel14/'
+        ##- 'HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include'
+        ## NOTE(JK): Using wrong combination of HDF5, netCDF-C and netCDF-F libs can lead to
+        ##           undefined symbol: __intel_skx_avx512_memcpy
+        ##           This combination was recommended by DKRZ support
+        #HDF5ROOT: /sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/
+        #HDF5_C_INCLUDE_DIRECTORIES: $HDF5ROOT/include
+        ## NOTE(PG): The version of HDF5_ROOT **WITH** an underscore is used by PISM Cmake.
+        ##           Moved to PISM yamls, but doesn't show up??
+        #HDF5_ROOT: $HDF5ROOT
 
-        #########################################################################
-        # NETCDF Defaults
-        #########################################################################
-        #
-        # NOTE(PG): Is it intentional to have different netcdf_fortran and
-        # netcdf_c versions?
-        NETCDFFROOT: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/
-        NETCDFROOT: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/
-        # NOTE(PG): The next lines are moved to echam.yaml, and only active for:
-        # A) mistral
-        # and
-        # B) echam-6.3.05p2-concurrent-radiation-paleodyn
-        # the next line is the critical one, this works:
-        # - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
-        # this doesn't - mismatch with cxx_include_directories???:
-        # - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
-        NETCDF_Fortran_INCLUDE_DIRECTORIES: $NETCDFFROOT/include
-        NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
-        NETCDF_CXX_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_cxx-4.2.1-gcc48/include
+        ##########################################################################
+        ## NETCDF Defaults
+        ##########################################################################
+        ##
+        ## NOTE(PG): Is it intentional to have different netcdf_fortran and
+        ## netcdf_c versions?
+        #NETCDFFROOT: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/
+        #NETCDFROOT: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/
+        ## NOTE(PG): The next lines are moved to echam.yaml, and only active for:
+        ## A) mistral
+        ## and
+        ## B) echam-6.3.05p2-concurrent-radiation-paleodyn
+        ## the next line is the critical one, this works:
+        ## - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
+        ## this doesn't - mismatch with cxx_include_directories???:
+        ## - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
+        #NETCDF_Fortran_INCLUDE_DIRECTORIES: $NETCDFFROOT/include
+        #NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
+        #NETCDF_CXX_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_cxx-4.2.1-gcc48/include
 
-        #########################################################################
-        # Linear Algebra (LAPACK)
-        #########################################################################
-        #
-        LAPACK_LIB: "'-mkl=sequential'"
-        LAPACK_LIB_DEFAULT: "'-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
+        ##########################################################################
+        ## Linear Algebra (LAPACK)
+        ##########################################################################
+        ##
+        #LAPACK_LIB: "'-mkl=sequential'"
+        #LAPACK_LIB_DEFAULT: "'-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
 
-        #########################################################################
-        # General Software (Perl, usw.)
-        #########################################################################
-        #
-        PERL5LIB: /usr/lib64/perl5
-        SZIPROOT: /sw/rhel6-x64/sys/libaec-0.3.2-gcc48
-        ZLIBROOT: /usr
+        ##########################################################################
+        ## General Software (Perl, usw.)
+        ##########################################################################
+        ##
+        #PERL5LIB: /usr/lib64/perl5
+        #SZIPROOT: /sw/rhel6-x64/sys/libaec-0.3.2-gcc48
+        #ZLIBROOT: /usr
 
-        #########################################################################
-        # seb-wahl: OASIS3MCT_FC_LIB is used by ECHAM, since it's unclear whether
-        # it's used by other models it stays in mistral.yaml for now
-        #########################################################################
-        OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
+        ##########################################################################
+        ## seb-wahl: OASIS3MCT_FC_LIB is used by ECHAM, since it's unclear whether
+        ## it's used by other models it stays in mistral.yaml for now
+        ##########################################################################
+        #OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
 
-        #########################################################################
-        # LD_LIBRARY_PATH
-        #
-        # Since the LD_LIBRARY_PATH modifies linking, this block probably needs
-        # to be at the end!!
-        #########################################################################
-        #
-        LD_LIBRARY_PATH[(0)]: $NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH
-        # avoid GLIBCXX_3.4.15 not found error
-        LD_LIBRARY_PATH[(1)]: /sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH
-        # The following line is also moved to echam.yaml, only active for mistral and paleodyn echam6:
-        # - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
+        ##########################################################################
+        ## LD_LIBRARY_PATH
+        ##
+        ## Since the LD_LIBRARY_PATH modifies linking, this block probably needs
+        ## to be at the end!!
+        ##########################################################################
+        ##
+        #LD_LIBRARY_PATH[(0)]: $NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH
+        ## avoid GLIBCXX_3.4.15 not found error
+        #LD_LIBRARY_PATH[(1)]: /sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH
+        ## The following line is also moved to echam.yaml, only active for mistral and paleodyn echam6:
+        ## - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
 
-        ################################################
-        # This needs to be moved into OIFS
-        # MPI environent variables important at runtime
-        I_MPI_FABRICS: shm:dapl
-        I_MPI_FALLBACK: disable
-        I_MPI_SLURM_EXT: 1
-        I_MPI_LARGE_SCALE_THRESHOLD: 8192
-        I_MPI_DYNAMIC_CONNECTION: 1
+        #################################################
+        ## This needs to be moved into OIFS
+        ## MPI environent variables important at runtime
+        #I_MPI_FABRICS: shm:dapl
+        #I_MPI_FALLBACK: disable
+        #I_MPI_SLURM_EXT: 1
+        #I_MPI_LARGE_SCALE_THRESHOLD: 8192
+        #I_MPI_DYNAMIC_CONNECTION: 1
 
-        DAPL_NETWORK_NODES: $SLURM_NNODES
-        DAPL_NETWORK_PPN: $SLURM_NTASKS_PER_NODE
-        DAPL_WR_MAX: 500
+        #DAPL_NETWORK_NODES: $SLURM_NNODES
+        #DAPL_NETWORK_PPN: $SLURM_NTASKS_PER_NODE
+        #DAPL_WR_MAX: 500
 
-        OMPI_MCA_pml: cm
-        OMPI_MCA_mtl: mxm
-        OMPI_MCA_coll: ^ghc
-        OMPI_MCA_mtl_mxm_np: 0
+        #OMPI_MCA_pml: cm
+        #OMPI_MCA_mtl: mxm
+        #OMPI_MCA_coll: ^ghc
+        #OMPI_MCA_mtl_mxm_np: 0
 
-        MXM_RDMA_PORTS: mlx5_0:1
-        MXM_LOG_LEVEL: FATAL
-        ################################################
+        #MXM_RDMA_PORTS: mlx5_0:1
+        #MXM_LOG_LEVEL: FATAL
+        #################################################
 
 choose_useMPI:
         intelmpi:
@@ -237,19 +238,19 @@ choose_useMPI:
                 add_export_vars:
                         LAPACK_LIB_DEFAULT: '-L/sw/rhel6-x64/intel/intel-17.0.6/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'
         openmpi:
-                add_module_actions:
-                        - "load intel/18.0.4"
-                        - "load openmpi/2.0.2p2_hpcx-intel14"
-                add_export_vars:
-                        OMPI_MCA_pml: cm          # sets the point-to-point management layer
-                        OMPI_MCA_mtl: mxm         # sets the matching transport layer
-                        MXM_RDMA_PORTS: mlx5_0:1
-                        MXM_LOG_LEVEL: ERROR
-                        MXM_HANDLE_ERRORS: bt
-                        UCX_HANDLE_ERRORS: bt
-                        HDF5ROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
-                        NETCDFFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
-                        NETCDFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
+                #add_module_actions:
+                #        - "load intel/18.0.4"
+                #        - "load openmpi/2.0.2p2_hpcx-intel14"
+                #add_export_vars:
+                #        OMPI_MCA_pml: cm          # sets the point-to-point management layer
+                #        OMPI_MCA_mtl: mxm         # sets the matching transport layer
+                #        MXM_RDMA_PORTS: mlx5_0:1
+                #        MXM_LOG_LEVEL: ERROR
+                #        MXM_HANDLE_ERRORS: bt
+                #        UCX_HANDLE_ERRORS: bt
+                #        HDF5ROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
+                #        NETCDFFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
+                #        NETCDFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
 
                 fc: mpif90
                 f77: mpif90

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -260,8 +260,8 @@ choose_useMPI:
                         HDF5_C_INCLUDE_DIRECTORIES: "/sw/rhel6-x64/hdf5/hdf5-1.8.14-threadsafe-intel14/include"
                         NETCDFFROOT: "/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.3-intel14"
                         NETCDFROOT: "/sw/rhel6-x64/netcdf/netcdf_c-4.4.0-gcc48"
-                        NETCDF_Fortran_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-intel14/include # ANIMAL!
-                        NETCDF_C_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-intel14/include # ANIMAL!
+                        #NETCDF_Fortran_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-intel14/include # REMOVE_THIS!
+                        #NETCDF_C_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-intel14/include # REMOVE THIS!
 
                 fc: mpif90
                 f77: mpif90

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -71,16 +71,16 @@ pool_dir:  "/pool/data"
 
 useMPI: intelmpi
 module_actions:
-        #- "purge"
-        - "source /pf/a/a270152/shell-intel+openmpi"
-        #- "unload netcdf_c"
-        #- "unload intel intelmpi"
-        #- "load python/3.5.2"
-        #- "load cmake/3.13.3"
-        #- "load autoconf/2.69"
-        #- "load nco"
-        #- "load cdo"
-        #- "load gcc/4.8.2"
+        - "purge"
+        #- "source /pf/a/a270152/shell-intel+openmpi"
+        - "unload netcdf_c"
+        - "unload intel intelmpi"
+        - "load python/3.5.2"
+        - "load cmake"
+        - "load autoconf/2.69"
+        - "load nco"
+        - "load cdo"
+        - "load gcc/4.8.2"
 
 export_vars:
         #########################################################################
@@ -89,101 +89,101 @@ export_vars:
         #
         LC_ALL: en_US.UTF-8
 
-        ##########################################################################
-        ## Compiler Settings
-        ##########################################################################
-        ##
-        #FC: ${fc}
-        #F77: ${f77}
-        #MPIFC: ${mpifc}
-        #CC: ${cc}
-        #CXX: ${cxx}
+        #########################################################################
+        # Compiler Settings
+        #########################################################################
+        #
+        FC: ${fc}
+        F77: ${f77}
+        MPIFC: ${mpifc}
+        CC: ${cc}
+        CXX: ${cxx}
 
-        ##########################################################################
-        ## MPI Settings
-        ##########################################################################
-        ##
+        #########################################################################
+        # MPI Settings
+        #########################################################################
+        #
         #MPIROOT: "\"$(${mpifc} -show | perl -lne 'm{ -I(.*?)/include } and print $1')\""
         #MPI_LIB: "\"$(${mpifc} -show |sed -e 's/^[^ ]*//' -e 's/-[I][^ ]*//g')\""
 
-        ##########################################################################
-        ## HDF5 Defaults
-        ##########################################################################
-        ##
-        ## Why are we not using MPI HDF5?
-        ##- 'HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.16-parallel-impi-intel14/'
-        ##- 'HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include'
-        ## NOTE(JK): Using wrong combination of HDF5, netCDF-C and netCDF-F libs can lead to
-        ##           undefined symbol: __intel_skx_avx512_memcpy
-        ##           This combination was recommended by DKRZ support
-        #HDF5ROOT: /sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/
-        #HDF5_C_INCLUDE_DIRECTORIES: $HDF5ROOT/include
-        ## NOTE(PG): The version of HDF5_ROOT **WITH** an underscore is used by PISM Cmake.
-        ##           Moved to PISM yamls, but doesn't show up??
-        #HDF5_ROOT: $HDF5ROOT
+        #########################################################################
+        # HDF5 Defaults
+        #########################################################################
+        #
+        # Why are we not using MPI HDF5?
+        #- 'HDF5ROOT=/sw/rhel6-x64/hdf5/hdf5-1.8.16-parallel-impi-intel14/'
+        #- 'HDF5_C_INCLUDE_DIRECTORIES=$HDF5ROOT/include'
+        # NOTE(JK): Using wrong combination of HDF5, netCDF-C and netCDF-F libs can lead to
+        #           undefined symbol: __intel_skx_avx512_memcpy
+        #           This combination was recommended by DKRZ support
+        HDF5ROOT: /sw/rhel6-x64/hdf5/hdf5-1.8.14-parallel-impi-intel14/
+        HDF5_C_INCLUDE_DIRECTORIES: $HDF5ROOT/include
+        # NOTE(PG): The version of HDF5_ROOT **WITH** an underscore is used by PISM Cmake.
+        #           Moved to PISM yamls, but doesn't show up??
+        HDF5_ROOT: $HDF5ROOT
 
-        ##########################################################################
-        ## NETCDF Defaults
-        ##########################################################################
-        ##
-        ## NOTE(PG): Is it intentional to have different netcdf_fortran and
-        ## netcdf_c versions?
-        #NETCDFFROOT: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/
-        #NETCDFROOT: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/
-        ## NOTE(PG): The next lines are moved to echam.yaml, and only active for:
-        ## A) mistral
-        ## and
-        ## B) echam-6.3.05p2-concurrent-radiation-paleodyn
-        ## the next line is the critical one, this works:
-        ## - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
-        ## this doesn't - mismatch with cxx_include_directories???:
-        ## - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
-        #NETCDF_Fortran_INCLUDE_DIRECTORIES: $NETCDFFROOT/include
-        #NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
-        #NETCDF_CXX_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_cxx-4.2.1-gcc48/include
+        #########################################################################
+        # NETCDF Defaults
+        #########################################################################
+        #
+        # NOTE(PG): Is it intentional to have different netcdf_fortran and
+        # netcdf_c versions?
+        NETCDFFROOT: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-parallel-impi-intel14/
+        NETCDFROOT: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/
+        # NOTE(PG): The next lines are moved to echam.yaml, and only active for:
+        # A) mistral
+        # and
+        # B) echam-6.3.05p2-concurrent-radiation-paleodyn
+        # the next line is the critical one, this works:
+        # - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-gcc48"
+        # this doesn't - mismatch with cxx_include_directories???:
+        # - "NETCDFROOT=/sw/rhel6-x64/netcdf/netcdf_c-4.3.2-parallel-impi-intel14/"
+        NETCDF_Fortran_INCLUDE_DIRECTORIES: $NETCDFFROOT/include
+        NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
+        NETCDF_CXX_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_cxx-4.2.1-gcc48/include
 
-        ##########################################################################
-        ## Linear Algebra (LAPACK)
-        ##########################################################################
-        ##
-        #LAPACK_LIB: "'-mkl=sequential'"
-        #LAPACK_LIB_DEFAULT: "'-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
+        #########################################################################
+        # Linear Algebra (LAPACK)
+        #########################################################################
+        #
+        LAPACK_LIB: "'-mkl=sequential'"
+        LAPACK_LIB_DEFAULT: "'-L/sw/rhel6-x64/intel/intel-18.0.1/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'"
 
-        ##########################################################################
-        ## General Software (Perl, usw.)
-        ##########################################################################
-        ##
-        #PERL5LIB: /usr/lib64/perl5
-        #SZIPROOT: /sw/rhel6-x64/sys/libaec-0.3.2-gcc48
-        #ZLIBROOT: /usr
+        #########################################################################
+        # General Software (Perl, usw.)
+        #########################################################################
+        #
+        PERL5LIB: /usr/lib64/perl5
+        SZIPROOT: /sw/rhel6-x64/sys/libaec-0.3.2-gcc48
+        ZLIBROOT: /usr
 
-        ##########################################################################
-        ## seb-wahl: OASIS3MCT_FC_LIB is used by ECHAM, since it's unclear whether
-        ## it's used by other models it stays in mistral.yaml for now
-        ##########################################################################
-        #OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
+        #########################################################################
+        # seb-wahl: OASIS3MCT_FC_LIB is used by ECHAM, since it's unclear whether
+        # it's used by other models it stays in mistral.yaml for now
+        #########################################################################
+        OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
 
-        ##########################################################################
-        ## LD_LIBRARY_PATH
-        ##
-        ## Since the LD_LIBRARY_PATH modifies linking, this block probably needs
-        ## to be at the end!!
-        ##########################################################################
-        ##
-        #LD_LIBRARY_PATH[(0)]: $NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH
-        ## avoid GLIBCXX_3.4.15 not found error
-        #LD_LIBRARY_PATH[(1)]: /sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH
-        ## The following line is also moved to echam.yaml, only active for mistral and paleodyn echam6:
-        ## - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
+        #########################################################################
+        # LD_LIBRARY_PATH
+        #
+        # Since the LD_LIBRARY_PATH modifies linking, this block probably needs
+        # to be at the end!!
+        #########################################################################
+        #
+        LD_LIBRARY_PATH[(0)]: $NETCDFROOT/lib:$NETCDFFROOT/lib:$HDF5ROOT/lib:$LD_LIBRARY_PATH
+        # avoid GLIBCXX_3.4.15 not found error
+        LD_LIBRARY_PATH[(1)]: /sw/rhel6-x64/gcc/gcc-4.8.2/lib64:$LD_LIBRARY_PATH
+        # The following line is also moved to echam.yaml, only active for mistral and paleodyn echam6:
+        # - "LD_LIBRARY_PATH=/sw/rhel6-x64/netcdf/parallel_netcdf-1.6.1-impi-intel14/lib/:$LD_LIBRARY_PATH"
 
-        #################################################
-        ## This needs to be moved into OIFS
-        ## MPI environent variables important at runtime
-        #I_MPI_FABRICS: shm:dapl
-        #I_MPI_FALLBACK: disable
-        #I_MPI_SLURM_EXT: 1
-        #I_MPI_LARGE_SCALE_THRESHOLD: 8192
-        #I_MPI_DYNAMIC_CONNECTION: 1
+        ################################################
+        # This needs to be moved into OIFS
+        # MPI environent variables important at runtime
+        I_MPI_FABRICS: shm:dapl
+        I_MPI_FALLBACK: disable
+        I_MPI_SLURM_EXT: 1
+        I_MPI_LARGE_SCALE_THRESHOLD: 8192
+        I_MPI_DYNAMIC_CONNECTION: 1
 
         #DAPL_NETWORK_NODES: $SLURM_NNODES
         #DAPL_NETWORK_PPN: $SLURM_NTASKS_PER_NODE
@@ -195,8 +195,8 @@ export_vars:
         #OMPI_MCA_mtl_mxm_np: 0
 
         #MXM_RDMA_PORTS: mlx5_0:1
-        #MXM_LOG_LEVEL: FATAL
-        #################################################
+        MXM_LOG_LEVEL: FATAL
+        ################################################
 
 choose_useMPI:
         intelmpi:
@@ -238,19 +238,30 @@ choose_useMPI:
                 add_export_vars:
                         LAPACK_LIB_DEFAULT: '-L/sw/rhel6-x64/intel/intel-17.0.6/mkl/lib/intel64 -lmkl_intel_lp64 -lmkl_core -lmkl_sequential'
         openmpi:
-                #add_module_actions:
-                #        - "load intel/18.0.4"
-                #        - "load openmpi/2.0.2p2_hpcx-intel14"
-                #add_export_vars:
-                #        OMPI_MCA_pml: cm          # sets the point-to-point management layer
-                #        OMPI_MCA_mtl: mxm         # sets the matching transport layer
-                #        MXM_RDMA_PORTS: mlx5_0:1
-                #        MXM_LOG_LEVEL: ERROR
-                #        MXM_HANDLE_ERRORS: bt
-                #        UCX_HANDLE_ERRORS: bt
-                #        HDF5ROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
-                #        NETCDFFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
-                #        NETCDFROOT: "/work/ab0246/a270152/HPC_libraries/intel2014.0.3_openmpi_2.0.2p2_20210804/"
+                add_module_actions:
+                        - "load intel/18.0.4"
+                        - "load openmpi/2.0.2p2_hpcx-intel14"
+                        - "unload netcdf"
+                        - "load netcdf_c/4.3.2-gcc48"
+                add_export_vars:
+                        I_MPI_SLURM_EXT: 0
+
+                        #OMPI_MCA_pml: cm          # sets the point-to-point management layer
+                        #OMPI_MCA_mtl: mxm         # sets the matching transport layer
+                        #MXM_RDMA_PORTS: mlx5_0:1
+                        MXM_LOG_LEVEL: ERROR
+                        #MXM_HANDLE_ERRORS: bt
+                        #UCX_HANDLE_ERRORS: bt
+                        I_MPI_CHECK_DAPL_PROVIDER_COMPATIBILITY: 0
+                        I_MPI_HARD_FINALIZE: 1
+                        I_MPI_ADJUST_GATHER: 1 # do not use =3 (Shumilin's algorithm)
+
+                        HDF5ROOT: "/sw/rhel6-x64/hdf5/hdf5-1.8.14-threadsafe-gcc48"
+                        HDF5_C_INCLUDE_DIRECTORIES: "/sw/rhel6-x64/hdf5/hdf5-1.8.14-threadsafe-intel14/include"
+                        NETCDFFROOT: "/sw/rhel6-x64/netcdf/netcdf_fortran-4.4.3-intel14"
+                        NETCDFROOT: "/sw/rhel6-x64/netcdf/netcdf_c-4.4.0-gcc48"
+                        NETCDF_Fortran_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_fortran-4.4.2-intel14/include # ANIMAL!
+                        NETCDF_C_INCLUDE_DIRECTORIES: /sw/rhel6-x64/netcdf/netcdf_c-4.3.2-intel14/include # ANIMAL!
 
                 fc: mpif90
                 f77: mpif90


### PR DESCRIPTION
Working `openMPI` environment for `AWICM3` on `mistral` (environment taken from the @hegish ksh environment).

If `useMPI` is not specified in the `runscript` or through the `esm_master` using the `-m` flag, everything remains as before.