### PR TITLE
CI: Fix for PyPI Publication

### DIFF
--- a/.github/workflows/esm_tools_publish.yml
+++ b/.github/workflows/esm_tools_publish.yml
@@ -4,6 +4,15 @@ on:
   create:
     tags:
       - v*
+  # I am not sure which one is better:
+  # workflow_run:
+  #  workflows: [pre-merge_actions]
+  #  types:
+  #    - completed
+  workflow_call:
+    secrets:
+      PYPI_API_TOKEN:
+        required: true
 
 jobs:
   publish:

--- a/.github/workflows/pre-merge_actions.yml
+++ b/.github/workflows/pre-merge_actions.yml
@@ -131,7 +131,13 @@ jobs:
         run: |
           git push;
           git push --tags
-          
+      - name: Call Publish
+        run: |
+          # FIXME: Once this works, we need to change the @ to release, or a
+          # specific commit
+          uses: "esm-tools/esm_tools/.github/workflows/esm_tools_publish@fix/pypi_publish"  
+          secrets:
+            PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       # Merge PR-branch into `develop`
       - name: merge into develop
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ dummy_script.sh
 # pkl files, deniz
 *.pkl
 
+# direnv files
+.envrc
+.direnv
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
A problem with publishing to PyPI was introduced when we began using the bump
syntax (here explicitly I do not add the `#` to avoid triggering it).

In effect, workflows will not call other workflows. Here we have two:

1. `pre-merge_actions.yml` by @mandresm: based upon branch naming conventions
   and a specific comment in the PR discussion, will create a patch or feature
   version number, i.e.: `6.3.0` -> `6.4.0`, and also generate a new tag. These
   new version numbers and tag is pushed to GitHub. The final step of merging the
   PR into the target branch is done by hand.

2. `esm_tools_publish.yml` by @pgierz: whenever a tag is pushed, a Python
   package is built using: 
   
   ```shell
   $ python setup.py sdist bdist_wheel
   $ twine upload
   ```

The `twine upload` step is actually performed by a Marketplace action
`pypa/gh-action-pypi-publish`.

As mentioned above, workflows will not call other workflows, so the "create
tag" trigger generated in workflow 1 will not trigger workflow 2. I have two
solutions for this:

A. `esm_tools_publish` get's a `workflow_call` trigger, so that any workflow is
   able to call the publish step if it wants to. `pre-merge_actions` calls this
   after pushing.

B. `esm_tools_publish` is run whenever it detects `pre-merge_actions` is finished.

I am not sure which solution is better, and I am also not sure which if it
works, since the `Publish package` step explicitly checks if the `github.ref`
starts with `refs/tags`. It might turn out that this needs more fine grained
control, e.g. something like this in case of option A:

```yaml
if: startsWith(github.ref, 'refs/tags') || ...something detecting called from...
```

or for option B:

```yaml
if: startsWith(github.ref, 'refs/tags') || ...something states workflow is triggered by a finished other workflow...
```

Unfortunately the GitHub Actions docs, while fancy, don't particularly give me
any insight here...

Suggestions welcome please!
