### PR TITLE
ci: run installer inside a virtual environment

### DIFF
--- a/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
+++ b/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
@@ -73,6 +73,8 @@ jobs:
             run: |
               module load git
               module load python3
+              python3 -m venv .venv
+              source .venv/bin/activate
               ./install.sh
 
           - name: Create esmtoolsrc file

--- a/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
+++ b/.github/workflows/esm_tools_actions_hpc_awi_ollie.yml
@@ -45,6 +45,10 @@ jobs:
         steps:
             - name: Download Code
               uses: actions/checkout@v2
+            - id: print inputs
+              run: echo ${{inputs.model_version}}
+            - id: print_version_env
+              run: echo "VERSION=$(python utils/versions_to_json_matrix.py ${{inputs.model_version}})"
             - id: set_version_env
               run: echo "VERSION=$(python utils/versions_to_json_matrix.py ${{inputs.model_version}})" >> $GITHUB_ENV
             - id: test-set-matrix


### PR DESCRIPTION
Now that there are multiple runners on Ollie, they complete with each other during the install step, and this fails. Wrapping it into a virtual environment should give a unique install every time.