### PR TITLE
solves issue esm-tools/esm_tools/issues/616

### DIFF
--- a/configs/components/recom/recom.yaml
+++ b/configs/components/recom/recom.yaml
@@ -106,11 +106,8 @@ choose_lresume:
                                 pavariables:
                                         recom_restart: false
 
-config_files:
-        recom:  recom
-
 config_sources:
-        recom:  "${namelist_dir}/namelist.recom"
+        "namelist.recom":  "${namelist_dir}/namelist.recom"
 #        io.recom.ciso: "${namelist_dir}/namelist.io.recom.ciso"
 
 restart_name: ""


### PR DESCRIPTION
This bugfix solves the issue https://github.com/esm-tools/esm_tools/issues/616

When I debug the code, I can see that the parser adds `add_config_sources` to the target but since it is appended it does not have any effect:
```python
target_config['recom']['config_sources']
{'recom': '${namelist_dir}/namelist.recom', 
 'namelist.recom': '/mnt/lustre01/pf/a/a271096/Solutions/Christopher/2022/namelist.recom'
}
```
A simple solution is to modify the Recom YAML file, so that the parser can safely overwrite the `namelist.recom` key. Another solution is also possible but I wanted to make it look similar to Echam example in the docs so that it is consistent.