### PR TITLE
moves complete_config_from_user_config() and get_user_config_from_com…

### DIFF
--- a/src/esm_runscripts/config_initialization.py
+++ b/src/esm_runscripts/config_initialization.py
@@ -43,27 +43,6 @@ def init_first_user_config(command_line_config, user_config):
     return user_config
 
 
-def complete_config_from_user_config(user_config):
-    config = get_total_config_from_user_config(user_config)
-
-    if "verbose" not in config["general"]:
-        config["general"]["verbose"] = False
-
-    config["general"]["reset_calendar_to_last"] = False
-
-    if config["general"].get("inspect"):
-        config["general"]["jobtype"] = "inspect"
-
-        if config["general"].get("inspect") not in [
-            "workflow",
-            "overview",
-            "config",
-        ]:
-            config["general"]["reset_calendar_to_last"] = True
-
-    return config
-
-
 def save_command_line_config(config, command_line_config):
     if command_line_config:
         config["general"]["command_line_config"] = command_line_config
@@ -107,47 +86,8 @@ def get_user_config_from_command_line(command_line_config):
     user_config["general"].update(command_line_config)
     if deupdate_use_venv:
         user_config["general"]["use_venv"] = user_use_venv
+
     return user_config
-
-
-def get_total_config_from_user_config(user_config):
-
-    if "version" in user_config["general"]:
-        version = str(user_config["general"]["version"])
-    else:
-        setup_name = user_config["general"]["setup_name"]
-
-        if "version" in user_config[setup_name.replace("_standalone", "")]:
-            version = str(user_config[setup_name.replace("_standalone", "")]["version"])
-        else:
-            version = "DEFAULT"
-
-    config = esm_parser.ConfigSetup(
-        user_config["general"]["setup_name"].replace("_standalone", ""),
-        version,
-        user_config,
-    )
-
-    config = add_esm_runscripts_defaults_to_config(config)
-
-    config["computer"]["jobtype"] = config["general"]["jobtype"]
-    config["general"]["experiment_dir"] = (
-        config["general"]["base_dir"] + "/" + config["general"]["expid"]
-    )
-
-    # Check if the 'account' variable is needed and missing
-    if config["computer"].get("accounting", False):
-        if "account" not in config["general"]:
-            esm_parser.user_error(
-                "Missing account info",
-                f"You cannot run simulations in '{config['computer']['name']}' "
-                "without providing an 'account' variable in the 'general' section, whose "
-                "value refers to the project where the computing resources are to be "
-                "taken from. Please, add the following to your runscript:\n\n"
-                "general:\n\taccount: <the_account_to_be_used>",
-            )
-
-    return config
 
 
 def add_esm_runscripts_defaults_to_config(config):

--- a/src/esm_runscripts/sim_objects.py
+++ b/src/esm_runscripts/sim_objects.py
@@ -35,7 +35,9 @@ class SimulationSetup(object):
             setup_name = user_config["general"]["setup_name"]
 
             if "version" in user_config[setup_name.replace("_standalone", "")]:
-                version = str(user_config[setup_name.replace("_standalone", "")]["version"])
+                version = str(
+                    user_config[setup_name.replace("_standalone", "")]["version"]
+                )
             else:
                 version = "DEFAULT"
 
@@ -46,12 +48,14 @@ class SimulationSetup(object):
             user_config,
         )
 
-        self.config = config_initialization.add_esm_runscripts_defaults_to_config(self.config)
+        self.config = config_initialization.add_esm_runscripts_defaults_to_config(
+            self.config
+        )
 
         self.config["computer"]["jobtype"] = self.config["general"]["jobtype"]
-        self.config["general"]["experiment_dir"] = (
-            f"{self.config['general']['base_dir']}/{self.config['general']['expid']}"
-        )
+        self.config["general"][
+            "experiment_dir"
+        ] = f"{self.config['general']['base_dir']}/{self.config['general']['expid']}"
 
         # Check if the 'account' variable is needed and missing
         if self.config["computer"].get("accounting", False):
@@ -64,8 +68,6 @@ class SimulationSetup(object):
                     "taken from. Please, add the following to your runscript:\n\n"
                     "general:\n\taccount: <the_account_to_be_used>",
                 )
-
-
 
         if "verbose" not in self.config["general"]:
             self.config["general"]["verbose"] = False
@@ -83,7 +85,7 @@ class SimulationSetup(object):
                 self.config["general"]["reset_calendar_to_last"] = True
 
         # add the user runscript content
-        self.config['general']['runscript_content'] = user_config
+        self.config["general"]["runscript_content"] = user_config
 
         self.config = config_initialization.save_command_line_config(
             self.config, command_line_config
@@ -96,7 +98,6 @@ class SimulationSetup(object):
 
         # esm_parser.pprint_config(self.config)
         # sys.exit(0)
-
 
     def __call__(self, kill_after_submit=True):
         # Trigger inspect functionalities
@@ -156,19 +157,16 @@ class SimulationSetup(object):
 
         return self.config["general"].get("experiment_over", False)
 
-
     #########################     OBSERVE      #############################################################
     def observe(self):
         from . import observe
 
         self.config = observe.run_job(self.config)
 
-
     def assembler(self):
         from . import assembler
 
         self.config = assembler.run_job(self.config)
-
 
     ###################################     TIDY      #############################################################
     def tidy(self):
@@ -193,14 +191,12 @@ class SimulationSetup(object):
 
         self.config = tidy.run_job(self.config)
 
-
     ###################################     INSPECT      #############################################################
     def inspect(self):
         from . import inspect
 
         print(f"Inspecting {self.config['general']['experiment_dir']}")
         self.config = inspect.run_job(self.config)
-
 
     ###################################     PREPCOMPUTE      #############################################################
     def prepcompute(self):
@@ -216,7 +212,6 @@ class SimulationSetup(object):
         from . import prepcompute
 
         self.config = prepcompute.run_job(self.config)
-
 
     ###################################     VIZ     #############################################################
     def viz(self):


### PR DESCRIPTION
Removed these functions (from `config_initialization.py`)
- `def complete_config_from_user_config(user_config)`
- `def get_user_config_from_command_line(command_line_config)`

and moved them to `sim_objects.py` into `SimulationSetup` initializer.

Added user runscript into `config['general']['runscript_content']`

**Reasons:**
- Instantiation of the `ConfigSetup` object was handled in the `get_user_config_from_command_line()` function but this is not a good place to do that. 
- It is much better to place all initialization and instantiation codes into an `__init__()` method. This enhances encapsulation.
- Placing the user runscript into config as a separate entity is important. We can query if the user has specified an option.

This PR is required for a further bugfix.