### PR TITLE
fix/venv monorepository

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.6.6
+current_version = 6.6.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.6.6",
+    version="6.6.7",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_runscripts/virtual_env_builder.py
+++ b/src/esm_runscripts/virtual_env_builder.py
@@ -302,52 +302,44 @@ def find_package(pkg):
 
 def _integorate_user_venv(config):
     questionary.print("\t" + 100 * "=")
-    questionary.print(
-        "\t\tRunning jobs can optionally be encapsulated into a virtual environment\n"
+    questionary_text = (
+        "\t\tRunning jobs can optionally be encapsulated into a virtual environment\n\n"
+
+        "\t\tThis shields the run from changes made to the remainder of the ESM-Tool installation\n\n"
+
+        "\t\tBefore the first run, a local copy will be installed in the experiment tree,\n"
+        "\t\tand **this** installation will be used:\n"
+        f"\t\t\t {config['general']['experiment_dir']}/.venv_esmtools/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages/esm_tools\n"
+        "\t\tinstead of:\n"
+        f"\t\t\t{find_package('esm-tools')}\n"
+
+        "\n\t\tIf you choose to use a virtual environment, a folder named `.venv_esmtools`\n"
+        "\t\twill be created at the root of your experiment. This contains all the Python\n"
+        "\t\tlibraries used by the esm-tools. The first installation induces some overhead (~2-3 minutes).\n"
+
+        "\n\t\tThe virtual environment installs by default the `release` branch, pulling it directly\n"
+        "\t\tfrom our GitHub repository. You can choose to override this default by specifying another\n"
+        "\t\tbranch, adding to your runscript:\n"
+        "\t\t\tgeneral:\n"
+        "\t\t\t\tinstall_esm_tools_branch: '<your_branch_name>'\n"
+        "\t\tNote: the branch needs to exist on GitHub as it is cloned form there, and not from your\n"
+        "\t\tlocal folder. If you made any changes in your local branch make sure they are pushed before\n"
+        "\t\trunning esm_runscripts with a virtual environment, so that your changes are included in the\n"
+        "\t\tvirtual environment installation.\n\n"
+
+        "\n\t\tYou may also select to install esm_tools in 'editable mode', in which case\n"
+        "\t\tthey will be installed in a folder `src/esm_tools/` in the root of\n"
+        "\t\tyour experiment. Any changes made to code in that folder **will** influence how the\n"
+        "\t\tesm-tools behave.\n"
+
+        "\n\t\tNote regarding config yamls and namelists\n"
+        "\t\t-----------------------------------------\n"
+        "\t\tWhen using a virtual environment, config files and namelists will come of the\n"
+        "\t\tfolder .venv_esmtools listed above and **not** from your user install directory.\n"
+        "\t\tYou should make **all** changes to the namelists and config files via your user\n"
+        "\t\trunscript. This is recommended in all cases!!!\n"
     )
-    questionary.print(
-        "\t\tThis shields the run from changes made to the remainder of the ESM-Tool installation\n"
-    )
-    questionary.print(
-        "\t\tBefore the first run, a local copy will be installed in the experiment tree,"
-    )
-    questionary.print("\t\tand **this** installation will be used:")
-    questionary.print(
-        f"\t\t\t {config['general']['experiment_dir']}/.venv_esmtools/lib/python-{sys.version_info.major}.{sys.version_info.minor}/site-packages/esm-tools"
-    )
-    questionary.print("\t\tinstead of:")
-    questionary.print(f"\t\t\t{find_package('esm-tools')}\n")
-    questionary.print(
-        "\n\t\tIf you choose to use a virtual environment, a folder named `.venv_esmtools`"
-    )
-    questionary.print(
-        "\t\twill be created at the root of your experiment. This contains all the Python"
-    )
-    questionary.print(
-        "\t\tlibraries used by the esm-tools. The first installation induces some overhead (~2-3 minutes)."
-    )
-    questionary.print(
-        "\n\t\tYou may also select to install some packages in 'editable mode', in which case"
-    )
-    questionary.print(
-        "\t\tthey will be installed in a folder `src/esm_tools/<package_name>` in the root of"
-    )
-    questionary.print(
-        "\t\tyour experiment. Any changes made to code in that folder **will** influence how the"
-    )
-    questionary.print("\t\tesm-tools behave.")
-    questionary.print("\n\t\tNote regarding config yamls and namelists")
-    questionary.print("\t\t-----------------------------------------")
-    questionary.print(
-        "\t\tWhen using a virtual environment, config files and namelists will come of the"
-    )
-    questionary.print(
-        "\t\tfolder .venv_esmtools listed above and **not** from your user install directory."
-    )
-    questionary.print(
-        "\t\tYou should make **all** changes to the namelists and config files via your user"
-    )
-    questionary.print("\t\trunscript. This is recommended in all cases!!!")
+    questionary.print(questionary_text)
     questionary.print(
         "\t\t --> Changing any settings in your user install ($HOME or similar) will therefore not change your run!! <--",
         style="fg:red",
@@ -378,13 +370,21 @@ def _integorate_user_venv(config):
             sys.exit(0)
         config["general"]["use_venv"] = "Run in virtualenv" in response
         user_confirmed = questionary.confirm("Are you sure?").ask()
-    if "Run in virtualenv" in response:
-        editable_mode_choices = questionary.checkbox(
-            "Which of the following packages do you want to install in 'editable mode'? End with <Enter>",
-            choices=esm_tools_modules,
-        ).ask()
-        for choice in editable_mode_choices:
-            config["general"][f"install_{choice}_editable"] = True
+    if (
+        "Run in virtualenv" in response
+        and not "install_esm_tools_editable" in config["general"]
+    ):
+        response = questionary.select(
+            "Do you want to install esm_tools in **editable mode**?",
+            choices=[
+                f"No (default, esm_tools will be installed in `{config['general']['experiment_dir']}/.venv_esmtools/lib/python{sys.version_info.major}.{sys.version_info.minor}/site-packages/esm_tools`)",
+                f"Yes (esm_tools will be installed in `{config['general']['experiment_dir']}/src/esm-tools`)",
+                "Quit right now to adapt your runscript (you can set `general.install_esm_tools_editable` to override this questionary)",
+            ],
+        ).ask()  # returns value of selection
+        if "Quit" in response:
+            sys.exit(0)
+        config["general"][f"install_esm_tools_editable"] = "Yes" in response
     return config
 
 

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.6.6"
+__version__ = "6.6.7"


### PR DESCRIPTION
This PR includes some changes to make the `venv` dialogue box clearer (changes were not made there for Release 6):
- Includes @JanStreffing suggestion on including a mention to the `install_esm_tools_branch` option in the dialogue box.
- Updated the text for release 6
- Removes the packages editable-installation questionary, as we don't have packages anymore, and instead asks about editable installation of the tools only