### PR TITLE
Ci/automate esm tests info update

### DIFF
--- a/.github/workflows/approve_esm_tests_changes.yml
+++ b/.github/workflows/approve_esm_tests_changes.yml
@@ -13,7 +13,7 @@ on:
     
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
-
+ 
 jobs:
   # Sequence of tasks that will be executed as part of the job
   ollie:

--- a/.github/workflows/esm_tests_computer_workflow.yml
+++ b/.github/workflows/esm_tests_computer_workflow.yml
@@ -52,7 +52,7 @@ jobs:
         cd src/esm_tests/resources;
         rm -rf automatic_testing; # cleanup the resources directory from tests
         git add .;
-        #git commit -ma "approved changes from GitHub actions for ${{ inputs.computer }}";
-        echo "approved changes from GitHub actions for ${{ inputs.computer }}";
-        git status
+        git commit -ma "approved changes from GitHub actions for ${{ inputs.computer }}";
+        git status;
+        git push;
         

--- a/.github/workflows/esm_tests_computer_workflow.yml
+++ b/.github/workflows/esm_tests_computer_workflow.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
     # NK: this changes working directory to fesom2
     - uses: actions/checkout@v2
+      with:
+        ref: CI/automate_esm_tests_info_update
 
     - name: add to the path
       run: |

--- a/.github/workflows/esm_tests_computer_workflow.yml
+++ b/.github/workflows/esm_tests_computer_workflow.yml
@@ -34,8 +34,6 @@ jobs:
     steps:
     # NK: this changes working directory to fesom2
     - uses: actions/checkout@v2
-      with:
-        ref: CI/automate_esm_tests_info_update
 
     - name: add to the path
       run: |

--- a/.github/workflows/esm_tests_computer_workflow.yml
+++ b/.github/workflows/esm_tests_computer_workflow.yml
@@ -50,6 +50,7 @@ jobs:
         git config --global user.name "${GITHUB_ACTOR}";
         git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com";
         cd src/esm_tests/resources;
+        rm -rf automatic_testing; # cleanup the resources directory from tests
         git add .;
         #git commit -ma "approved changes from GitHub actions for ${{ inputs.computer }}";
         echo "approved changes from GitHub actions for ${{ inputs.computer }}";


### PR DESCRIPTION
Should allow for approval of changes in the esm_tests info by typing $approve-changes command (change $ by #).