### PR TITLE
fix/awiesm address changes

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -52,7 +52,7 @@ compile_infos:
             branch: "ice"
             clean_command: rm -rf src/echam/bin; rm -rf bin; make clean
             comp_command: ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps yaxt/tests/.deps; ./configure $configure_opts --with-fortran=intel INSTALL='/usr/bin/install -p'; make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin; cp  bin/echam6 src/echam/bin/echam6
-            git-repository: https://gitlab.awi.de/pgierz/echam6.git
+            git-repository: https://gitlab.awi.de/paleodyn/Models/echam6.git
           6.3.05p2-concurrent_radiation-paleodyn-hammoz:
             branch: "hammoz"
             clean_command: rm -rf src/echam/bin; make clean
@@ -62,7 +62,7 @@ compile_infos:
               ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps
               yaxt/tests/.deps; ./configure --with-coupler=oasis3-mct --with-fortran=intel
               FCFLAGS="-cpp -DHAMMOZ" INSTALL='/usr/bin/install -p'
-            git-repository: https://gitlab.awi.de/pgierz/echam6.git
+            git-repository: https://gitlab.awi.de/paleodyn/Models/echam6.git
           6.3.05p2-foci:
             branch: esm-tools
             git-repository: https://git.geomar.de/foci/src/echam.git
@@ -73,7 +73,7 @@ compile_infos:
             branch: "wiso"
             clean_command: rm -rf src/echam/bin; rm -rf bin; make clean
             comp_command: ./config/createMakefiles.pl; autoreconf -i --force; mkdir -p src/.deps yaxt/src/.deps yaxt/tests/.deps; ./configure $configure_opts --with-fortran=intel INSTALL='/usr/bin/install -p'; make -j `nproc --all`; make install -j `nproc --all`; mkdir -p src/echam/bin; cp  bin/echam6 src/echam/bin/echam6
-            git-repository: "https://gitlab.awi.de/pgierz/echam6.git"
+            git-repository: "https://gitlab.awi.de/paleodyn/Models/echam6.git"
             destination: echam-6.3.05p2-wiso
         clean_command: ${defaults.clean_command}
         comp_command: ${defaults.comp_command}

--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -58,7 +58,7 @@ choose_version:
     branch: paleodyn_frozen
     destination: fesom-2.0
     git-repository:
-    - https://gitlab.dkrz.de/FESOM/fesom2.git
+    - https://github.com/FESOM/fesom2.git
   2.0-r:
     # OG: This will be the master branch for fesom-recom-2.0. All the recom related
     # files will be cleared from the src folder. After Dima's update we will return

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -19,8 +19,6 @@ choose_version:
     branch: "2.1.0"
   2.1-wiso:
     branch: wiso
-    git-repository:
-    - https://gitlab.dkrz.de/FESOM/fesom2.git
     add_restart_in_files:
         wiso_restart: wiso_restart
     add_restart_out_files:

--- a/configs/components/fesom_mesh_part/fesom_mesh_part-2.0.yaml
+++ b/configs/components/fesom_mesh_part/fesom_mesh_part-2.0.yaml
@@ -9,8 +9,8 @@ namelist_dir: "${esm_namelist_dir}/fesom2/"
 
 branch: 2.0.2
 git-repository:
-- https://gitlab.dkrz.de/FESOM/fesom2.git
 - github.com/FESOM/fesom2.git
+- https://gitlab.dkrz.de/FESOM/fesom2.git
 install_bins: mesh_part/build/fesom_ini
 comp_command: cd mesh_part; mkdir build -p; cd build; cmake ..; make -j `nproc --all`
 clean_command: rm -rf bin/fesom.x.ini mesh_part/build mesh_part/CMakeCache.txt

--- a/configs/components/oasis3mct/oasis3mct.yaml
+++ b/configs/components/oasis3mct/oasis3mct.yaml
@@ -28,6 +28,9 @@ available_versions:
 - 4.0-awicm-frontiers
 - 4.0-awicm-3.0
 choose_version:
+  '2.8-paleodyn':
+    branch: '2.8'
+    url: https://gitlab.awi.de/paleodyn/Models/oasis3-mct
   '2.8':
     branch: '2.8'
   '3.0':

--- a/configs/components/oasis3mct/oasis3mct.yaml
+++ b/configs/components/oasis3mct/oasis3mct.yaml
@@ -30,7 +30,7 @@ available_versions:
 choose_version:
   '2.8-paleodyn':
     branch: '2.8'
-    url: https://gitlab.awi.de/paleodyn/Models/oasis3-mct
+    git-repository: https://gitlab.awi.de/paleodyn/Models/oasis3-mct
   '2.8':
     branch: '2.8'
   '3.0':

--- a/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-1.4+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.04p1-paleodyn
 - fesom-1.4
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 - pism-github1.2
 - scope-dev
 coupling_changes:

--- a/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn/fesom-1.4+echam-6.3.04p1-paleodyn.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.04p1-paleodyn/fesom-1.4+echam-6.3.04p1-paleodyn.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.04p1-paleodyn
 - fesom-1.4
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-1.4+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.04p1-paleodyn
 - fesom-1.4
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux

--- a/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation/fesom-1.4+echam-6.3.05p2-concurrent_radiation.yaml
+++ b/configs/couplings/fesom-1.4+echam-6.3.05p2-concurrent_radiation/fesom-1.4+echam-6.3.05p2-concurrent_radiation.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-concurrent_radiation
 - fesom-1.4
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation/config/mh-linux
 - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-1.4/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn+pism-github1.2+scope-dev.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.04p1-paleodyn
 - fesom-2.0-paleodyn
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 - pism-github1.2
 - scope-dev
 coupling_changes:

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn/fesom-2.0-paleodyn+echam-6.3.04p1-paleodyn.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.04p1-paleodyn
 - fesom-2.0-paleodyn
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.04p1/CMakeLists.txt

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2+scope-dev+debm-esm_tools.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-concurrent_radiation-paleodyn
 - fesom-2.0-paleodyn
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 - pism-github1.2
 - scope-dev
 - debm-esm_tools

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn+pism-github1.2.1+scope-dev+debm-esm_tools.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-concurrent_radiation-paleodyn
 - fesom-2.0-paleodyn
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 - pism-github1.2.1
 - scope-dev
 - debm-esm_tools

--- a/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
+++ b/configs/couplings/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn/fesom-2.0-paleodyn+echam-6.3.05p2-concurrent_radiation-paleodyn.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-concurrent_radiation-paleodyn
 - fesom-2.0-paleodyn
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/set(FESOM_COUPLED/s/OFF/ON/g' fesom-2.0/CMakeLists.txt
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-concurrent_radiation-paleodyn/config/mh-linux

--- a/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0.yaml
+++ b/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-wiso
 - fesom-2.1-recom
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-wiso/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-wiso/configure.ac

--- a/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso/fesom-2.1-wiso+echam-6.3.05p2-wiso.yaml
+++ b/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso/fesom-2.1-wiso+echam-6.3.05p2-wiso.yaml
@@ -1,7 +1,7 @@
 components:
 - echam-6.3.05p2-wiso
 - fesom-2.1-wiso
-- oasis3mct-2.8
+- oasis3mct-2.8-paleodyn
 coupling_changes:
 - sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-wiso/config/mh-linux
 - sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-wiso/configure.ac


### PR DESCRIPTION
## Summary:
This PR allows AWIESM versions to be pulled from github.com for FESOM and
gitlab.awi.de for oasis, thus it is no longer required for users to have access
to gitlab.dkrz.de

## Commits:
- fix(awiesm): change the OASIS3-mct URL to point to AWI gitlab instead of DKRZ gitlab
- fix(oasis3mct.yaml): correct the url name
- fix(fesom.yaml): change the url address in various fesom versions to use github instead of dkrz gitlab

## Follow up questions:

We currently have this "couplings" folder, which has always a folder name, and
then the exact same yaml file name inside of it. What is the reason here? Could
we simply it? (For the cleanup phase)
