### PR TITLE
ci: allow manually selecting test jobs

### DIFF
--- a/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
+++ b/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
@@ -2,6 +2,22 @@ name: esm-tools Ollie
 
 # Reusuable part
 on:
+    workflow_dispatch:
+      inputs:
+        model_name:
+          required: True
+          type: choice
+          description: "Which model shall be tested?"
+          options:
+            - AWIESM
+            - AWICM
+            - ECHAM Standalone
+            - FESOM Standalone
+            - PISM Standalone
+        model_version:
+            required: True
+            type: string
+            description: "Which model version to be tested"
     workflow_call:
         inputs:
             model_name:


### PR DESCRIPTION
This should allow to select CI Jobs for manual testing. It will not be active until it is in the default branch though...