### PR TITLE
Feature: Commented Origins

### DIFF
--- a/configs/esm_software/esm_runscripts/esm_plugins.yaml
+++ b/configs/esm_software/esm_runscripts/esm_plugins.yaml
@@ -78,7 +78,6 @@ core:
                         - "database_entry"
 
                 batch_system:
-                        #- "calculate_requirements"
                         - "write_simple_runscript"
                         - "write_env"
                         - "find_openmp"

--- a/src/esm_calendar/esm_calendar.py
+++ b/src/esm_calendar/esm_calendar.py
@@ -42,6 +42,7 @@ def date_range(start_date, stop_date, frequency):
 
 
 class Dateformat(object):
+    yaml_tag = "!Dateformat"
     datesep = ["", "-", "-", "-", " ", " ", "", "-", "", "", "/"]
     timesep = ["", ":", ":", ":", " ", ":", ":", "", "", "", ":"]
     dtsep = ["_", "_", "T", " ", " ", " ", "_", "_", "", "_", " "]
@@ -96,6 +97,7 @@ class Calendar(object):
         (considering leapyears)
     """
 
+    yaml_tag = "!esm_calendar"
     timeunits = ["years", "months", "days", "hours", "minutes", "seconds"]
     monthnames = [
         "Jan",
@@ -259,6 +261,12 @@ class Date(object):
     Methods
     -------
     """
+
+    yaml_tag = "!esm_date"
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_mapping(cls.yaml_tag, data.__dict__)
 
     def __init__(self, indate, calendar=Calendar()):
         printhours = True

--- a/src/esm_environment/esm_environment.py
+++ b/src/esm_environment/esm_environment.py
@@ -49,6 +49,8 @@ class EnvironmentInfos:
         will loop through all the available keys in ``complete_config``.
     """
 
+    yaml_tag = "!EnvironmentInfos"
+
     def __init__(self, run_or_compile, complete_config=None, model=None):
         # Ensure local copy of complete config to avoid mutating it... (facepalm)
         complete_config = copy.deepcopy(complete_config)

--- a/src/esm_parser/yaml_to_dict.py
+++ b/src/esm_parser/yaml_to_dict.py
@@ -4,6 +4,7 @@ import sys
 
 import yaml
 from loguru import logger
+from ruamel.yaml import YAML
 
 import esm_parser
 
@@ -178,7 +179,14 @@ def yaml_file_to_dict(filepath):
                 # Back to the beginning of the file
                 yaml_file.seek(0, 0)
                 # Actually load the file
-                yaml_load = yaml.load(yaml_file, Loader=loader)  # yaml.FullLoader)
+                yaml_from_ruamel = YAML()
+                import pdb
+
+                pdb.set_trace()
+                yaml_load = yaml_from_ruamel.load(yaml_file)
+                print(yaml_load)
+                pdb.set_trace()
+                # yaml_load = yaml.load(yaml_file, Loader=loader)  # yaml.FullLoader)
                 # Check for incompatible ``_changes`` (no more than one ``_changes``
                 # type should be accessible simultaneously)
                 check_changes_duplicates(yaml_load, filepath + extension)

--- a/src/esm_parser/yaml_to_dict.py
+++ b/src/esm_parser/yaml_to_dict.py
@@ -146,6 +146,28 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
     return loader
 
 
+
+def add_origin_metadata(my_dict, filename):
+    for key, value in my_dict.items():
+        if isinstance(value, dict):
+            add_origin_metadata(value, filename)
+        # FIXME LISTS
+        import ipdb
+        ipdb.set_trace()
+        setattr(key.lc, "filename", filename)
+
+
+def add_origin_comments(my_dict):
+    for key, value in my_dict.items():
+        if isinstance(value, dict):
+            add_origin_comments(value)
+        # FIXME LISTS
+        try:
+            my_dict[key].yaml_add_eol_comment(my_dict[key].filename)
+        except AttributeError:
+            print(value, key)
+
+
 def yaml_file_to_dict(filepath):
     """
     Given a yaml file, returns a corresponding dictionary.
@@ -180,12 +202,17 @@ def yaml_file_to_dict(filepath):
                 yaml_file.seek(0, 0)
                 # Actually load the file
                 yaml_from_ruamel = YAML()
-                import pdb
+                import ipdb
 
-                pdb.set_trace()
                 yaml_load = yaml_from_ruamel.load(yaml_file)
+                ipdb.set_trace()
+                add_origin_metadata(yaml_load, yaml_file)
                 print(yaml_load)
-                pdb.set_trace()
+                add_origin_comments(yaml_load)
+                with open("foo.yaml","w") as f:
+                    yaml_from_ruamel.dump(yaml_load, f)
+                ipdb.set_trace()
+
                 # yaml_load = yaml.load(yaml_file, Loader=loader)  # yaml.FullLoader)
                 # Check for incompatible ``_changes`` (no more than one ``_changes``
                 # type should be accessible simultaneously)

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -219,9 +219,14 @@ def reuse_sources(config):
     return config
 
 
+
+
 def choose_needed_files(config):
     # aim of this function is to only take those files specified in fileytype_files
     # (if exists), and then remove filetype_files
+    import pprint
+
+    print = pprint.pprint
 
     for filetype in config["general"]["all_model_filetypes"]:
         for model in config["general"]["valid_model_names"] + ["general"]:
@@ -239,11 +244,10 @@ def choose_needed_files(config):
                         + filetype
                         + " of model "
                         + model,
-                        flush=True,
                     )
-                    print(config[model][filetype + "_files"], flush=True)
-                    print(config[model][filetype + "_sources"], flush=True)
-                    print(datetime.datetime.now(), flush=True)
+                    print(config[model][filetype + "_files"],)
+                    print(config[model][filetype + "_sources"],)
+                    print(datetime.datetime.now(),)
                     sys.exit(-1)
                 new_sources.update({categ: config[model][filetype + "_sources"][name]})
 

--- a/src/esm_runscripts/prepare.py
+++ b/src/esm_runscripts/prepare.py
@@ -36,7 +36,13 @@ def mini_resolve_variable_date_file(date_file, config):
                         )
                         print(f"date_file = {date_file}")
                         sys.exit(1)
-        date_file = pre + answer + post
+        try:
+            date_file = pre + answer + post
+        except TypeError:
+            print(f"We need to do a string conversion here: {answer}")
+            print(f"{answer=}")
+            print(f"str(answer) = {str(answer)}")
+            date_file = pre + str(answer) + post
     return date_file
 
 


### PR DESCRIPTION
This currently **wip** PR will allow origin comments to be included in a
finished YAML. There is still come cleanup work that needs to be done.

Example of current output:

```yaml
echam:
# ECHAM YAML DEFAULT CONFIGURATION FILE:

  model: echam  # ESM_ORIGIN: /work/ollie/pgierz/SciComp/Projects/Workflows/model_runtime/software/github.com/esm-tools/esm_tools/configs/.//components/echam/echam.yaml:(2, 7)
  repository: https://gitlab.dkrz.de/modular_esm/echam6 # ESM_ORIGIN: /work/ollie/pgierz/SciComp/Projects/Workflows/model_runtime/software/github.com/esm-tools/esm_tools/configs/.//components/echam/echam.yaml:(3, 12)
  type: atmosphere # ESM_ORIGIN: /work/ollie/pgierz/SciComp/Projects/Workflows/model_runtime/software/github.com/esm-tools/esm_tools/configs/.//components/echam/echam.yaml:(4, 6)
  compile_infos:
    available_versions:  # ESM_ORIGIN: /work/ollie/pgierz/SciComp/Projects/Workflows/model_runtime/software/github.com/esm-tools/esm_tools/configs/.//components/echam/echam.yaml:(10, 8)
    - 6.3.05p2
    - 6.3.05p2-foci
    - 6.3.05p2-foci_oasismct4
    - 6.3.02p4
    - 6.3.04p1-esm_interface
    - 6.3.05p2-concurrent_radiation
    - 6.3.04p1-paleodyn
    - 6.3.04p1-recom-awicm
    - 6.3.05p2-concurrent_radiation-paleodyn
    - 6.3.04p1
    - 6.3.05p2-wiso
    branch: 6.3.05p2-concurrent_radiation-paleodyn # ESM_ORIGIN: /work/ollie/pgierz/SciComp/Projects/Workflows/model_runtime/software/github.com/esm-tools/esm_tools/configs/.//components/echam/echam.yaml:(22, 16)
```
