### PR TITLE
Fix/icb fesom namelist suggestions

### DIFF
--- a/configs/components/fesom/fesom-2.0.yaml
+++ b/configs/components/fesom/fesom-2.0.yaml
@@ -9,10 +9,6 @@ type: ocean
 comp_command: ${defaults.comp_command}
 clean_command: ${defaults.clean_command}
 
-# LA these are both iceberg related
-use_icebergs: False                 # turns on icebergs
-use_icesheet_coupling: False        # initializes new icebergs every restart
-
 choose_version:
   '2.0':
     branch: 2.0.2
@@ -156,27 +152,21 @@ restart_in_files:
         ice_restart: ice_restart
         par_oce_restart: par_oce_restart
         par_ice_restart: par_ice_restart
-        icb_restart: icb_restart
-        icb_restart_ISM: icb_restart_ISM
 
 restart_in_in_work:
         oce_restart: fesom.${parent_date!syear}.oce.restart.nc
         ice_restart: fesom.${parent_date!syear}.ice.restart.nc
-        icb_restart: iceberg.restart #.${parent_date!syear!month}
         par_oce_restart: fesom.${parent_date!syear}.oce.restart/*.nc
         par_ice_restart: fesom.${parent_date!syear}.ice.restart/*.nc
         fesom_raw_restart_info: fesom_raw_restart/*.info
         fesom_raw_restart: fesom_raw_restart/np${nproc}/*.dump
-        icb_restart_ISM: iceberg.restart.ISM
 restart_in_sources:
         oce_restart: fesom.${parent_date!syear}.oce.restart.nc
         ice_restart: fesom.${parent_date!syear}.ice.restart.nc
-        icb_restart: iceberg.restart #.${parent_date!syear!month}
         par_oce_restart: fesom.${parent_date!syear}.oce.restart/*.nc
         par_ice_restart: fesom.${parent_date!syear}.ice.restart/*.nc
         fesom_raw_restart_info: fesom_raw_restart/*.info
         fesom_raw_restart: fesom_raw_restart/np${nproc}/*.dump
-        icb_restart_ISM: iceberg.restart.ISM
 
 restart_out_files:
         oce_restart: oce_restart
@@ -185,97 +175,28 @@ restart_out_files:
         par_ice_restart: par_ice_restart
         fesom_raw_restart_info: fesom_raw_restart_info
         fesom_raw_restart: fesom_raw_restart
-        icb_restart: icb_restart
-        icb_restart_ISM: icb_restart_ISM
 
 restart_out_in_work:
         oce_restart: fesom.${end_date!syear}.oce.restart.nc
         ice_restart: fesom.${end_date!syear}.ice.restart.nc
-        icb_restart: iceberg.restart #.${parent_date!syear}
         par_oce_restart: fesom.${end_date!syear}.oce.restart/*.nc
         par_ice_restart: fesom.${end_date!syear}.ice.restart/*.nc
         fesom_raw_restart_info: fesom_raw_restart/*.info
         fesom_raw_restart: fesom_raw_restart/np${nproc}/*.dump
-        icb_restart_ISM: iceberg.restart.ISM
 
 restart_out_sources:
         oce_restart: fesom.${end_date!syear}.oce.restart.nc
         ice_restart: fesom.${end_date!syear}.ice.restart.nc
-        icb_restart: iceberg.restart #.${parent_date!syear}
         par_oce_restart: fesom.${end_date!syear}.oce.restart/*.nc
         par_ice_restart: fesom.${end_date!syear}.ice.restart/*.nc
         fesom_raw_restart_info: fesom_raw_restart/*.info
         fesom_raw_restart: fesom_raw_restart/np${nproc}/*.dump
-        icb_restart_ISM: iceberg.restart.ISM
 
 
 outdata_sources:
         fesom: "*.fesom.*.nc"
 outdata_targets:
         fesom: "*.fesom.*.nc"
-
-choose_use_icebergs:
-        True:
-            outputs: 
-                    [Av, Bo, Kv, MLD1, MLD2, N2, Redi_K, a_ice, alpha, atmice_x, atmice_y, atmoce_x, atmoce_y, beta, bolus_u, bolus_v, bolus_w, evap, fer_C, fer_K, fh, fw, hbl, iceoce_x, iceoce_y, m_ice, m_snow, prec, reso, runoff, salt, slope_x, slope_y, slope_z, snow, ssh, sss, sst, temp, tx_sur, ty_sur, u, uice, v, vice, vve, w, h2o16, h2o18, hDo16, h2o16_ice, h2o18_ice, hDo16_ice, ibfwe, ibfwl, ibfwb, ibfwbv, ibhf]
-
-            add_outdata_targets:
-                    buoys_track: "buoys_track.nc_${run_datestamp}"
-
-            add_outdata_sources:
-                    buoys_track: "buoys_track.nc"
-
-            choose_use_icesheet_coupling:
-                    true: 
-                            choose_general.chunk_number:
-                                    1:
-                                            iceberg_dir: "${ini_iceberg_dir}"
-                                    "*":
-                                            iceberg_dir: "${general.experiment_couple_dir}"
-            
-                            choose_general.run_number:
-                                    1:
-                                            input_sources:
-                                                    num_non_melted_icb_file: "${ini_iceberg_dir}/num_non_melted_icb_file"
-                                    "*":
-                                            input_sources:
-                                                    num_non_melted_icb_file: "${general.experiment_couple_dir}/num_non_melted_icb_file"
-            
-                            input_files:
-                                    num_non_melted_icb_file: "num_non_melted_icb_file"
-            
-                            input_in_work:
-                                    num_non_melted_icb_file: "num_non_melted_icb_file"
-            
-                    "*": 
-                            iceberg_dir: "${ini_iceberg_dir}"
-            
-
-            input_in_work:
-                    longitude: "icb_longitude.dat"
-                    latitude: "icb_latitude.dat"
-                    length: "icb_length.dat"
-                    height: "icb_height.dat"
-                    scaling: "icb_scaling.dat"
-
-            input_sources:
-                    longitude: "${iceberg_dir}/LON.dat"
-                    latitude: "${iceberg_dir}/LAT.dat"
-                    length: "${iceberg_dir}/LENGTH.dat"
-                    height: "${iceberg_dir}/HEIGHT.dat"
-                    scaling: "${iceberg_dir}/SCALING.dat"
-
-            input_files:
-                    longitude: "longitude"
-                    latitude: "latitude"
-                    length: "length"
-                    height: "height"
-                    scaling: "scaling"
-        
-        False:
-            outputs: 
-                    [Av, Bo, Kv, MLD1, MLD2, N2, Redi_K, a_ice, alpha, atmice_x, atmice_y, atmoce_x, atmoce_y, beta, bolus_u, bolus_v, bolus_w, evap, fer_C, fer_K, fh, fw, hbl, iceoce_x, iceoce_y, m_ice, m_snow, prec, reso, runoff, salt, slope_x, slope_y, slope_z, snow, ssh, sss, sst, temp, tx_sur, ty_sur, u, uice, v, vice, vve, w, h2o16, h2o18, hDo16, h2o16_ice, h2o18_ice, hDo16_ice, www1, www2, www3, iii1, iii2, iii3]
-            
 
 log_files:
         clock: clock
@@ -353,26 +274,6 @@ namelist_changes:
                         nm_mslp_file: "${forcing_data_dir}/slp."
                         nm_runoff_file: "${forcing_data_dir}/runoff.nc"
                         nm_sss_data_file: "${forcing_data_dir}/PHC2_salx.nc"
-
-use_landice_water: False
-choose_general.iterative_coupling:
-        true:
-                choose_general.chunk_number:
-                        1:
-                                use_landice_water: False
-                        "*":
-                                use_landice_water: True
-                
-        '*':
-                use_landice_water: False
-
-add_namelist_changes:
-    namelist.config:
-        icebergs:
-            use_icebergs: "${use_icebergs}"
-            use_icesheet_coupling: "${use_icesheet_coupling}"
-            steps_per_ib_step: 8
-            ib_num: 1
 
 lasttime: "$(( 86400 - ${time_step}))"
 currentday: "${current_date!sdoy}"

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -12,6 +12,9 @@ clean_command: ${defaults.clean_command}
 # LA these are both iceberg related
 use_icebergs: False                 # turns on icebergs
 use_icesheet_coupling: False        # initializes new icebergs every restart
+# MA This variable needs to be set true in every version of fesom-2.1 (choose_ block
+# below) whose source code contains the icebergs implementation
+icb_code: False
 
 choose_version:
   2.1-unstable:
@@ -115,9 +118,6 @@ choose_resolution:
 restart_in_files:
         oce_restart: oce_restart
         ice_restart: ice_restart
-        icb_restart: icb_restart
-        icb_restart_ISM: icb_restart_ISM
-
 restart_in_in_workdir:
         oce_restart: fesom.${parent_date!syear}.oce.restart.nc
         ice_restart: fesom.${parent_date!syear}.ice.restart.nc
@@ -134,8 +134,6 @@ restart_in_sources:
 restart_out_files:
         oce_restart: oce_restart
         ice_restart: ice_restart
-        icb_restart: icb_restart
-        icb_restart_ISM: icb_restart_ISM
 restart_out_in_workdir:
         oce_restart: fesom.${end_date!syear}.oce.restart.nc
         ice_restart: fesom.${end_date!syear}.ice.restart.nc
@@ -156,8 +154,13 @@ outdata_targets:
 
 choose_use_icebergs:
         True:
-            outputs: 
-                    [Av, Bo, Kv, MLD1, MLD2, N2, Redi_K, a_ice, alpha, atmice_x, atmice_y, atmoce_x, atmoce_y, beta, bolus_u, bolus_v, bolus_w, evap, fer_C, fer_K, fh, fw, hbl, iceoce_x, iceoce_y, m_ice, m_snow, prec, reso, runoff, salt, slope_x, slope_y, slope_z, snow, ssh, sss, sst, temp, tx_sur, ty_sur, u, uice, v, vice, vve, w, h2o16, h2o18, hDo16, h2o16_ice, h2o18_ice, hDo16_ice, ibfwe, ibfwl, ibfwb, ibfwbv, ibhf]
+
+            add_restart_in_files:
+                icb_restart: icb_restart
+                icb_restart_ISM: icb_restart_ISM
+            add_restart_out_files:
+                icb_restart: icb_restart
+                icb_restart_ISM: icb_restart_ISM
 
             add_outdata_targets:
                     buoys_track: "buoys_track.nc_${run_datestamp}"
@@ -166,13 +169,13 @@ choose_use_icebergs:
                     buoys_track: "buoys_track.nc"
 
             choose_use_icesheet_coupling:
-                    true: 
+                    true:
                             choose_general.chunk_number:
                                     1:
                                             iceberg_dir: "${ini_iceberg_dir}"
                                     "*":
                                             iceberg_dir: "${general.experiment_couple_dir}"
-            
+
                             choose_general.run_number:
                                     1:
                                             input_sources:
@@ -180,16 +183,16 @@ choose_use_icebergs:
                                     "*":
                                             input_sources:
                                                     num_non_melted_icb_file: "${general.experiment_couple_dir}/num_non_melted_icb_file"
-            
+
                             input_files:
                                     num_non_melted_icb_file: "num_non_melted_icb_file"
-            
+
                             input_in_work:
                                     num_non_melted_icb_file: "num_non_melted_icb_file"
-            
-                    "*": 
+
+                    "*":
                             iceberg_dir: "${ini_iceberg_dir}"
-            
+
 
             input_in_work:
                     longitude: "icb_longitude.dat"
@@ -211,11 +214,6 @@ choose_use_icebergs:
                     length: "length"
                     height: "height"
                     scaling: "scaling"
-        
-        False:
-            outputs: 
-                    [Av, Bo, Kv, MLD1, MLD2, N2, Redi_K, a_ice, alpha, atmice_x, atmice_y, atmoce_x, atmoce_y, beta, bolus_u, bolus_v, bolus_w, evap, fer_C, fer_K, fh, fw, hbl, iceoce_x, iceoce_y, m_ice, m_snow, prec, reso, runoff, salt, slope_x, slope_y, slope_z, snow, ssh, sss, sst, temp, tx_sur, ty_sur, u, uice, v, vice, vve, w, h2o16, h2o18, hDo16, h2o16_ice, h2o18_ice, hDo16_ice, www1, www2, www3, iii1, iii2, iii3]
-            
 
 log_files:
         clock: clock
@@ -321,13 +319,15 @@ namelist_changes:
 
                         runoff_data_source: ${runoff_data_source}
                         sss_data_source: ${sss_data_source}
-add_namelist_changes:
-    namelist.config:
-        icebergs:
-            use_icebergs: "${use_icebergs}"
-            use_icesheet_coupling: "${use_icesheet_coupling}"
-            steps_per_ib_step: 8
-            ib_num: 1
+icb_code:
+    True:
+        add_namelist_changes:
+            namelist.config:
+                icebergs:
+                    use_icebergs: "${use_icebergs}"
+                    use_icesheet_coupling: "${use_icesheet_coupling}"
+                    steps_per_ib_step: 8
+                    ib_num: 1
 
 lasttime: "$(( 86400 - ${time_step}))"
 currentday: "${current_date!sdoy}"

--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -319,7 +319,7 @@ namelist_changes:
 
                         runoff_data_source: ${runoff_data_source}
                         sss_data_source: ${sss_data_source}
-icb_code:
+choose_icb_code:
     True:
         add_namelist_changes:
             namelist.config:

--- a/namelists/fesom2/2.1/namelist.config
+++ b/namelists/fesom2/2.1/namelist.config
@@ -60,10 +60,3 @@ use_sw_pene=.true.
 n_levels=2
 n_part= 12, 36          ! 432 number of partitions on each hierarchy level
 /
-
-&icebergs
-    use_icebergs = .false.
-    use_icesheet_coupling = .false.
-    ib_num = 0
-    steps_per_ib_step = 8
-/


### PR DESCRIPTION
So this are all my suggestions for the branch.

The only thing I see it could destroy iceberg simulations right now with this PR is the `icb_code` switch. Once it is clear to us in which `fesom-2.1` versions we should include `icb_code: true` then we can overcome the problem in an automatic manner. For the time being, @ackerlar will need to add to his runscript the following:
```
fesom:
    icb_code: true
``` 