### PR TITLE
fix/additional flags list

### DIFF
--- a/configs/machines/generic.yaml
+++ b/configs/machines/generic.yaml
@@ -1,7 +1,7 @@
 # GENERIC YAML CONFIGURATION FILES
 
 #hyper_flag: "--cpus-per-task=1"
-additional_flags: "--mem=0"
+additional_flags: ["--mem=0"]
 
 accounting: true
 

--- a/configs/machines/mistral.yaml
+++ b/configs/machines/mistral.yaml
@@ -2,7 +2,7 @@
 
 name: mistral
 #hyper_flag: "--cpus-per-task=1"
-additional_flags: "--mem=0"
+additional_flags: ["--mem=0"]
 account: None
 
 use_hyperthreading: False

--- a/configs/other_software/batch_system/pbs.yaml
+++ b/configs/other_software/batch_system/pbs.yaml
@@ -38,7 +38,7 @@ notification_flag: "${mail1} ${mail2}"
 nodes_flag: "-l nodes=@nodes@"
 partition_flag: "-q ${partition}"
 time_flag: "-l walltime=${compute_time}"
-additional_flags: ""
+additional_flags: []
 output_path: "${experiment_dir}/log/"
 thisrun_logfile: "${output_path}${expid}_${general.setup_name}_@jobtype@_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_$PBS_JOBID.log"
 output_flags: "-j oe -o ${thisrun_logfile}"

--- a/configs/other_software/batch_system/slurm.yaml
+++ b/configs/other_software/batch_system/slurm.yaml
@@ -41,7 +41,7 @@ tasks_flag: "--ntasks=@tasks@"
 partition_flag: "--partition=@partition@"
 nodes_flag: "--nodes=@nodes@"
 time_flag: "--time=${compute_time}"
-additional_flags: ""
+additional_flags: []
 output_path: "${experiment_dir}/log/"
 thisrun_logfile: "${output_path}${expid}_${general.setup_name}_@jobtype@_${general.current_date!syear!smonth!sday}-${general.end_date!syear!smonth!sday}_%j.log"
 output_flags: "--output=${thisrun_logfile} --error=${thisrun_logfile}"


### PR DESCRIPTION
all the aditional_flags variables in slurm.yaml, pbs.yaml and machine files turned into a list, so that add_additional_flags can be used from the runscript to expand the job manager flags

This will allow us in the workshop to add the following to the runscript and show how to use `additinal_flags`:
```
computer:
    add_additional_flags:
        - "--reservation=esmtools"
```