### PR TITLE
Het par improvement

### DIFF
--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -48,8 +48,6 @@ thisrun_logfile: "${output_path}${expid}_${general.setup_name}_@jobtype@_${gener
 output_flags: "--output=${thisrun_logfile} --error=${thisrun_logfile}"
 name_flag: "--job-name=${expid}"
 
-heterogeneous_parallelization: false
-
 add_choose_heterogeneous_parallelization:
         true:
                 cpu_bind: "none"

--- a/configs/setups/awicm3/awicm3.yaml
+++ b/configs/setups/awicm3/awicm3.yaml
@@ -581,7 +581,6 @@ oasis3mct:
 
 
 computer:
-        heterogeneous_parallelization: false
         choose_computer.name:
                 blogin:
                         compiler_mpi: intel2019_ompi

--- a/configs/setups/oifsamip/oifsamip.yaml
+++ b/configs/setups/oifsamip/oifsamip.yaml
@@ -285,5 +285,3 @@ oasis3mct:
                 rstos.nc: rstos.nc
 
 
-computer:
-        heterogeneous_parallelization: false

--- a/runscripts/awicm3/deck/awicm3-deck-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/deck/awicm3-deck-juwels-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/jstreffi/esm_tools/model_codes/awicm3-1.0-deck/"

--- a/runscripts/awicm3/deck/awicm3-deck-mistral-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/deck/awicm3-deck-mistral-TL159L60-CORE2.yaml
@@ -12,9 +12,6 @@ general:
     nyear: 0
     use_venv: false # This needs to be deleted as default so that the user gets the dialogue and takes action
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/pf/a/a270092/model_codes/awicm3-1.0-deck/"

--- a/runscripts/awicm3/deck/awicm3-deck-ollie-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/deck/awicm3-deck-ollie-TL159L60-CORE2.yaml
@@ -9,9 +9,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: false #true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/jstreffi/model_codes/awicm3-1.0-deck/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-aleph-TCO319L137-DART.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-aleph-TCO319L137-DART.yaml
@@ -11,9 +11,6 @@ general:
     nyear: 0
     use_venv: false # This needs to be deleted as default so that the user gets the dialogue and takes action
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: /home/awiiccp2/esm/model_codes/awicm3-1.0-frontiers/

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-aleph-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-aleph-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO159L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO159L91-CORE2_inital.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO159L91-CORE2_inital.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-D3.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-D3.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-D3_coldstart.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-D3_coldstart.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-DART.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO319L137-DART.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO639L137-DART_initial.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO639L137-DART_initial.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO95L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TCO95L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2_inital.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2_inital.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2_initial.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-juwels-TL159L60-CORE2_initial.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TCO159L91-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/{setup_name}-${version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TL159L60-CORE2_inital.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-ollie-TL159L60-CORE2_inital.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-aleph-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-aleph-TCO159L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/${user}/model_codes/${general.setup_name}-${general.version}//"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-aleph-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-aleph-TL159L60-CORE2.yaml
@@ -10,7 +10,6 @@ general:
     nday: 1
     nmonth: 0
     nyear: 0
-    heterogeneous_parallelization: true
 
 awicm3:
     postprocessing: false

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO159L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO319L137-DART.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO319L137-DART.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO639L137-DART.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO639L137-DART.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 3
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO639L137-DART_initial.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO639L137-DART_initial.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO95L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO95L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO95L91-CORE2_initial.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TCO95L91-CORE2_initial.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-juwels-TL159L60-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: false
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO159L91-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO95L91-CORE2.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO95L91-CORE2.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO95L91-CORE2_inital.yaml
+++ b/runscripts/awicm3/frontiers/awicm3-frontiers-xios-ollie-TCO95L91-CORE2_inital.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/frontiers/xios_workshop.yaml
+++ b/runscripts/awicm3/frontiers/xios_workshop.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 1
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/master/awicm3-master-ollie-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/master/awicm3-master-ollie-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: false #true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"
@@ -41,7 +38,7 @@ oifs:
     lresume: false
     time_step: 3600
     nproc: 72
-    omp_num_threads: 1 # Set heterogeneous_parallelization: true for this option to take effect
+    omp_num_threads: 1
 
 oasis3mct:
     lresume: false # Set to false to generate the rst files for first leg

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-aleph-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-aleph-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO159L91-CORE2.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 0
     nyear: 20
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO159L91-CORE2_inital.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO159L91-CORE2_inital.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO319L137-D3_coldstart.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO319L137-D3_coldstart.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO319L137-DART.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TCO319L137-DART.yaml
@@ -11,9 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TL159L60-CORE2.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TL159L60-CORE2_inital.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-juwels-TL159L60-CORE2_inital.yaml
@@ -11,8 +11,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
 awicm3:
     postprocessing: false
     model_dir: "/p/project/chhb19/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TCO159L91-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TCO159L91-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TL159L60-CORE2.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 1
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/{setup_name}-${version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TL159L60-CORE2_inital.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-ollie-TL159L60-CORE2_inital.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 awicm3:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/awicm3/v3.0/awicm3-v3.0-xios-aleph-TL159L60-CORE2.yaml
+++ b/runscripts/awicm3/v3.0/awicm3-v3.0-xios-aleph-TL159L60-CORE2.yaml
@@ -10,7 +10,6 @@ general:
     nday: 0
     nmonth: 1
     nyear: 0
-    heterogeneous_parallelization: true
 
 awicm3:
     postprocessing: false

--- a/runscripts/oifsamip/oifsamip-cy43-ollie-TCO159L91.yaml
+++ b/runscripts/oifsamip/oifsamip-cy43-ollie-TCO159L91.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 5
 
-computer:
-    heterogeneous_parallelization: true
-
 oifsamip:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"

--- a/runscripts/oifsamip/oifsamip-cy43-ollie-TCO159L91_inital.yaml
+++ b/runscripts/oifsamip/oifsamip-cy43-ollie-TCO159L91_inital.yaml
@@ -10,9 +10,6 @@ general:
     nmonth: 0
     nyear: 0
 
-computer:
-    heterogeneous_parallelization: true
-
 oifsamip:
     postprocessing: false
     model_dir: "/home/ollie/${user}/model_codes/${general.setup_name}-${general.version}/"


### PR DESCRIPTION
The `heterogeneous_parallelization` variable is only set to `True` now if `omp_num_threads` of any model is greater than 1 (before it was set to `True` if `omp_num_threads` existed). It can also handle evaluation of `omp_num_threads` that depend on other variables. This is an improvement because the `.run` files where the threads for OpenMP is 1 for all models, will be cleaner, as the taskset work around is not needed