### PR TITLE
fix/awiesm_general_scenario

### DIFF
--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -85,7 +85,7 @@ general:
         with_icebergs: false
         with_bootstrap: false
 
-        scenario: "PALEO"
+        scenario: "PI-CTRL"
         resolution: ${echam.resolution}_${fesom.resolution}
         postprocessing: false
         post_time: "00:05:00"
@@ -102,6 +102,7 @@ general:
 #########################################################################################
 
 echam:
+        scenario: ${general.scenario}
         restart_firstlast: "first"
         namelist_changes:
                 namelist.echam:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.13.2
+current_version = 6.13.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.13.2",
+    version="6.13.3",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_archiving import (
     archive_mistral,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 
 from .yaml_to_dict import yaml_file_to_dict

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .sim_objects import *
 from .batch_system import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .initialization import *
 from .tests import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.13.2"
+__version__ = "6.13.3"
 
 from .utils import *


### PR DESCRIPTION
Before, the AWIESM's `general.scenario` was never transmitted to ECHAM. One can see by just running a runscript without any scenario variable, and then looking at the `finished_config.yaml`: the `general.scenario` there is `PALEO`, the default for AWIESM, however, in ECHAM the scenario is `PI-CTRL`, the default for ECHAM. 

`general.scenario` did really nothing on the past, since it was not fed into any other variable, but `echam.scenario` does a bunch. That's what I decided to change the default of `general.scenario` for AWIESM to `PI-CTRL`, so when people update ESM-Tools the still get the same behavior (`echam.scenario: PI-CTRL`)