### PR TITLE
fixed wrong version number from click --version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.1.5
+current_version = 6.1.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.1.5",
+    version="6.1.6",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_profile import *

--- a/src/esm_rcfile/__init__.py
+++ b/src/esm_rcfile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .esm_rcfile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"
 
 import functools
 import inspect

--- a/src/esm_tools/cli.py
+++ b/src/esm_tools/cli.py
@@ -3,9 +3,13 @@ Functionality for displaying the version number
 """
 import sys
 import click
+import esm_tools
 
+# click.version_option read the PKG_INFO which contains the wrong version 
+# number. Get it directly from __init__.py
+version = esm_tools.__version__
 
-@click.version_option()
+@click.version_option(version=version)
 @click.group()
 def main(args=None):
     """Console script for esm_tools"""

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.1.5"
+__version__ = "6.1.6"


### PR DESCRIPTION
## BUG:
esm_tools --version is not working correctly due to `click` module.
`--version` triggers `click.version_option()` which is explained here:
https://click.palletsprojects.com/en/7.x/api/?highlight=version#click.version_option

It's code is here: https://github.com/pallets/click/blob/7.x/src/click/decorators.py

As you can see, it is reading the version information from the `pkg_resources` module. Maybe you can remember that, I fixed a similar issue in the former `esm_version`. There is an inconsistency in the Python packages `setuptools` and `pkg_resources`.

`pkg_resources` and `pip` read the version information from `esm_tools/src/esm_tools.egg-info/PKG_INFO` file. For example, if I change the version info in this file as 

```
...
Name: esm-tools
Version: 6.6.6
Summary: ESM Tools external infrastructure for Earth System Modelling
...
```   
```
$ esm_tools --version
esm_tools, version 6.6.6

$ pip3 list | grep esm-tools
esm-tools     6.6.6          /mnt/lustre01/pf/a/a271096/esm_tools_R6/esm_tools/src
```

So, there are multiple things to change:
1) fix the `--version`
2) fix the `PKG-INFO` file

## 1)
This bug fix basically fixes the `click --version` bug. It reads the data directly from __init__.py file which will always get updated in our manual CI pipeline and pass is to `click` for further processing.

## 2)
For this part, it seems that the only way to update that is running the setup.py script like so:
`python setup.py egg_info`

```
$ python setup.py egg_info
    running egg_info
    writing src/esm_tools.egg-info/PKG-INFO
    writing dependency_links to src/esm_tools.egg-info/dependency_links.txt
    writing entry points to src/esm_tools.egg-info/entry_points.txt
    writing requirements to src/esm_tools.egg-info/requires.txt
    writing top-level names to src/esm_tools.egg-info/top_level.txt
    reading manifest file 'src/esm_tools.egg-info/SOURCES.txt'
    reading manifest template 'MANIFEST.in'
    warning: no directories found matching 'stuff'
    writing manifest file 'src/esm_tools.egg-info/SOURCES.txt'
```

I checked the `bumpversion` code and could not find an option to trigger an update to the egg files so, our new workflow should be

```
bumpversion --dry-run  --verbose patch
bumpversion patch
python3 setup.py egg_info
```