### PR TITLE
Feat/Docker

### DIFF
--- a/.github/workflows/esm_tools_actions.yml
+++ b/.github/workflows/esm_tools_actions.yml
@@ -73,6 +73,18 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
+    - name: Build Container
+      if: startsWidth(github.ref, 'refs/tags')
+      # You may pin to the exact commit or the version.
+      # uses: macbre/push-to-ghcr@d45c4b8f5a72d7fe21f6b832c42d05c29356c840
+      uses: macbre/push-to-ghcr@v8
+      with:
+        # Your secrets.GITHUB_TOKEN
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        # Image name, e.g. my-user-name/my-repo
+        image_name: esm-tools/esm_tools
+        # A path to the Dockerfile (if it's not in the repository's root directory)
+        dockerfile: containerization/Dockerfile # optional, default is ./Dockerfile
     - name: Report Skip
       if: (! startsWith(github.ref, 'refs/tags'))
       run: |

--- a/.github/workflows/esm_tools_actions.yml
+++ b/.github/workflows/esm_tools_actions.yml
@@ -74,7 +74,7 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
     - name: Build Container
-      if: startsWidth(github.ref, 'refs/tags')
+      if: startsWith(github.ref, 'refs/tags')
       # You may pin to the exact commit or the version.
       # uses: macbre/push-to-ghcr@d45c4b8f5a72d7fe21f6b832c42d05c29356c840
       uses: macbre/push-to-ghcr@v8

--- a/README.rst
+++ b/README.rst
@@ -71,3 +71,15 @@ You should now have the command line tools ``esm_master`` and ``esm_runscripts``
 You may have to add the installation path to your ``PATH`` variable::
 
     $ export PATH=~/.local/bin:$PATH
+    
+Installing the Containerized Version
+------------------------------------
+
+``esm-tools`` is also available for use with Docker and Singularity. To download it for Docker, you can use::
+
+    $ docker pull ghcr.io/esm-tools/esm_tools:latest
+    
+Or alternatively for Singularity::
+    
+    $ singularity pull docker://ghcr.io/esm-tools/esm_tools:latest
+

--- a/containerization/Dockerfile
+++ b/containerization/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1
+
+# The following can result in a much smaller container, but it currently does not work.
+# See here: https://github.com/autamus/registry/issues
+# FROM ghcr.io/autamus/python:latest
+
+FROM python:3.9-slim-bullseye
+
+WORKDIR /app
+
+COPY . .
+RUN python3 -m pip install .
+
+ENTRYPOINT ["./containerization/entrypoint.sh"]

--- a/containerization/Dockerfile
+++ b/containerization/Dockerfile
@@ -11,4 +11,5 @@ WORKDIR /app
 COPY . .
 RUN python3 -m pip install .
 
-ENTRYPOINT ["./containerization/entrypoint.sh"]
+# Give the full path, just to be safe:
+ENTRYPOINT ["/app/containerization/entrypoint.sh"]

--- a/containerization/entrypoint.sh
+++ b/containerization/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+echo "Welcome to $(esm_tools --version) (containerized)"
+case $1 in
+	master)
+		shift
+		esm_master $@
+		;;
+	runscripts)
+		shift
+		esm_runscripts $@
+		;;
+	*)
+		echo "UKNOWN ESM TOOLS COMMAND!"
+		exit 1
+		;;
+esac

--- a/src/esm_master/compile_info.py
+++ b/src/esm_master/compile_info.py
@@ -24,16 +24,18 @@ import colorama
 
 
 def save_pickle(obj, path):
-    with open(path, "wb") as f:
-        pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
+    try:
+        with open(path, "wb") as f:
+            pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
+    except OSError:
+        # Should be a logger.debug at some point
+        print(f"{path} was not writable, pickle file is not dumped")
 
 
 def load_pickle(path):
     if os.path.isfile(path):
         with open(path, "rb") as f:
             return pickle.load(f)
-    else:
-        return None
 
 
 def combine_components_yaml(parsed_args):
@@ -345,7 +347,8 @@ class setup_and_model_infos:
 
         elif "list_all_packages" in parsed_args:
             self.config = load_pickle(ESM_MASTER_PICKLE)
-
+            if self.config is None:  # PG: This occurs when the pickle file cannot be written in the above step
+                self.config, self.relevant_entries = combine_components_yaml(parsed_args)
         else:
             self.config, self.relevant_entries = combine_components_yaml(parsed_args)
             save_pickle(self.config, ESM_MASTER_PICKLE)

--- a/src/esm_master/compile_info.py
+++ b/src/esm_master/compile_info.py
@@ -18,6 +18,8 @@ import esm_parser
 from .software_package import *
 import colorama
 
+from loguru import logger
+
 ######################################################################################
 ############################## Combine all YAMLS #####################################
 ######################################################################################
@@ -28,8 +30,7 @@ def save_pickle(obj, path):
         with open(path, "wb") as f:
             pickle.dump(obj, f, pickle.HIGHEST_PROTOCOL)
     except OSError:
-        # Should be a logger.debug at some point
-        print(f"{path} was not writable, pickle file is not dumped")
+        logger.warning(f"{path} was not writable, pickle file is not dumped")
 
 
 def load_pickle(path):


### PR DESCRIPTION
## Summary

Adds a very small `Dockerfile` and `entrypoint.sh`

## Still TODO
+ [x] Update documentation (maybe in README?)
+ [x] CI Updates for automatic building of container on tags
+ [x] Integrate with GitHub Container Registry ([ghcr.io](https://github.com/features/packages))
+ [x] Fix ESM Master
+ [ ] Test if runs still actually work 😉 
    + [ ] ESM Master in Container can build AWIESM-2.1
    + [ ] ESM Runscripts in Container can run 3 months of AWIESM-2.1 

@denizural, I think you have experience with containers, can you look? Maybe we can also work on the CI idea together.