### PR TITLE
fix/default update filetypes

### DIFF
--- a/docs/esm_runscripts.rst
+++ b/docs/esm_runscripts.rst
@@ -29,8 +29,9 @@ Optional arguments                                     Description
   -p ``PID``, --pid ``PID``                            The PID of the task to observe.
   -x ``EXCLUDE``, --exclude ``EXCLUDE``                E[x]clude this step.
   -o ``ONLY``, --only ``ONLY``                         [o]nly do this step.
-  -r ``RESUME_FROM``, --resume-from ``RESUME_FROM``    [r]esume from this step.
+  -r ``RESUME_FROM``, --resume-from ``RESUME_FROM``    [r]esume from the specified run/step (i.e. to resume a second run you'll need to use ``-r 2``).
   -U, --update                                         [U]pdate the runscript in the experiment folder and associated files
+  --update-filetypes                                   Updates the requested files from external sources in a currently ongoing simulation. We strongly advise against using this option unless you really know what you are doing.
   -i, --inspect                                        This option can be used to [i]nspect the results of a previous
                                                        run, for example one prepared with ``-c``. This argument needs an
                                                        additional keyword. Choose among: ``overview`` (gives you the

--- a/src/esm_runscripts/cli.py
+++ b/src/esm_runscripts/cli.py
@@ -143,6 +143,7 @@ def parse_shargs():
         "simulation. We strongly advise against using this option unless you "
         "really know what you are doing.",
         nargs="+",
+        default=[],
     )
 
     parser.add_argument(


### PR DESCRIPTION
Argparse was missing a default for the `--update-filetypes` flag. That meant that whenever a  loop over the `update_filetypes` was run and not flag was provided, it's value would be `None` and it would crash. Now the default is set as a list and crashes are avoided. I also added a few minor changes to the documentation.