### PR TITLE
fix/import git in juwels

### DIFF
--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -106,6 +106,7 @@ choose_compiler_mpi:
         - "load Python/3.9.6"
         - "load imkl/2021.4.0"
         - "load Perl/5.34.0"
+         - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -127,6 +128,7 @@ choose_compiler_mpi:
         - "load Python/3.9.6"
         - "load imkl/2021.4.0"
         - "load Perl/5.34.0"
+         - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -149,6 +151,7 @@ choose_compiler_mpi:
         - "load imkl/2020.2.254"
         - "load Perl/5.32.0"
         - "load UCX/1.10.1"
+         - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -168,6 +171,7 @@ choose_compiler_mpi:
         - "load Python/3.8.5"
         - "load imkl/2020.2.254"
         - "load Perl/5.32.0"
+         - "load git"
       add_export_vars:
         FC: mpiifort
         F77: mpiifort
@@ -193,6 +197,7 @@ choose_compiler_mpi:
         - "unload netCDF-Fortran"
         - "unload netCDF"
         - "unload grib_api"
+         - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -211,6 +216,7 @@ choose_compiler_mpi:
          - "load CMake"
          - "load Python/3.6.8"
          - "load imkl/2019.3.199"
+         - "load git"
       add_export_vars:
          FC: mpiifort
          F77: mpiifort
@@ -233,6 +239,7 @@ choose_compiler_mpi:
          - "unload netCDF-Fortran"
          - "unload netCDF"
          - "unload grib_api"
+         - "load git"
       add_export_vars:
          FC: mpifort
          F77: mpifort
@@ -250,6 +257,7 @@ choose_iolibraries:
        # TODO: find the correct libraries and dependencies
        add_module_actions:
          - "load netCDF netCDF-Fortran"
+         - "load git"
 
     # AWI LIBS
     awi_libs:

--- a/configs/machines/juwels.yaml
+++ b/configs/machines/juwels.yaml
@@ -106,7 +106,7 @@ choose_compiler_mpi:
         - "load Python/3.9.6"
         - "load imkl/2021.4.0"
         - "load Perl/5.34.0"
-         - "load git"
+        - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -128,7 +128,7 @@ choose_compiler_mpi:
         - "load Python/3.9.6"
         - "load imkl/2021.4.0"
         - "load Perl/5.34.0"
-         - "load git"
+        - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -151,7 +151,7 @@ choose_compiler_mpi:
         - "load imkl/2020.2.254"
         - "load Perl/5.32.0"
         - "load UCX/1.10.1"
-         - "load git"
+        - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort
@@ -171,7 +171,7 @@ choose_compiler_mpi:
         - "load Python/3.8.5"
         - "load imkl/2020.2.254"
         - "load Perl/5.32.0"
-         - "load git"
+        - "load git"
       add_export_vars:
         FC: mpiifort
         F77: mpiifort
@@ -197,7 +197,7 @@ choose_compiler_mpi:
         - "unload netCDF-Fortran"
         - "unload netCDF"
         - "unload grib_api"
-         - "load git"
+        - "load git"
       add_export_vars:
         FC: mpifort
         F77: mpifort

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.12.5
+current_version = 6.12.6
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.12.6
+current_version = 6.12.7
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.12.6",
+    version="6.12.7",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.12.5",
+    version="6.12.6",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_calendar import *

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_environment import *

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 
 from . import database

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_motd import *

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_plugin_manager import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .esm_profile import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 import functools
 import inspect

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.12.5"
+__version__ = "6.12.6"
 
 from .utils import *

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.12.6"
+__version__ = "6.12.7"
 
 from .utils import *


### PR DESCRIPTION
In Juwels, `import git` from the `helpers.py` results into an error stating that git needs to be loaded. This PR adds the `module load git` to the Juwels environments to solve the problem. 