### PR TITLE
Fix/find variable transformations and choose booleans

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.3.6
+current_version = 6.3.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.3.6",
+    version="6.3.7",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -1494,8 +1494,8 @@ def resolve_basic_choose(config, config_to_replace_in, choose_key, blackdict={})
     for ckey in choices_available:
         choices_bool &= isinstance(ckey, bool)
     # If the choices are booleans and the ``choice`` is a string, try to transform the
-    # try to transform the string in an integer (that will be able to select a choice
-    # from the boolean choices
+    # string in an integer (that will be able to select a choice from the boolean
+    # choices)
     if choices_bool and isinstance(choice, str):
         if choice == "0" or choice == "1":
             choice = int(choice)

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -1971,8 +1971,11 @@ def find_variable(tree, rhs, full_config, white_or_black_list, isblacklist):
             # If the substituted variable is not a list, and there is either a
             # preceding (``prefix``) or following (``suffix``) string, then add up
             # the parts, making sure that other variables (``${}``) are also
-            # substituted
-            if type(var_result) not in [list] and (prefix or suffix):
+            # substitute. The "NONE_YET" part is to handle PrevRunInfo class correctly
+            if (
+                (not isinstance(var_result, list) and (prefix or suffix)) or
+                (isinstance(var_result, dict) and "NONE_YET" in var_result)
+            ):
                 prefix, var_result, more_rest = (
                     str(prefix),
                     str(var_result),

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -1490,13 +1490,13 @@ def resolve_basic_choose(config, config_to_replace_in, choose_key, blackdict={})
             choices_available[ckey] = cval
 
     # Are choices all booleans?
-    choices_bool = True
+    all_choices_are_bool = True
     for ckey in choices_available:
-        choices_bool &= isinstance(ckey, bool)
+        all_choices_are_bool &= isinstance(ckey, bool)
     # If the choices are booleans and the ``choice`` is a string, try to transform the
     # string in an integer (that will be able to select a choice from the boolean
     # choices)
-    if choices_bool and isinstance(choice, str):
+    if all_choices_are_bool and isinstance(choice, str):
         if choice == "0" or choice == "1":
             choice = int(choice)
 

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_profile import *

--- a/src/esm_rcfile/__init__.py
+++ b/src/esm_rcfile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .esm_rcfile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.3.6"
+__version__ = "6.3.7"


### PR DESCRIPTION
This PR solves the following problem:
```
general:
    a_var_in_general: true
fesom:
    a_var_in_fesom: ${general.a_var_in_general}
    choose_a_var_in_fesom:
         True:
             a_variable: true
```

Under this situation, `general.a_var_in_general` is interpreted in the `config` as a boolean, however, when searched from the fesom using the `esm_parser.find_variable` method it returns `"True"` as a string. This is because of a bug in `find_variable` that apparently was known to exist (there was a big BUG comment in the lines affected). With this bug, the correct option in the choose is not selected because `True` is not `"True"`.

Additionally to this fix, this also solves:
- renames the misleading `ok_part` and `new_raw` variables to `prefix` and `suffix` variables
- solves a subsequent bug introduce by this fix, so that 0 and 1 are understand as True or False as well
- solves a subsequent bug introduce by this fix that affects `PrevRunInfo` classes when using `find_variable`

**TODO**

- [ ] Heavy testing with `esm_tests`. **Very important** to make sure nothing changes in the configuration files or namelists in terms of variable types. Full compilation and runs will be run in all computers. 