### PR TITLE
fix compilation flags in rnfmap (only affecting FOCI-OpenIFS)

### DIFF
--- a/configs/components/rnfmap/rnfmap.yaml
+++ b/configs/components/rnfmap/rnfmap.yaml
@@ -172,10 +172,18 @@ compiletime_environment_changes:
       - 'OIFS_NETCDFF_LIB="-L$NETCDFFROOT/lib -lnetcdff"'
       # compiler and compiler flags
       - 'OIFS_FC=$FC'
-      - 'OIFS_FFLAGS="-r8 -fp-model precise -align array32byte -O3 -march=core-avx2 -mtune=core-avx2 -g -traceback -convert big_endian -fpe0"'
+      - 'OIFS_FFLAGS="${rnfmap.fflags}"'
       - 'OIFS_FFIXED=""'
       - 'OIFS_FCDEFS="BLAS LITTLE LINUX INTEGER_IS_INT"'
       - 'OIFS_LFLAGS=$OIFS_MPI_LIB'
       - 'OIFS_CC=$CC'
-      - 'OIFS_CFLAGS="-fp-model precise -O3 -march=core-avx2 -mtune=core-avx2 -g -traceback -qopt-report=0 -fpe0"'
+      - 'OIFS_CFLAGS="${rnfmap.cflags}"'
       - 'OIFS_CCDEFS="LINUX LITTLE INTEGER_IS_INT _ABI64 BLAS"'
+
+choose_computer.name:
+    levante:
+        fflags: -r8 -fp-model precise -align array32byte -O3 -march=core-avx2 -mtune=core-avx2 -g -traceback -convert big_endian -fpe0
+        cflags: -fp-model precise -O3 -march=core-avx2 -mtune=core-avx2 -g -traceback -qopt-report=0 -fpe0
+    "*":
+       fflags: -r8 -fp-model precise -align array32byte -O3 -xCORE_AVX2 -g -traceback -convert big_endian -fpe0
+       cflags: -fp-model precise -O3 -xCORE_AVX2 -g -traceback -qopt-report=0 -fpe0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.7.4
+current_version = 6.7.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.7.4",
+    version="6.7.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.7.4"
+__version__ = "6.7.5"


### PR DESCRIPTION
The file `configs/components/rnfmap/rnfmap.env.yaml` contained the compilation flags for `levante` (`-march` and `-mtune`) and was applying it to all computers (including `blogin`). After this fix, the default will be the standard, and `-march` and `-mtune` will only be used in `levante`. This only affects to FOCI-OpenIFS, because AWICM3 uses a common environment for all components based on `oifs.env.yaml`, and there, the levante flags are already behind a choose block for levante.