### PR TITLE
hotfix/filelist wild cards in target folder

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.1.2
+current_version = 6.1.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.1.2",
+    version="6.1.3",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_profile import *

--- a/src/esm_rcfile/__init__.py
+++ b/src/esm_rcfile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .esm_rcfile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -332,7 +332,7 @@ def target_subfolders(config):
                             ] = filename.replace("*", source_filename)
                         elif "/" in filename:
                             # Return the correct target name
-                            target_name = get_target_name_from_wild_card(
+                            target_name = get_target_name_from_wildcard(
                                 config, model, filename, filetype, descr
                             )
                             config[model][filetype + "_targets"][descr] = (
@@ -342,7 +342,7 @@ def target_subfolders(config):
                             )
                         else:
                             # Return the correct target name
-                            target_name = get_target_name_from_wild_card(
+                            target_name = get_target_name_from_wildcard(
                                 config, model, filename, filetype, descr
                             )
                             config[model][filetype + "_targets"][descr] = target_name
@@ -357,7 +357,52 @@ def target_subfolders(config):
     return config
 
 
-def get_target_name_from_wild_card(config, model, filename, filetype, descr):
+def get_target_name_from_wildcard(config, model, filename, filetype, descr):
+    """
+    Given a taget ``filename`` path containing a wildcard (``*``), and the ``descr``
+    key to an specific file (i.e. the one that points to the actual specific file),
+    returns the ``target_name`` basename for that specific file, taking care of
+    changing the name from source to target, if both are compatible (same number of
+    ``*``).
+
+    For example::
+      filename = "<new_name>.*.nc"
+      model = "fesom"
+      filetype = "restart_in"
+      config["fesom"]["restart_in_sources_wild_card"] = "<old_name>.*.nc"
+      config["fesom"]["restart_in_sources"]["<restart_file>_glob_1"] = "<old_name>.temp.nc"
+
+    Then the outcome will be substitutting ``temp`` into the ``*`` of ``filename``::
+      target_name = "<new_name>.temp.nc"
+
+    Note:: MA: This is very poorly generalized and too specific to the current use.
+    I volunteer myself to clean the ``filelists.py``, and make this method more
+    general.
+
+    Parameters
+    ----------
+    config : dict
+        The experiment configuration
+    model : str
+        Target component/model
+    filename : str
+        Target path, with or without wildcards
+    filetype : str
+        Target file type
+    descr : str
+        Key pointing at the specific file, which target name needs to be constructed
+
+    Returns
+    -------
+    targer_name : str
+        Basename of the specific target file associated to the ``descr`` key
+
+    Raises
+    ------
+    user_error : esm_parser.user_error
+        If source and target wildcard patterns do not match (different number of ``*``
+        in the patterns), raises a user friendly error
+    """
 
     source_filename = os.path.basename(config[model][filetype + "_sources"][descr])
     target_filename = os.path.basename(filename)

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -331,42 +331,20 @@ def target_subfolders(config):
                                 descr
                             ] = filename.replace("*", source_filename)
                         elif "/" in filename:
+                            # Return the correct target name
+                            target_name = get_target_name_from_wild_card(
+                                config, model, filename, filetype, descr
+                            )
                             config[model][filetype + "_targets"][descr] = (
                                 "/".join(filename.split("/")[:-1])
                                 + "/"
-                                + source_filename.split("/")[-1]
+                                + target_name
                             )
                         else:
-                            # Get the general description of the filename
-                            gen_descr = descr.split("_glob_")[0]
-                            # Load the wild cards from source and target and split them
-                            # at the *
-                            wild_card_source_all = config[model][
-                                f"{filetype}_sources_wild_card"
-                            ]
-                            wild_card_source = wild_card_source_all[gen_descr].split(
-                                "*"
-                            )
-                            wild_card_target = filename.split("*")
-                            # Check for syntax mistakes
-                            if len(wild_card_target) != len(wild_card_source):
-                                esm_parser.user_error(
-                                    "Wild card",
-                                    (
-                                        "The wild card pattern of the source "
-                                        + f"{wild_card_source} does not match with the "
-                                        + f"target {wild_card_target}. Make sure the "
-                                        + f"that the number of * are the same in both "
-                                        + f"sources and targets."
-                                    ),
-                                )
-                            # Loop through the pieces of the wild cards to create
-                            # the correct target name by substituting in the source
-                            # name
-                            target_name = source_filename
-                            for wcs, wct in zip(wild_card_source, wild_card_target):
-                                target_name = target_name.replace(wcs, wct)
                             # Return the correct target name
+                            target_name = get_target_name_from_wild_card(
+                                config, model, filename, filetype, descr
+                            )
                             config[model][filetype + "_targets"][descr] = target_name
                     elif filename.endswith("/"):
                         source_filename = os.path.basename(
@@ -377,6 +355,44 @@ def target_subfolders(config):
                         )
 
     return config
+
+
+def get_target_name_from_wild_card(config, model, filename, filetype, descr):
+
+    source_filename = os.path.basename(config[model][filetype + "_sources"][descr])
+    target_filename = os.path.basename(filename)
+
+    # Get the general description of the filename
+    gen_descr = descr.split("_glob_")[0]
+    # Load the wild cards from source and target and split them
+    # at the *
+    wild_card_source_all = config[model][
+        f"{filetype}_sources_wild_card"
+    ]
+    wild_card_source = wild_card_source_all[gen_descr].split(
+        "*"
+    )
+    wild_card_target = target_filename.split("*")
+    # Check for syntax mistakes
+    if len(wild_card_target) != len(wild_card_source):
+        esm_parser.user_error(
+            "Wild card",
+            (
+                "The wild card pattern of the source "
+                + f"{wild_card_source} does not match with the "
+                + f"target {wild_card_target}. Make sure the "
+                + f"that the number of * are the same in both "
+                + f"sources and targets."
+            ),
+        )
+    # Loop through the pieces of the wild cards to create
+    # the correct target name by substituting in the source
+    # name
+    target_name = source_filename
+    for wcs, wct in zip(wild_card_source, wild_card_target):
+        target_name = target_name.replace(wcs, wct)
+
+    return target_name
 
 
 def complete_restart_in(config):

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
@@ -11,6 +11,17 @@ computer:
     batch_system: pbs
     c++_lib: cray-c++-rts
     cc: cc
+    check_error:
+        Exiting due to errors. Application aborted:
+            file: /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_@jobid@.log
+            frequency: 30
+            message: 'PBS ERROR: pbs ended with an error, exiting.'
+            method: kill
+        'exit signals: Killed':
+            file: /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_@jobid@.log
+            frequency: 30
+            message: 'PBS ERROR: pbs ended with an error, exiting.'
+            method: kill
     cxx: CC
     debug_info:
         loaded_from_file:
@@ -78,7 +89,7 @@ computer:
     nodes_flag: -l nodes=@nodes@
     notification_flag: ''
     operating_system: SLES
-    output_flags: -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_$PBS_JOBID.log
     output_path: /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/
     partition: iccp
     partition_cpn: 40
@@ -103,11 +114,11 @@ computer:
     sh_interpreter: /bin/sh
     submit: qsub
     submitted: false
-    thisrun_logfile: /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_$PBS_JOBID.log
     threads_per_core: 1
     time_flag: -l walltime=00:30:00
     useMPI: cray_mpich
-    write_execution_log: '| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101.log'
+    write_execution_log: '| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_$PBS_JOBID.log'
 debug_info:
     loaded_from_file:
     - /mnt/lustre/home/awiiccp/esm_tools/configs/.//setups/awicm3/awicm3.yaml
@@ -914,7 +925,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 139556
+    jobid: 283084
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1902,6 +1913,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1932,6 +1944,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2899,6 +2912,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2908,6 +2922,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
@@ -2,7 +2,7 @@
 #PBS -q iccp
 #PBS -l walltime=00:30:00
 #PBS -l nodes=1
-#PBS -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101.log
+#PBS -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101_$PBS_JOBID.log
 #PBS -N awicm3-frontiers-TCO159L91-CORE2_initial
 #PBS -A iccp
 
@@ -62,7 +62,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 336115.sdb - start >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 343620.sdb - start >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
 
 cd /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/run_20000101-20000101/work/
 time aprun -n 1 -N 1 -d 1 env OMP_NUM_THREADS=1 env PMI_LABEL_ERROUT_FORMAT="[DATAPROCESS]%l:" /mnt/lustre/home/awiiccp/esm_tools/configs/.//setups/awicm3/postprocessing.sh /scratch/awi/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/outdata/oifs/ 20000101 2>&1 &

--- a/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
@@ -11,6 +11,17 @@ computer:
     batch_system: pbs
     c++_lib: cray-c++-rts
     cc: cc
+    check_error:
+        Exiting due to errors. Application aborted:
+            file: /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_@jobid@.log
+            frequency: 30
+            message: 'PBS ERROR: pbs ended with an error, exiting.'
+            method: kill
+        'exit signals: Killed':
+            file: /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_@jobid@.log
+            frequency: 30
+            message: 'PBS ERROR: pbs ended with an error, exiting.'
+            method: kill
     cxx: CC
     debug_info:
         loaded_from_file:
@@ -78,7 +89,7 @@ computer:
     nodes_flag: -l nodes=@nodes@
     notification_flag: ''
     operating_system: SLES
-    output_flags: -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_$PBS_JOBID.log
     output_path: /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/
     partition: iccp
     partition_cpn: 40
@@ -103,11 +114,11 @@ computer:
     sh_interpreter: /bin/sh
     submit: qsub
     submitted: false
-    thisrun_logfile: /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_$PBS_JOBID.log
     threads_per_core: 1
     time_flag: -l walltime=00:20:00
     useMPI: cray_mpich
-    write_execution_log: '| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101.log'
+    write_execution_log: '| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_$PBS_JOBID.log'
 debug_info:
     loaded_from_file:
     - /mnt/lustre/home/awiiccp/esm_tools/configs/.//setups/awicm3/awicm3.yaml
@@ -914,7 +925,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 139165
+    jobid: 282674
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1880,6 +1891,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1910,6 +1922,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2877,6 +2890,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2886,6 +2900,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/aleph/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
@@ -2,7 +2,7 @@
 #PBS -q iccp
 #PBS -l walltime=00:20:00
 #PBS -l nodes=6
-#PBS -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101.log
+#PBS -j oe -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_$PBS_JOBID.log
 #PBS -N awicm3-v3.0-TCO159L91-CORE2_initial
 #PBS -A iccp
 
@@ -62,12 +62,13 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 139165 - start >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 282674 - start >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 cd /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/run_20000101-20000101/work/
+qalter $PBS_JOBID -o /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_$PBS_JOBID.log
 time aprun -n 40 -N 40 -d 1 env OMP_NUM_THREADS=1 env PMI_LABEL_ERROUT_FORMAT="[FESOM]%l:" ./fesom \
          : -n 80 -N 20 -d 2 env OMP_NUM_THREADS=2 env PMI_LABEL_ERROUT_FORMAT="[OIFS]%l:" ./oifs -v ecmwf -e awi3 \
-         : -n 1 -N 1 -d 40 env OMP_NUM_THREADS=40 env PMI_LABEL_ERROUT_FORMAT="[RNFMAP]%l:" ./rnfma  2>&1| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101.log &
+         : -n 1 -N 1 -d 40 env OMP_NUM_THREADS=40 env PMI_LABEL_ERROUT_FORMAT="[RNFMAP]%l:" ./rnfma  2>&1| tee /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_execution_20000101-20000101_$PBS_JOBID.log &
 
 # Call to esm_runscript to start subjobs:
 # ['tidy']
@@ -76,6 +77,6 @@ process=$!
 cd /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/scripts/
 esm_runscripts awicm3-v3.0-TCO159L91-CORE2_initial.yaml -e awicm3-v3.0-TCO159L91-CORE2_initial -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 139165 - done >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 282674 - done >> /scratch/awi/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm1-CMIP6-initial-monthly/config/awicm1-CMIP6-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm1-CMIP6-initial-monthly/config/awicm1-CMIP6-initial-monthly_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=awicm1-CMIP6-initial-monthly
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log --error=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log --error=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log
     output_path: /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log
     threads_per_core: 1
     time_flag: --time=01:00:00
     useMPI: intelmpi
@@ -2099,7 +2099,7 @@ general:
     - restart_in
     initial_date: '1850-01-01T00:00:00'
     inspect: null
-    jobid: 19285
+    jobid: 13387
     jobtype: prepcompute
     last_run_datestamp: 18491201-18491231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm1-CMIP6-initial-monthly/scripts/awicm1-CMIP6-initial-monthly_compute_18500101-18500131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm1-CMIP6-initial-monthly/scripts/awicm1-CMIP6-initial-monthly_compute_18500101-18500131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=01:00:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131.log --error=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131_%j.log --error=/work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131_%j.log
 #SBATCH --job-name=awicm1-CMIP6-initial-monthly
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -73,7 +73,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 19285 - start >> /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 13387 - start >> /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
 
 cd /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/run_18500101-18500131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -85,6 +85,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/scripts/
 esm_runscripts awicm1-CMIP6-initial-monthly.yaml -e awicm1-CMIP6-initial-monthly -t observe_compute -p ${process} -s 18500101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 19285 - done >> /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 13387 - done >> /work/ab0995/a270152/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm2-initial-monthly/config/awicm2-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm2-initial-monthly/config/awicm2-initial-monthly_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=awicm2-initial-monthly
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log --error=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log --error=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log
     output_path: /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log
     threads_per_core: 1
     time_flag: --time=00:15:00
     useMPI: intelmpi
@@ -1658,7 +1658,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 28238
+    jobid: 30263
     jobtype: prepcompute
     last_run_datestamp: 19991201-19991231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm2-initial-monthly/scripts/awicm2-initial-monthly_compute_20000101-20000131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm/awicm2-initial-monthly/scripts/awicm2-initial-monthly_compute_20000101-20000131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:15:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131.log --error=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131_%j.log --error=/work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131_%j.log
 #SBATCH --job-name=awicm2-initial-monthly
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -74,7 +74,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 28238 - start >> /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 30263 - start >> /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
 
 cd /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/run_20000101-20000131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -86,6 +86,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/scripts/
 esm_runscripts awicm2-initial-monthly.yaml -e awicm2-initial-monthly -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 28238 - done >> /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 30263 - done >> /work/ab0995/a270152/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
@@ -26,7 +26,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -113,7 +113,7 @@ computer:
     name_flag: --job-name=awicm3-frontiers-TCO159L91-CORE2_initial
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     output_path: /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -144,7 +144,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     threads_per_core: 1
     time_flag: --time=00:30:00
     unset_vars:
@@ -963,7 +963,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 36439
+    jobid: 20970
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1939,6 +1939,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1969,6 +1970,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2936,6 +2938,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2945,6 +2948,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:30:00
 #SBATCH --nodes=1
-#SBATCH --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101_%j.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101_%j.log
 #SBATCH --job-name=awicm3-frontiers-TCO159L91-CORE2_initial
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -92,7 +92,7 @@ unset SLURM_ARBITRARY_NODELIST
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 33864160 - start >> /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 34370034 - start >> /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
 
 cd /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/run_20000101-20000101/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=none /mnt/lustre01/pf/a/a270152/esm_tools/configs/.//setups/awicm3/postprocessing.sh /work/ab0995/a270152/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/outdata/oifs/ 20000101 2>&1 &

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
@@ -26,7 +26,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -113,7 +113,7 @@ computer:
     name_flag: --job-name=awicm3-v3.0-TCO159L91-CORE2_initial
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     output_path: /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -144,7 +144,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     threads_per_core: 1
     time_flag: --time=00:20:00
     unset_vars:
@@ -963,7 +963,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 9817
+    jobid: 38504
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1917,6 +1917,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1947,6 +1948,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2914,6 +2916,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2923,6 +2926,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:20:00
 #SBATCH --nodes=13
-#SBATCH --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_%j.log --error=/work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_%j.log
 #SBATCH --job-name=awicm3-v3.0-TCO159L91-CORE2_initial
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -92,7 +92,7 @@ unset SLURM_ARBITRARY_NODELIST
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 9817 - start >> /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 38504 - start >> /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 cd /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/run_20000101-20000101/work/
 
@@ -132,6 +132,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/scripts/
 esm_runscripts awicm3-v3.0-TCO159L91-CORE2_initial.yaml -e awicm3-v3.0-TCO159L91-CORE2_initial -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 9817 - done >> /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 38504 - done >> /work/ab0995/a270152/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/PI_ctrl_awiesm-2.1-wiso/config/PI_ctrl_awiesm-2.1-wiso_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/PI_ctrl_awiesm-2.1-wiso/config/PI_ctrl_awiesm-2.1-wiso_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=PI_ctrl_awiesm-2.1-wiso
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=01:00:00
     useMPI: intelmpi
@@ -1972,7 +1972,7 @@ general:
     initial_date: '2001-01-01T00:00:00'
     inspect: null
     jP: /work/ba1066/a270061/mesh_CORE2_finaltopo_mean/tarfilesT63/input/jsbach/jsbach_T63CORE2_11tiles_5layers_1850.nc
-    jobid: 39619
+    jobid: 26985
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/PI_ctrl_awiesm-2.1-wiso/scripts/PI_ctrl_awiesm-2.1-wiso_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/PI_ctrl_awiesm-2.1-wiso/scripts/PI_ctrl_awiesm-2.1-wiso_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=01:00:00
 #SBATCH --ntasks=360
-#SBATCH --output=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131_%j.log
 #SBATCH --job-name=PI_ctrl_awiesm-2.1-wiso
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -75,7 +75,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 39619 - start >> /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 26985 - start >> /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
 
 cd /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -87,6 +87,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/scripts/
 esm_runscripts PI_ctrl_awiesm-2.1-wiso.yaml -e PI_ctrl_awiesm-2.1-wiso -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 39619 - done >> /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 26985 - done >> /work/ab0995/a270152/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/config/all_awiesm-2.1-recom_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/config/all_awiesm-2.1-recom_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=all_awiesm-2.1-recom
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,9 +137,9 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
-    time_flag: --time=00:29:00
+    time_flag: --time=01:00:00
     useMPI: intelmpi
     use_hyperthreading: false
 debug_info:
@@ -1641,7 +1641,7 @@ fesom:
             geometry:
                 force_rotation: true
             paths:
-                ClimateDataPath: /pf/a/a270108/fesom2_recom_config/input-for-awiesm/
+                ClimateDataPath: /home/a/a270105/initial_files/
                 MeshPath: /pf/a/a270064/bb1029/AWIESM2.1-EXP/mesh_core2/
                 ResultPath: /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/work/
             restart_log:
@@ -1772,8 +1772,8 @@ fesom:
     with_part_format: false
     yearnew: 2001
 general:
-    CDP: /pf/a/a270108/fesom2_recom_config/input-for-awiesm/
-    RDP: /pf/a/a270108/fesom2_recom_config/input-for-awiesm/
+    CDP: /home/a/a270105/initial_files/
+    RDP: /home/a/a270105/initial_files/
     account: ab0995
     additional_files: []
     all_filetypes:
@@ -1828,7 +1828,7 @@ general:
         update_filetypes: []
         use_venv: false
         verbose: false
-    compute_time: 00:29:00
+    compute_time: 01:00:00
     coupled_setup: true
     coupler: oasis3mct
     coupler_config_dir: /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/config/oasis3mct/
@@ -1957,7 +1957,7 @@ general:
     initial_date: '2001-01-01T00:00:00'
     inspect: null
     jP: /pf/a/a270064/bb1029/AWIESM2.1-EXP/mesh_core2/tarfilesT63/input/jsbach/jsbach_T63CORE2_11tiles_5layers_1850.nc
-    jobid: 46017
+    jobid: 27620
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false
@@ -3352,7 +3352,7 @@ recom:
             paco2_flux_param: {}
             pavariables:
                 DIC_PI: false
-                REcoMDataPath: /pf/a/a270108/fesom2_recom_config/input-for-awiesm/
+                REcoMDataPath: /home/a/a270105/initial_files/
                 benthos_num: 8
                 bgc_num: 31
                 bottflx_num: 8

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/scripts/all_awiesm-2.1-recom_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/scripts/all_awiesm-2.1-recom_compute_20010101-20010131.run
@@ -1,8 +1,8 @@
 #!/bin/bash
 #SBATCH --partition=compute
-#SBATCH --time=00:29:00
+#SBATCH --time=01:00:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131_%j.log
 #SBATCH --job-name=all_awiesm-2.1-recom
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -75,7 +75,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 46017 - start >> /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 27620 - start >> /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
 
 cd /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -87,6 +87,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/scripts/
 esm_runscripts all_awiesm-2.1-recom.yaml -e all_awiesm-2.1-recom -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 46017 - done >> /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 27620 - done >> /work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.config
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.config
@@ -16,7 +16,7 @@
 
 &paths
     meshpath = '/pf/a/a270064/bb1029/AWIESM2.1-EXP/mesh_core2/'
-    climatedatapath = '/pf/a/a270108/fesom2_recom_config/input-for-awiesm/'
+    climatedatapath = '/home/a/a270105/initial_files/'
     resultpath = '/work/ab0995/a270152/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/work/'
 /
 

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.oce
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.oce
@@ -73,11 +73,12 @@
 &oce_init3d
     n_ic3d = 8
     idlist = 1019, 1022, 1018, 1003, 1002, 1001, 1, 0
-    filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_fesom2.nc',
-               'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_fix_z_Fillvalue.nc',
-               'GLODAPv2.2016b.TCO2_fesom2_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc',
+    filelist = 'fe_pisces_opa_eq_init_3D_changed_name.nc', 'woa18_all_o00_01_mmol_fesom2.nc',
+               'woa13_all_i00_01_fesom2.nc', 'GLODAPv2.2016b.TAlk_fesom2_mmol_fix_z_Fillvalue.nc',
+               'GLODAPv2.2016b.TCO2_fesom2_mmol_fix_z_Fillvalue.nc', 'woa13_all_n00_01_fesom2.nc',
                'phc3.0_winter.nc', 'phc3.0_winter.nc'
-    varlist = 'Fe', 'o_an', 'i_an', 'TAlk', 'TCO2', 'n_an', 'salt', 'temp'
+    varlist = 'Fe', 'oxygen_mmol', 'i_an', 'TAlk_mmol', 'TCO2_mmol', 'n_an',
+              'salt', 'temp'
     t_insitu = .true.
 /
 

--- a/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.recom
+++ b/src/esm_tests/resources/last_tested/mistral/run/awiesm/all_awiesm-2.1-recom/work/namelist.recom
@@ -20,7 +20,7 @@
     use_fe2n = .true.
     use_photodamage = .true.
     hetrespflux_plus = .true.
-    recomdatapath = '/pf/a/a270108/fesom2_recom_config/input-for-awiesm/'
+    recomdatapath = '/home/a/a270105/initial_files/'
     restore_alkalinity = .true.
     nitrogenss = .false.
     useaeoliann = .false.
@@ -226,5 +226,5 @@
     warp_file = 'warptracers.nc'
     lambda_14 = 3.8561e-12
     delta_co2_13 = -6.61
-    big_delta_co2_14(1:3) = '0.!!', '0.!!', '0.!!'
+    big_delta_co2_14(1:3) = 0.0, 0.0, 0.0
 /

--- a/src/esm_tests/resources/last_tested/mistral/run/echam/echam6.3.04p1-initial-monthly/config/echam6.3.04p1-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/echam/echam6.3.04p1-initial-monthly/config/echam6.3.04p1-initial-monthly_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=echam6.3.04p1-initial-monthly
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log --error=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log --error=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log
     output_path: /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log
     threads_per_core: 1
     time_flag: --time=00:15:00
     useMPI: intelmpi
@@ -1297,7 +1297,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 18981
+    jobid: 49017
     jobtype: prepcompute
     last_run_datestamp: 19991201-19991231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/echam/echam6.3.04p1-initial-monthly/scripts/echam6.3.04p1-initial-monthly_compute_20000101-20000131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/echam/echam6.3.04p1-initial-monthly/scripts/echam6.3.04p1-initial-monthly_compute_20000101-20000131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:15:00
 #SBATCH --ntasks=576
-#SBATCH --output=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131.log --error=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131_%j.log --error=/work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131_%j.log
 #SBATCH --job-name=echam6.3.04p1-initial-monthly
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -72,7 +72,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 18981 - start >> /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 49017 - start >> /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
 
 cd /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/run_20000101-20000131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -84,6 +84,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/scripts/
 esm_runscripts echam6.3.04p1-initial-monthly.yaml -e echam6.3.04p1-initial-monthly -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 18981 - done >> /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 49017 - done >> /work/ab0995/a270152/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.0-initial-monthly/config/fesom2.0-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.0-initial-monthly/config/fesom2.0-initial-monthly_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=fesom2.0-initial-monthly
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=00:08:00
     useMPI: intelmpi
@@ -671,7 +671,7 @@ general:
     - restart_in
     initial_date: '2001-01-01T00:00:00'
     inspect: null
-    jobid: 49057
+    jobid: 37766
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.0-initial-monthly/scripts/fesom2.0-initial-monthly_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.0-initial-monthly/scripts/fesom2.0-initial-monthly_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:08:00
 #SBATCH --ntasks=288
-#SBATCH --output=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131_%j.log
 #SBATCH --job-name=fesom2.0-initial-monthly
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -74,7 +74,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 49057 - start >> /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 37766 - start >> /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
 
 cd /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -86,6 +86,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/scripts/
 esm_runscripts fesom2.0-initial-monthly.yaml -e fesom2.0-initial-monthly -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 49057 - done >> /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 37766 - done >> /work/ab0995/a270152/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
 
 wait

--- a/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.1-initial-monthly/config/fesom2.1-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.1-initial-monthly/config/fesom2.1-initial-monthly_finished_config.yaml
@@ -20,7 +20,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -106,7 +106,7 @@ computer:
     name_flag: --job-name=fesom2.1-initial-monthly
     nodes_flag: --nodes=@nodes@
     notification_flag: --mail-type=NONE
-    output_flags: --output=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -137,7 +137,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=00:08:00
     useMPI: intelmpi
@@ -776,7 +776,7 @@ general:
     - restart_in
     initial_date: '2001-01-01T00:00:00'
     inspect: null
-    jobid: 48715
+    jobid: 33766
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.1-initial-monthly/scripts/fesom2.1-initial-monthly_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/mistral/run/fesom/fesom2.1-initial-monthly/scripts/fesom2.1-initial-monthly_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=compute
 #SBATCH --time=00:08:00
 #SBATCH --ntasks=288
-#SBATCH --output=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131.log
+#SBATCH --output=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131_%j.log --error=/work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131_%j.log
 #SBATCH --job-name=fesom2.1-initial-monthly
 #SBATCH --account=ab0995
 #SBATCH --mail-type=NONE
@@ -74,7 +74,7 @@ export ENVIRONMENT_SET_BY_ESMTOOLS=TRUE
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 48715 - start >> /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 33766 - start >> /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
 
 cd /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -86,6 +86,6 @@ process=$!
 cd /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/scripts/
 esm_runscripts fesom2.1-initial-monthly.yaml -e fesom2.1-initial-monthly -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 48715 - done >> /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 33766 - done >> /work/ab0995/a270152/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm1-CMIP6-initial-monthly/config/awicm1-CMIP6-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm1-CMIP6-initial-monthly/config/awicm1-CMIP6-initial-monthly_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log --error=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log --error=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log
     output_path: /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_@jobtype@_18500101-18500131_%j.log
     threads_per_core: 1
     time_flag: --time=01:00:00
     unset_vars:
@@ -2084,7 +2084,7 @@ general:
     - restart_in
     initial_date: '1850-01-01T00:00:00'
     inspect: null
-    jobid: 43771
+    jobid: 10427
     jobtype: prepcompute
     last_run_datestamp: 18491201-18491231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm1-CMIP6-initial-monthly/scripts/awicm1-CMIP6-initial-monthly_compute_18500101-18500131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm1-CMIP6-initial-monthly/scripts/awicm1-CMIP6-initial-monthly_compute_18500101-18500131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=01:00:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131.log --error=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131_%j.log --error=/work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log/awicm1-CMIP6-initial-monthly_awicm_compute_18500101-18500131_%j.log
 #SBATCH --job-name=awicm1-CMIP6-initial-monthly
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -58,7 +58,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 43771 - start >> /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 10427 - start >> /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
 
 cd /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/run_18500101-18500131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -70,6 +70,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/scripts/
 esm_runscripts awicm1-CMIP6-initial-monthly.yaml -e awicm1-CMIP6-initial-monthly -t observe_compute -p ${process} -s 18500101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 43771 - done >> /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1850-01-01T00:00:00 10427 - done >> /work/ollie/mandresm/testing//run/awicm//awicm1-CMIP6-initial-monthly/log//awicm1-CMIP6-initial-monthly_awicm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm2-initial-monthly/config/awicm2-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm2-initial-monthly/config/awicm2-initial-monthly_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log --error=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log --error=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log
     output_path: /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_@jobtype@_20000101-20000131_%j.log
     threads_per_core: 1
     time_flag: --time=00:15:00
     unset_vars:
@@ -1643,7 +1643,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 43402
+    jobid: 9255
     jobtype: prepcompute
     last_run_datestamp: 19991201-19991231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm2-initial-monthly/scripts/awicm2-initial-monthly_compute_20000101-20000131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm/awicm2-initial-monthly/scripts/awicm2-initial-monthly_compute_20000101-20000131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:15:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131.log --error=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131_%j.log --error=/work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log/awicm2-initial-monthly_awicm_compute_20000101-20000131_%j.log
 #SBATCH --job-name=awicm2-initial-monthly
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -59,7 +59,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 43402 - start >> /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 9255 - start >> /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
 
 cd /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/run_20000101-20000131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -71,6 +71,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/scripts/
 esm_runscripts awicm2-initial-monthly.yaml -e awicm2-initial-monthly -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 43402 - done >> /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 9255 - done >> /work/ollie/mandresm/testing//run/awicm//awicm2-initial-monthly/log//awicm2-initial-monthly_awicm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/config/awicm3-frontiers-TCO159L91-CORE2_initial_finished_config.yaml
@@ -25,7 +25,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -101,7 +101,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     output_path: /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -130,7 +130,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     threads_per_core: 1
     time_flag: --time=00:30:00
     unset_vars:
@@ -947,7 +947,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 167653
+    jobid: 5006
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1923,6 +1923,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1953,6 +1954,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2920,6 +2922,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2929,6 +2932,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-frontiers-TCO159L91-CORE2_initial/scripts/awicm3-frontiers-TCO159L91-CORE2_initial_postprocessing_20000101-20000101.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=smp
 #SBATCH --time=00:30:00
 #SBATCH --nodes=1
-#SBATCH --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101_%j.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log/awicm3-frontiers-TCO159L91-CORE2_initial_awicm3_postprocessing_20000101-20000101_%j.log
 #SBATCH --job-name=awicm3-frontiers-TCO159L91-CORE2_initial
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -80,7 +80,7 @@ unset SLURM_ARBITRARY_NODELIST
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 13448829 - start >> /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : postprocessing_oifs 1 2000-01-01T00:00:00 13541246 - start >> /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/log//awicm3-frontiers-TCO159L91-CORE2_initial_awicm3.log
 
 cd /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/run_20000101-20000101/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=none /home/ollie/mandresm/esm_tools/configs/.//setups/awicm3/postprocessing.sh /work/ollie/mandresm/testing//run/awicm3//awicm3-frontiers-TCO159L91-CORE2_initial/outdata/oifs/ 20000101 2>&1 &

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/config/awicm3-v3.0-TCO159L91-CORE2_initial_finished_config.yaml
@@ -25,7 +25,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -101,7 +101,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     output_path: /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -130,7 +130,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_@jobtype@_20000101-20000101_%j.log
     threads_per_core: 1
     time_flag: --time=00:20:00
     unset_vars:
@@ -947,7 +947,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 39861
+    jobid: 3691
     jobtype: prepcompute
     last_run_datestamp: 19991231-19991231
     last_run_in_chunk: false
@@ -1901,6 +1901,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - LAPACK_LIB='-mkl=sequential'
@@ -1931,6 +1932,7 @@ oifs:
                 - OIFS_CC=$CC
                 - OIFS_CFLAGS="-fp-model precise -O1 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0"
                 - OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - ESM_NETCDF_C_DIR=$NETCDFROOT
@@ -2898,6 +2900,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             glogin:
                 add_export_vars:
                 - OIFS_FFIXED=""
@@ -2907,6 +2910,7 @@ oifs:
                 - OMP_STACKSIZE=128M
                 add_module_actions:
                 - source $I_MPI_ROOT/intel64/bin/mpivars.sh release_mt
+                iolibraries: geomar_libs
             juwels:
                 add_export_vars:
                 - OIFS_FFIXED=""

--- a/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awicm3/awicm3-v3.0-TCO159L91-CORE2_initial/scripts/awicm3-v3.0-TCO159L91-CORE2_initial_compute_20000101-20000101.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:20:00
 #SBATCH --nodes=6
-#SBATCH --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_%j.log --error=/work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log/awicm3-v3.0-TCO159L91-CORE2_initial_awicm3_compute_20000101-20000101_%j.log
 #SBATCH --job-name=awicm3-v3.0-TCO159L91-CORE2_initial
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -80,7 +80,7 @@ unset SLURM_ARBITRARY_NODELIST
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 39861 - start >> /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 3691 - start >> /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 cd /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/run_20000101-20000101/work/
 
@@ -120,6 +120,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/scripts/
 esm_runscripts awicm3-v3.0-TCO159L91-CORE2_initial.yaml -e awicm3-v3.0-TCO159L91-CORE2_initial -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 39861 - done >> /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 3691 - done >> /work/ollie/mandresm/testing//run/awicm3//awicm3-v3.0-TCO159L91-CORE2_initial/log//awicm3-v3.0-TCO159L91-CORE2_initial_awicm3.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/awiesm/PI_ctrl_awiesm-2.1-wiso/config/PI_ctrl_awiesm-2.1-wiso_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awiesm/PI_ctrl_awiesm-2.1-wiso/config/PI_ctrl_awiesm-2.1-wiso_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=01:00:00
     unset_vars:
@@ -1945,7 +1945,7 @@ general:
     initial_date: '2001-01-01T00:00:00'
     inspect: null
     jP: /work/ollie/dsidoren/input/fesom2.0/meshes/mesh_CORE2_finaltopo_mean/tarfilesT63/input/jsbach/jsbach_T63CORE2_11tiles_5layers_1850.nc
-    jobid: 42407
+    jobid: 7634
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/awiesm/PI_ctrl_awiesm-2.1-wiso/scripts/PI_ctrl_awiesm-2.1-wiso_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awiesm/PI_ctrl_awiesm-2.1-wiso/scripts/PI_ctrl_awiesm-2.1-wiso_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=01:00:00
 #SBATCH --ntasks=360
-#SBATCH --output=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log/PI_ctrl_awiesm-2.1-wiso_awiesm_compute_20010101-20010131_%j.log
 #SBATCH --job-name=PI_ctrl_awiesm-2.1-wiso
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -59,7 +59,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 42407 - start >> /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 7634 - start >> /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
 
 cd /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -71,6 +71,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/scripts/
 esm_runscripts PI_ctrl_awiesm-2.1-wiso.yaml -e PI_ctrl_awiesm-2.1-wiso -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 42407 - done >> /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 7634 - done >> /work/ollie/mandresm/testing//run/awiesm//PI_ctrl_awiesm-2.1-wiso/log//PI_ctrl_awiesm-2.1-wiso_awiesm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/awiesm/all_awiesm-2.1-recom/config/all_awiesm-2.1-recom_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/awiesm/all_awiesm-2.1-recom/config/all_awiesm-2.1-recom_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,9 +123,9 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
-    time_flag: --time=00:29:00
+    time_flag: --time=01:00:00
     unset_vars:
     - SLURM_MEM_PER_NODE
     - SLURM_MEM_PER_CPU
@@ -1801,7 +1801,7 @@ general:
         update_filetypes: []
         use_venv: false
         verbose: false
-    compute_time: 00:29:00
+    compute_time: 01:00:00
     coupled_setup: true
     coupler: oasis3mct
     coupler_config_dir: /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/config/oasis3mct/
@@ -1930,7 +1930,7 @@ general:
     initial_date: '2001-01-01T00:00:00'
     inspect: null
     jP: /work/ollie/dsidoren/input/fesom2.0/meshes/mesh_CORE2_finaltopo_mean/tarfilesT63/input/jsbach/jsbach_T63CORE2_11tiles_5layers_1850.nc
-    jobid: 175700
+    jobid: 8126
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/awiesm/all_awiesm-2.1-recom/scripts/all_awiesm-2.1-recom_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/awiesm/all_awiesm-2.1-recom/scripts/all_awiesm-2.1-recom_compute_20010101-20010131.run
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 #SBATCH --partition=mpp
-#SBATCH --time=00:29:00
+#SBATCH --time=01:00:00
 #SBATCH --ntasks=864
-#SBATCH --output=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log/all_awiesm-2.1-recom_awiesm_compute_20010101-20010131_%j.log
 #SBATCH --job-name=all_awiesm-2.1-recom
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -59,7 +59,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 175700 - start >> /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 8126 - start >> /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
 
 cd /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -71,6 +71,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/scripts/
 esm_runscripts all_awiesm-2.1-recom.yaml -e all_awiesm-2.1-recom -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 175700 - done >> /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 8126 - done >> /work/ollie/mandresm/testing//run/awiesm//all_awiesm-2.1-recom/log//all_awiesm-2.1-recom_awiesm.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/echam/echam6.3.04p1-initial-monthly/config/echam6.3.04p1-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/echam/echam6.3.04p1-initial-monthly/config/echam6.3.04p1-initial-monthly_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log --error=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log --error=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log
     output_path: /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_@jobtype@_20000101-20000131_%j.log
     threads_per_core: 1
     time_flag: --time=00:15:00
     unset_vars:
@@ -1285,7 +1285,7 @@ general:
     - restart_in
     initial_date: '2000-01-01T00:00:00'
     inspect: null
-    jobid: 41641
+    jobid: 6795
     jobtype: prepcompute
     last_run_datestamp: 19991201-19991231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/echam/echam6.3.04p1-initial-monthly/scripts/echam6.3.04p1-initial-monthly_compute_20000101-20000131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/echam/echam6.3.04p1-initial-monthly/scripts/echam6.3.04p1-initial-monthly_compute_20000101-20000131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:15:00
 #SBATCH --ntasks=576
-#SBATCH --output=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131.log --error=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131_%j.log --error=/work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log/echam6.3.04p1-initial-monthly_echam_compute_20000101-20000131_%j.log
 #SBATCH --job-name=echam6.3.04p1-initial-monthly
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -57,7 +57,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 41641 - start >> /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 6795 - start >> /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
 
 cd /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/run_20000101-20000131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -69,6 +69,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/scripts/
 esm_runscripts echam6.3.04p1-initial-monthly.yaml -e echam6.3.04p1-initial-monthly -t observe_compute -p ${process} -s 20000101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 41641 - done >> /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2000-01-01T00:00:00 6795 - done >> /work/ollie/mandresm/testing//run/echam//echam6.3.04p1-initial-monthly/log//echam6.3.04p1-initial-monthly_echam.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom-recom/fesom-recom1.4-initial-daily/config/fesom-recom1.4-initial-daily_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom-recom/fesom-recom1.4-initial-daily/config/fesom-recom1.4-initial-daily_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101.log --error=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101_%j.log --error=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101_%j.log
     output_path: /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_@jobtype@_19580101-19580101_%j.log
     threads_per_core: 1
     time_flag: --time=00:10:00
     unset_vars:
@@ -1261,7 +1261,7 @@ general:
     - restart_in
     initial_date: '1958-01-01T00:00:00'
     inspect: null
-    jobid: 39530
+    jobid: 3431
     jobtype: prepcompute
     last_run_datestamp: 19571231-19571231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom-recom/fesom-recom1.4-initial-daily/scripts/fesom-recom1.4-initial-daily_compute_19580101-19580101.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom-recom/fesom-recom1.4-initial-daily/scripts/fesom-recom1.4-initial-daily_compute_19580101-19580101.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:10:00
 #SBATCH --ntasks=288
-#SBATCH --output=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_compute_19580101-19580101.log --error=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_compute_19580101-19580101.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_compute_19580101-19580101_%j.log --error=/work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log/fesom-recom1.4-initial-daily_fesom-recom_compute_19580101-19580101_%j.log
 #SBATCH --job-name=fesom-recom1.4-initial-daily
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -58,7 +58,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1958-01-01T00:00:00 39530 - start >> /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log//fesom-recom1.4-initial-daily_fesom-recom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1958-01-01T00:00:00 3431 - start >> /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log//fesom-recom1.4-initial-daily_fesom-recom.log
 
 cd /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/run_19580101-19580101/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -70,6 +70,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/scripts/
 esm_runscripts fesom-recom1.4-initial-daily.yaml -e fesom-recom1.4-initial-daily -t observe_compute -p ${process} -s 19580101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 1958-01-01T00:00:00 39530 - done >> /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log//fesom-recom1.4-initial-daily_fesom-recom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 1958-01-01T00:00:00 3431 - done >> /work/ollie/mandresm/testing//run/fesom-recom//fesom-recom1.4-initial-daily/log//fesom-recom1.4-initial-daily_fesom-recom.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.0-initial-monthly/config/fesom2.0-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.0-initial-monthly/config/fesom2.0-initial-monthly_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=00:08:00
     unset_vars:
@@ -656,7 +656,7 @@ general:
     - restart_in
     initial_date: '2001-01-01T00:00:00'
     inspect: null
-    jobid: 41052
+    jobid: 6073
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.0-initial-monthly/scripts/fesom2.0-initial-monthly_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.0-initial-monthly/scripts/fesom2.0-initial-monthly_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:08:00
 #SBATCH --ntasks=288
-#SBATCH --output=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log/fesom2.0-initial-monthly_fesom_compute_20010101-20010131_%j.log
 #SBATCH --job-name=fesom2.0-initial-monthly
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -59,7 +59,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 41052 - start >> /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 6073 - start >> /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
 
 cd /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -71,6 +71,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/scripts/
 esm_runscripts fesom2.0-initial-monthly.yaml -e fesom2.0-initial-monthly -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 41052 - done >> /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 6073 - done >> /work/ollie/mandresm/testing//run/fesom//fesom2.0-initial-monthly/log//fesom2.0-initial-monthly_fesom.log
 
 wait

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.1-initial-monthly/config/fesom2.1-initial-monthly_finished_config.yaml
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.1-initial-monthly/config/fesom2.1-initial-monthly_finished_config.yaml
@@ -19,7 +19,7 @@ computer:
         'srun: error:':
             file: stdout
             frequency: 30
-            message: 'SLURM ERROR: slurm endet with an error, exiting.'
+            message: 'SLURM ERROR: slurm ended with an error, exiting.'
             method: kill
     choose_heterogeneous_parallelization: *id001
     config_files:
@@ -94,7 +94,7 @@ computer:
     nothing: much
     notification_flag: --mail-type=NONE
     operating_system: linux-centos
-    output_flags: --output=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    output_flags: --output=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     output_path: /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/
     overcommit_flag: ''
     overcommit_nodes: None
@@ -123,7 +123,7 @@ computer:
     submit: sbatch
     submitted: false
     tasks_flag: --ntasks=@tasks@
-    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131.log
+    thisrun_logfile: /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_@jobtype@_20010101-20010131_%j.log
     threads_per_core: 1
     time_flag: --time=00:08:00
     unset_vars:
@@ -761,7 +761,7 @@ general:
     - restart_in
     initial_date: '2001-01-01T00:00:00'
     inspect: null
-    jobid: 41362
+    jobid: 6495
     jobtype: prepcompute
     last_run_datestamp: 20001201-20001231
     last_run_in_chunk: false

--- a/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.1-initial-monthly/scripts/fesom2.1-initial-monthly_compute_20010101-20010131.run
+++ b/src/esm_tests/resources/last_tested/ollie/run/fesom/fesom2.1-initial-monthly/scripts/fesom2.1-initial-monthly_compute_20010101-20010131.run
@@ -2,7 +2,7 @@
 #SBATCH --partition=mpp
 #SBATCH --time=00:08:00
 #SBATCH --ntasks=288
-#SBATCH --output=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131.log
+#SBATCH --output=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131_%j.log --error=/work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log/fesom2.1-initial-monthly_fesom_compute_20010101-20010131_%j.log
 #SBATCH --job-name=fesom2.1-initial-monthly
 #SBATCH --mail-type=NONE
 #SBATCH --exclusive
@@ -59,7 +59,7 @@ unset SLURM_MEM_PER_CPU
 ulimit -s unlimited
 # 3...2...1...Liftoff!
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 41362 - start >> /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 6495 - start >> /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
 
 cd /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/run_20010101-20010131/work/
 time srun -l --kill-on-bad-exit=1 --cpu_bind=cores --multi-prog hostfile_srun 2>&1 &
@@ -71,6 +71,6 @@ process=$!
 cd /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/scripts/
 esm_runscripts fesom2.1-initial-monthly.yaml -e fesom2.1-initial-monthly -t observe_compute -p ${process} -s 20010101 -r 1 -v  --open-run
 
-echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 41362 - done >> /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
+echo $(date +"%a %b  %e %T %Y") : compute 1 2001-01-01T00:00:00 6495 - done >> /work/ollie/mandresm/testing//run/fesom//fesom2.1-initial-monthly/log//fesom2.1-initial-monthly_fesom.log
 
 wait

--- a/src/esm_tests/resources/state.yaml
+++ b/src/esm_tests/resources/state.yaml
@@ -26,7 +26,7 @@ awicm3:
         run: true
       mistral:
         compilation: true
-        run: false
+        run: true
       ollie:
         compilation: true
         run: true

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.1.2"
+__version__ = "6.1.3"


### PR DESCRIPTION
In the past, if `*` was included in the source of a file, and there was no `/` in the string (the `esle` in line 339 of `filelists.py`), renaming of the file during coyping/moving/linking was permitted, as long as the target name contained a pattern equivalent to the original one:
```
source: foo.*.nc
target: bar*.something_here.nc
```

The problem was that this was not contemplated for an instance in which `/` was included (lines below 333), so that the following case was not working:
```
source: fesom_ice_restart/foo.*.nc
target: fesom_ice_restart/bar*.something_here.nc
```

This PR puts the wildcarding-renaming operations in the `get_target_name_from_wild_card` method, and uses it for both cases, fixing the problem of renaming files inside folders that contain wildcards.

**TODO**
- [x] Test for all computers
- [x] Comment and write docstrings
- [x] Correct based on comments