### PR TITLE
Fix/726 pism on levante

### DIFF
--- a/configs/components/pism/pism.yaml
+++ b/configs/components/pism/pism.yaml
@@ -89,6 +89,10 @@ choose_computer.partitions.compute.cores_per_node:
         nnodes: 2
         nproca: 72
         nprocb: 1
+    128:
+        nnodes: 1
+        nproca: 128
+        nprocb: 1
 
 
 time_step: 100

--- a/configs/components/pism/pism.yaml
+++ b/configs/components/pism/pism.yaml
@@ -89,6 +89,7 @@ choose_computer.partitions.compute.cores_per_node:
         nnodes: 2
         nproca: 72
         nprocb: 1
+    # Settings for DKRZ's Levante
     128:
         nnodes: 1
         nproca: 128

--- a/src/esm_master/task.py
+++ b/src/esm_master/task.py
@@ -37,11 +37,18 @@ def install(package: str) -> None:
     installed_packages = esm_plugin_manager.find_installed_plugins()
     if not package_name in installed_packages:
         try:
-            subprocess.check_call([sys.executable, "-m", "pip", "install", "--user",package])
+            if not os.environ.get("VIRTUAL_ENV"):
+                subprocess.check_call([sys.executable, "-m", "pip", "install", "--user",package])
+            else:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", package])
         except (OSError, subprocess.CalledProcessError):  # PermissionDeniedError would be nicer...
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", "--user", package]
-            )
+            if not os.environ.get("VIRTUAL_ENV"):
+                # FIXME(PG): I do not really understand this....it is the same call as above??
+                subprocess.check_call(
+                    [sys.executable, "-m", "pip", "install", "--user", package]
+                )
+            else:
+                subprocess.check_call([sys.executable, "-m", "pip", "install", package])
 
 
 ######################################################################################


### PR DESCRIPTION
This is still in progress, will close #726.

Support for PISM on DKRZ's Levante HPC. Includes number of CPUs for Levante, and fixes a problem with esm-master.

Still to do: spack support to install pism on Levante.