### PR TITLE
AWIESM 2.1 Gamma (with Wiso and PICO)

### DIFF
--- a/.github/workflows/esm_tools_awiesm.yml
+++ b/.github/workflows/esm_tools_awiesm.yml
@@ -30,4 +30,4 @@ jobs:
         with:
           model_name: awiesm
           # versions to test as a space seperated list
-          model_version: "2.1 2.1-wiso 2.1-recom"
+          model_version: "2.1 2.1-wiso 2.1-recom 2.1-gamma"

--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -17,6 +17,7 @@ compile_infos:
         - 6.3.04p1-paleodyn
         - 6.3.04p1-recom-awicm
         - 6.3.05p2-concurrent_radiation-paleodyn
+        - 6.3.05p2-concurrent_radiation-paleodyn-wiso
         - 6.3.04p1
         - 6.3.05p2-wiso
 
@@ -69,6 +70,15 @@ compile_infos:
           6.3.05p2-foci_oasismct4:
             branch: esm-tools-oasis3mct4
             git-repository: https://git.geomar.de/foci/src/echam.git
+          6.3.05p2-concurrent_radiation-paleodyn-wiso:
+            # FIXME (PG): Currently, the wiso branch seems to have everything
+            # we want for both ice coupling as well as isotopes, but this
+            # should be renamed at some point:
+            branch: "wiso"
+            clean_command: rm -rf src/echam/bin; rm -rf bin; make clean
+            comp_command: ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps yaxt/tests/.deps; ./configure $configure_opts --with-fortran=intel INSTALL='/usr/bin/install -p'; make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin; cp  bin/echam6 src/echam/bin/echam6
+            git-repository: "https://gitlab.awi.de/pgierz/echam6.git"
+            destination: echam-6.3.05p2-concurrent_radiation-paleodyn-wiso
           6.3.05p2-wiso:
             branch: "wiso"
             clean_command: rm -rf src/echam/bin; rm -rf bin; make clean
@@ -91,7 +101,7 @@ metadata:
                 'Atmosphericcomponent of the MPI-M earth system model: ECHAM6 <https://doi.org/10.1002/jame.20015>'
         License:
                 Please make sure you have a license to use ECHAM. Otherwise downloading ECHAM will already fail.
-                To use the repository on gitlab.dkrz.de/modular_esm/echam.git, register for the MPI-ESM user forum at 
+                To use the repository on gitlab.dkrz.de/modular_esm/echam.git, register for the MPI-ESM user forum at
                 https://mpimet.mpg.de/en/science/modeling-with-icon/code-availability/mpi-esm-users-forum and send a screenshot
                 to either dirk.barbi@awi.de, deniz.ural@awi.de or miguel.andres-martinez@awi.de
 
@@ -107,7 +117,7 @@ executable: echam6
 version: 6.3.04p1
 resolution: T63
 scenario: "PI-CTRL"
-scenario_type: ${scenario} 
+scenario_type: ${scenario}
 postprocessing_stream: 'BOT ATM LOG'
 yr_perp_off: false
 transient_advance_forcing: false
@@ -410,17 +420,17 @@ choose_scenario:
                         MAC-SP: MAC-SP
 
         ssp585:
-                scenario_type: cmip6 
+                scenario_type: cmip6
         ssp370:
-                scenario_type: cmip6 
+                scenario_type: cmip6
         ssp126:
-                scenario_type: cmip6 
+                scenario_type: cmip6
         ssp245:
-                scenario_type: cmip6 
+                scenario_type: cmip6
         ssp534os:
-                scenario_type: cmip6 
+                scenario_type: cmip6
         cmip6hist:
-                scenario_type: cmip6 
+                scenario_type: cmip6
 
 choose_scenario_type:
         cmip6:
@@ -436,7 +446,7 @@ choose_scenario_type:
                         aerofin_1850: piaerofin
                         aerofin_1851: piaerofin
                         ozone: ozone_hist_scenario
-                        greenhouse: greenhouse_hist_scenario 
+                        greenhouse: greenhouse_hist_scenario
                         volcir: histvolcir
                         volcsw: histvolcsw
                         swflux: histswflux
@@ -545,7 +555,7 @@ forcing_in_work:
         aerofarir_kinne_1850: "aero_farir_@YEAR_1850@.nc"
         aerofin_kinne_1850: "aero_fine_@YEAR_1850@.nc"
         # ok this is another crazy ECHAM6 speciality
-        # every year the background aerosol files for 1849 to 1851 
+        # every year the background aerosol files for 1849 to 1851
         # need to be linked to the same file for historical/scenario runs
         # don't blame me (seb-wahl), blame the MAC-SP developers at MPI
         # MAC-SP describes aerosol w.r.t. piControl conditions.

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -17,6 +17,17 @@ choose_version:
     namelist_dir: "${model_dir}/config/"
   '2.1':
     branch: "2.1.0"
+  2.1-paleodyn-gamma:
+    branch: "paleodyn/awiesm-2.1-gamma"
+    git-repository:
+    - https://gitlab.dkrz.de/FESOM/fesom2.git
+    add_restart_in_files:
+        wiso_restart: wiso_restart
+    add_restart_out_files:
+        wiso_restart: wiso_restart
+    add_coupling_fields:
+        "[[wiso_fields-->FIELD]]":
+            grid: feom
   2.1-wiso:
     branch: wiso
     add_restart_in_files:

--- a/configs/couplings/fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso/fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso.yaml
+++ b/configs/couplings/fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso/fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso.yaml
@@ -1,0 +1,8 @@
+components:
+- echam-6.3.05p2-concurrent_radiation-paleodyn-wiso
+- fesom-2.1-paleodyn-gamma
+- oasis3mct-2.8
+coupling_changes:
+- sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.1/CMakeLists.txt
+- sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn-wiso/config/mh-linux
+- sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-concurrent_radiation-paleodyn-wiso/configure.ac

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -210,7 +210,7 @@ fesom:
                         version: "2.0"
                 "2.1":
                         version: "2.1"
-                        ALE_scheme: 'linfs' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
+                        ALE_scheme: 'linfs'
                 "2.1-paleodyn-gamma":
                         # FIXME(PG): ....does that make sense? Choose version sets the version???
                         version: "2.1-paleodyn-gamma"

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -214,7 +214,7 @@ fesom:
                 "2.1-paleodyn-gamma":
                         # FIXME(PG): ....does that make sense? Choose version sets the version???
                         version: "2.1-paleodyn-gamma"
-                        ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
+                        ALE_scheme: 'zstar'
                 "2.1-wiso":
                         version: "2.1-wiso"
                         ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -217,7 +217,7 @@ fesom:
                         ALE_scheme: 'zstar'
                 "2.1-wiso":
                         version: "2.1-wiso"
-                        ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
+                        ALE_scheme: 'zstar'
                 "2.1-recom":
                         version: "2.1-recom"
                         ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -68,6 +68,7 @@ general:
             - fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso
             wiso_code: true
             with_wiso: false
+            with_pico: false
             fesom_Dflags: "-DFESOM_COUPLED=ON"
           '2.1-wiso':
             couplings:
@@ -249,6 +250,15 @@ fesom:
                                 wiso_restart: wiso_restart
                         add_restart_out_files:
                                 wiso_restart: wiso_restart
+        choose_general.with_pico:
+            True:
+                add_namelist_changes:
+                    namelist.forcing:
+                        pico:
+                            use_pico: True
+                            gammaS: 1.e-4
+                            gammaT: 1.e-4
+
 
 
         choose_general.resolution:

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -211,8 +211,7 @@ fesom:
                 "2.1":
                         version: "2.1"
                         ALE_scheme: 'linfs'
-                "2.1-paleodyn-gamma":
-                        # FIXME(PG): ....does that make sense? Choose version sets the version???
+                "2.1-gamma":
                         version: "2.1-paleodyn-gamma"
                         ALE_scheme: 'zstar'
                 "2.1-wiso":

--- a/configs/setups/awiesm/awiesm-2.1.yaml
+++ b/configs/setups/awiesm/awiesm-2.1.yaml
@@ -63,10 +63,10 @@ general:
         - '2.1-wiso'
         - '2.1-recom'
         choose_version:
-          '2.1':
+          '2.1-gamma':
             couplings:
-            - fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn
-            wiso_code: false
+            - fesom-2.1-paleodyn-gamma+echam-6.3.05p2-concurrent_radiation-paleodyn-wiso
+            wiso_code: true
             with_wiso: false
             fesom_Dflags: "-DFESOM_COUPLED=ON"
           '2.1-wiso':
@@ -210,6 +210,10 @@ fesom:
                 "2.1":
                         version: "2.1"
                         ALE_scheme: 'linfs' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
+                "2.1-paleodyn-gamma":
+                        # FIXME(PG): ....does that make sense? Choose version sets the version???
+                        version: "2.1-paleodyn-gamma"
+                        ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.
                 "2.1-wiso":
                         version: "2.1-wiso"
                         ALE_scheme: 'zstar' # NOTE(PG): This should probably be overriden in the AWIESM 2.x yaml or in the user runscript.


### PR DESCRIPTION
## Summary
This allows both WISO and PICO to be used in the AWI-ESM 2.1 Gamma Variant

## New Features and Tests:
- feat(awiesm): add configuration for AWIESM 2.1 Gamma Variant with WISO and PICO
- ci(awiesm): add AWIESM-2.1 Gamma to automatic testing suite

## TO-DO:
+ [x] Shortcuts to enable or disable either component
+ [ ] Example Run Config

## Related Git Stuff:
- Issue on Paul's Model Support page: https://gitlab.awi.de/pgierz/Model_Support/-/issues/1
- FESOM 2 on DKRZ GitLab: https://gitlab.dkrz.de/FESOM/fesom2/-/commits/paleodyn/awiesm-2.1-gamma
- Fernanda Matos' MIS3 Project: https://gitlab.awi.de/paleodyn/Projects/PalMod/mis3 and https://gitlab.awi.de/paleodyn/Projects/PalMod/mis3/-/merge_requests/2
