### PR TITLE
Remove develop merge in CI

### DIFF
--- a/.github/workflows/pre-merge_actions.yml
+++ b/.github/workflows/pre-merge_actions.yml
@@ -139,11 +139,11 @@ jobs:
           secrets:
             PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       # Merge PR-branch into `develop`
-      - name: merge into develop
-        run: |
-          echo ${{ steps.vars.outputs.current_branch }};
-          git checkout develop;
-          git merge ${{ steps.vars.outputs.current_branch }};
-          git push
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+      # - name: merge into develop
+      #   run: |
+      #     echo ${{ steps.vars.outputs.current_branch }};
+      #     git checkout develop;
+      #     git merge ${{ steps.vars.outputs.current_branch }};
+      #     git push
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  


### PR DESCRIPTION
This removes to merge to the develop branch in CI that is made with the $bump automation.
