### PR TITLE
Allowed Missing Files

### DIFF
--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -991,8 +991,8 @@ def filter_allowed_missing_files(config):
                     or missing_file_target_fname in glob.glob(allowed_missing_pattern)
                 ):
                     # TODO(PG): Replace with logger statements
-                  if config["general"].get("verbose", False):
-                      print(
+                    if config["general"].get("verbose", False):
+                        print(
                             f"Detected allowed missing file with {allowed_missing_pattern}"
                         )
                         print("Adding to allowed missing files:")

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -972,9 +972,10 @@ def filter_allowed_missing_files(config):
     allowed_missing_files = config["general"].setdefault("allowed_missing_files", {})
     missing_files = config["general"].get("files_missing_when_preparing_run", {})
     # TODO(PG): Replace with logger statements
-    print("Currently known missing files:")
-    for k, v in missing_files.items():
-        print(f"source: {k} --> target: {v}")
+    if config["general"].get("verbose", False):
+        print("Currently known missing files:")
+        for k, v in missing_files.items():
+            print(f"source: {k} --> target: {v}")
     remove_missing_files = []
     for missing_file_source, missing_file_target in missing_files.items():
         missing_file_source_fname = pathlib.Path(missing_file_source).name
@@ -990,12 +991,13 @@ def filter_allowed_missing_files(config):
                     or missing_file_target_fname in glob.glob(allowed_missing_pattern)
                 ):
                     # TODO(PG): Replace with logger statements
-                    print(
-                        f"Detected allowed missing file with {allowed_missing_pattern}"
-                    )
-                    print("Adding to allowed missing files:")
-                    print(f"source: {missing_file_source}")
-                    print(f"target: {missing_file_target}")
+                  if config["general"].get("verbose", False):
+                      print(
+                            f"Detected allowed missing file with {allowed_missing_pattern}"
+                        )
+                        print("Adding to allowed missing files:")
+                        print(f"source: {missing_file_source}")
+                        print(f"target: {missing_file_target}")
                     remove_missing_files.append(missing_file_source)
                     allowed_missing_files.update(
                         {missing_file_source: missing_file_target}

--- a/tests/test_esm_runscripts/test_filelists.py
+++ b/tests/test_esm_runscripts/test_filelists.py
@@ -1,0 +1,154 @@
+import unittest
+
+import esm_runscripts
+
+
+class TestAllowedMissingFiles(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_config = {
+            "general": {
+                "valid_model_names": ["foo_model"],
+                "files_missing_when_preparing_run": {
+                    "/some/long/directory/in/pool/foo.dat": "/some/directory/in/experiment/work/foo.dat",
+                    "/some/other/directory/in/user/bar.dat": "/some/directory/in/experiment/work/baz.dat",
+                },
+            },
+            "foo_model": {},
+        }
+        return super().setUp()
+
+    def test_undefined_missing(self):
+        self.assertEqual(
+            self.test_config,
+            esm_runscripts.filelists.filter_allowed_missing_files(self.test_config),
+        )
+
+    def test_allowed_missing_foo_explicit(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["foo.dat"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_foo_dotglob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["foo.*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_foo_glob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["foo*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/long/directory/in/pool/foo.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_bar_explicit(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["bar.dat"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_bar_dotglob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["bar.*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_bar_glob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["bar*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_baz_explicit(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["baz.dat"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_baz_dotglob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["baz.*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+    def test_allowed_missing_baz_glob(self):
+        self.test_config["foo_model"].update({"allowed_missing_files": ["baz*"]})
+        self.modifed_config = esm_runscripts.filelists.filter_allowed_missing_files(
+            self.test_config
+        )
+        self.assertNotIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["files_missing_when_preparing_run"],
+        )
+        self.assertIn(
+            "/some/other/directory/in/user/bar.dat",
+            self.test_config["general"]["allowed_missing_files"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This commit allows for components to define a `allowed_missing_files` list,
which can be globs or regex to match either the source or the target. Matching
files are moved from the missing files list to the allowed missing files list.

## Usage Example
As an example:
```python
test_config = {
    "general": {
        "valid_model_names": ["foo_model"],
        "files_missing_when_preparing_run": {
            "/some/long/directory/in/pool/foo.dat": "/some/directory/in/experiment/work/foo.dat",
            "/some/other/directory/in/user/bar.dat": "/some/directory/in/experiment/work/baz.dat",
        },
    },
    "foo_model": {
        "allowed_missing_files": ["foo.dat"]
      },
}

out_config = esm_runscripts.filelists.filter_allowed_missing_files(test_config)
print(out_config)
{
    "general": {
        "valid_model_names": ["foo_model"],
        "files_missing_when_preparing_run": {
            "/some/long/directory/in/pool/foo.dat": "/some/directory/in/experiment/work/foo.dat",
        },
        "allowed_missing_files": {
            "/some/other/directory/in/user/bar.dat": "/some/directory/in/experiment/work/baz.dat",
        },
    },
    "foo_model": {
        "allowed_missing_files": ["foo.dat"]
      },
}

```
See the units tests for more examples.

## TODO

The following still needs to be done:

+ [x] Implementation
+ [x] Basic Unit Tests
+ [ ] Real World Unit Tests
+ [ ] Modification of config YAMLs with agreed-upon allowed-missing files
