### PR TITLE
fix/path in juwels awicm3

### DIFF
--- a/configs/components/oifs/change_icm_date.sh
+++ b/configs/components/oifs/change_icm_date.sh
@@ -34,16 +34,13 @@ echo " Output dir: $outdir "
 echo " InExp ID: $inexpid "
 echo " OutExp ID: $outexpid "
 echo " Start date: $startdate "
-echo " End date: $enddate "
 echo " Perturb: $perturb "
 ndate=$(date -u -d "${inidate}" +%Y%m%d)
 initime=$(date -u -d "${inidate}" +%Y-%m-%dT%T)
 starttime=$(date -u -d "${startdate}" +%Y-%m-%dT%T)
-endtime=$(date -u -d "${enddate}" +%Y-%m-%dT%T)
 echo " New date: $ndate "
 echo " Initial time: $initime "
 echo " Start time: $starttime "
-echo " End time: $endtime "
 echo " "
 
 echo " * Change dataDate in files: "

--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -126,8 +126,6 @@ choose_compiler_mpi:
         - "load Python/3.9.6"
         - "load imkl/2021.4.0"
         - "load Perl/5.34.0"
-        - "load NCO/5.0.3"
-        - "load CDO/2.0.2"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -271,7 +269,7 @@ choose_iolibraries:
             NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
             NETCDF_CXX_INCLUDE_DIRECTORIES: $NETCDFROOT/include
             OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
-            PATH: $IO_LIB_ROOT/bin/:$PATH
+            PATH: $IO_LIB_ROOT/bin:$PATH
 
         choose_compiler_mpi:
             intel2022_ompi2022:

--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -271,7 +271,7 @@ choose_iolibraries:
             NETCDF_C_INCLUDE_DIRECTORIES: $NETCDFROOT/include
             NETCDF_CXX_INCLUDE_DIRECTORIES: $NETCDFROOT/include
             OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
-            PATH: $PATH:$IO_LIB_ROOT/bin #:/p/scratch/chhb19/hhb193/miniconda3/bin/:$PATH
+            PATH: $IO_LIB_ROOT/bin/:$PATH
 
         choose_compiler_mpi:
             intel2022_ompi2022:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.3.5
+current_version = 6.3.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.3.5",
+    version="6.3.6",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_profile import *

--- a/src/esm_rcfile/__init__.py
+++ b/src/esm_rcfile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .esm_rcfile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.3.5"
+__version__ = "6.3.6"


### PR DESCRIPTION
Fixes AWICM3 not running in Juwels due to an improper ordering in the PATH environment variable.

#593 is probably not solved previous to this fix. This PR will fix the problem.