### PR TITLE
enforce absolute path for path_in_computer 

### DIFF
--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -209,7 +209,7 @@ class SimulationFile(dict):
                 "File Dictionaries",
                 "The path defined for "
                 f"``{self.component}.files.{self.name}.path_in_computer`` is not "
-                "abosulte. Please, always define an absolute path for the "
+                "absolute. Please, always define an absolute path for the "
                 "``path_in_computer`` variable."
             )
 

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -21,7 +21,7 @@ class SimulationFile(dict):
         echam:
             files:
                 jan_surf:
-                    name_in_pool: T63CORE2_jan_surf.nc
+                    name_in_computer: T63CORE2_jan_surf.nc
                     name_in_work: unit.24
                     filetype: NetCDF
                     description: >
@@ -54,18 +54,18 @@ class SimulationFile(dict):
         self.component = component = attrs_address.split(".")[0]
         self.locations = {
             "work": pathlib.Path(full_config[component]["thisrun_work_dir"]),
-            "pool": pathlib.Path(self["path_in_pool"]),
+            "computer": pathlib.Path(self["path_in_computer"]),
 #            "exp_tree": pathlib.Path(full_config[component]["exp_dir"]), # This name is incorrect and depends on the type of file (to be resolved somewhere else before feeding it here)
 #            "run_tree": pathlib.Path(full_config[component]["thisrun_dir"]), # This name is incorrect and depends on the type of file (to be resolved somewhere else before feeding it here)
 
         }
         self.names = {
             "work": pathlib.Path(self["name_in_work"]),
-            "pool": pathlib.Path(self["name_in_pool"]),
+            "computer": pathlib.Path(self["name_in_computer"]),
         }
         # Allow dot access:
         self.work = self.locations["work"]
-        self.pool = self.locations["pool"]
+        self.computer = self.locations["computer"]
 #        self.exp_tree = self.locations["exp_tree"] # TODO: uncomment when lines above are fixed
 #        self.run_tree = self.locations["run_tree"] # TODO: uncomment when lines above are fixed
 
@@ -80,10 +80,10 @@ class SimulationFile(dict):
         Parameters
         ----------
         source : str
-            String specifying one of the following options: ``"pool"``, ``"work"``,
+            String specifying one of the following options: ``"computer"``, ``"work"``,
             ``"exp_tree"``, ``run_tree``
         target : str
-            String specifying one of the following options: ``"pool"``, ``"work"``,
+            String specifying one of the following options: ``"computer"``, ``"work"``,
             ``"exp_tree"``, ``run_tree``
         """
         # Build target and source paths
@@ -118,9 +118,9 @@ class SimulationFile(dict):
         Parameters
         ----------
         source : str
-            One of ``"pool"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
+            One of ``"computer"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
         target : str
-            One of ``"pool"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
+            One of ``"computer"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
         """
         if source not in self.locations:
             raise ValueError(
@@ -141,16 +141,16 @@ class SimulationFile(dict):
         """
         Determines names for source and target, depending on name and path
 
-        Source and target should be on of work, pool, exp_tree, or run_tree.
+        Source and target should be on of work, computer, exp_tree, or run_tree.
         You need to specify name_in_`source` and name_in_`target` in the
         object's attrs_dict.
 
         Parameters
         ----------
         source : str
-            One of ``"pool"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
+            One of ``"computer"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
         target : str
-            One of ``"pool"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
+            One of ``"computer"``, ``"work"``, ``"exp_tree"``, "``run_tree``"
 
         Returns
         -------

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -228,11 +228,8 @@ def test_check_path_in_computer_is_abs(fs):
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
-        try:
+        with pytest.raises(SystemExit) as error:
             sim_file = esm_runscripts.filedicts.SimulationFile(config, "echam.files.jan_surf")
-        except SystemExit as e:
-            error = e
 
     # error needs to occur as the path is not absolute
-    assert isinstance(error, SystemExit)
     assert any(["ERROR: File Dictionaries" in line for line in output])

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -38,7 +38,7 @@ def test_example(fs):
         simulation_files:
             jan_surf:
                 name: ECHAM Jan Surf File
-                path_in_pool: /work/ollie/pool/ECHAM/T63CORE2_jan_surf.nc
+                path_in_computer: /work/ollie/pool/ECHAM/T63CORE2_jan_surf.nc
                 name_in_work: unit.24
     """
     config = yaml.safe_load(config)
@@ -56,20 +56,21 @@ def test_filedicts_basics(fs):
 
     dummy_config = """
     general:
-        thisrun_work_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
-        exp_dir: "/work/ollie/pgierz/some_exp"
         thisrun_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101"
+        exp_dir: "/work/ollie/pgierz/some_exp"
     computer:
         pool_dir: "/work/ollie/pool"
     echam:
         files:
             jan_surf:
-                name_in_pool: T63CORE2_jan_surf.nc
+                name_in_computer: T63CORE2_jan_surf.nc
                 name_in_work: unit.24
+                path_in_computer: /work/ollie/pool/ECHAM/T63
                 filetype: NetCDF
                 description: >
                     Initial values used for the simulation, including
                     properties such as geopotential, temperature, pressure
+        thisrun_work_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
     """
     config = yaml.safe_load(dummy_config)
     # Not needed for this test, just a demonstration:
@@ -80,7 +81,7 @@ def test_filedicts_basics(fs):
         "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
     )
     assert sim_file._config == config
-    assert sim_file.locations["pool"] == Path("/work/ollie/pool")
+    assert sim_file.locations["computer"] == Path("/work/ollie/pool/ECHAM/T63")
 
 
 def test_cp_file(fs):
@@ -90,9 +91,9 @@ def test_cp_file(fs):
     echam:
         files:
             jan_surf:
-                name_in_pool: T63CORE2_jan_surf.nc
+                name_in_computer: T63CORE2_jan_surf.nc
                 name_in_work: unit.24
-                path_in_pool: /work/ollie/pool/ECHAM/T63/
+                path_in_computer: /work/ollie/pool/ECHAM/T63/
         thisrun_work_dir: /work/ollie/mandresm/awiesm/run_20010101-20010101/work/
     """
     config = yaml.safe_load(dummy_config)
@@ -100,8 +101,8 @@ def test_cp_file(fs):
     # Set source and targets
     target_folder = config["echam"]["thisrun_work_dir"]
     source = Path(
-        config["echam"]["files"]["jan_surf"]["path_in_pool"],
-        config["echam"]["files"]["jan_surf"]["name_in_pool"],
+        config["echam"]["files"]["jan_surf"]["path_in_computer"],
+        config["echam"]["files"]["jan_surf"]["name_in_computer"],
     )
     target = Path(
         target_folder,
@@ -113,7 +114,7 @@ def test_cp_file(fs):
 
     # Test the method
     sim_file = esm_runscripts.filedicts.SimulationFile(config, "echam.files.jan_surf")
-    sim_file.cp("pool", "work")
+    sim_file.cp("computer", "work")
 
     assert os.path.exists(target)
 
@@ -124,9 +125,9 @@ def test_cp_folder(fs):
     oifs:
         files:
             o3_data:
-                name_in_pool: o3chem_l91
+                name_in_computer: o3chem_l91
                 name_in_work: o3chem_l91
-                path_in_pool: /work/ollie/pool/OIFS/159_4
+                path_in_computer: /work/ollie/pool/OIFS/159_4
         thisrun_work_dir: /work/ollie/mandresm/awiesm/run_20010101-20010101/work/
     """
     config = yaml.safe_load(dummy_config)
@@ -134,8 +135,8 @@ def test_cp_folder(fs):
     # Set source and targets
     target_folder = config["oifs"]["thisrun_work_dir"]
     source = Path(
-        config["oifs"]["files"]["o3_data"]["path_in_pool"],
-        config["oifs"]["files"]["o3_data"]["name_in_pool"],
+        config["oifs"]["files"]["o3_data"]["path_in_computer"],
+        config["oifs"]["files"]["o3_data"]["name_in_computer"],
     )
     target = Path(
         target_folder,
@@ -147,7 +148,7 @@ def test_cp_folder(fs):
 
     # Test the method
     sim_file = esm_runscripts.filedicts.SimulationFile(config, "oifs.files.o3_data")
-    sim_file.cp("pool", "work")
+    sim_file.cp("computer", "work")
 
     assert os.path.exists(target)
 
@@ -164,7 +165,6 @@ def test_mv(fs):
     """Tests for mv"""
     dummy_config = """
     general:
-        thisrun_work_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
         exp_dir: "/work/ollie/pgierz/some_exp"
         thisrun_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101"
     computer:
@@ -172,18 +172,18 @@ def test_mv(fs):
     echam:
         files:
             jan_surf:
-                name_in_pool: T63CORE2_jan_surf.nc
-                path_in_pool: ECHAM/T63/
+                name_in_computer: T63CORE2_jan_surf.nc
+                path_in_computer: /work/ollie/pool/ECHAM/T63/
                 name_in_work: unit.24
                 path_in_work: .
-        thisrun_work_dir: /work/ollie/mandresm/awiesm/run_20010101-20010101/work/
+        thisrun_work_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
     """
     config = yaml.safe_load(dummy_config)
     fs.create_file("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
     fs.create_dir("/work/ollie/pgierz/some_exp/run_20010101-20010101/work")
     assert os.path.exists("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
     sim_file = esm_runscripts.filedicts.SimulationFile(config, "echam.files.jan_surf")
-    sim_file.mv("pool", "work")
+    sim_file.mv("computer", "work")
     assert not os.path.exists("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
     assert os.path.exists(
         "/work/ollie/pgierz/some_exp/run_20010101-20010101/work/unit.24"


### PR DESCRIPTION
- [x] Changes `pool` for `computer` in our moving-direction logic
- [x] Fixes the broken unit tests
- [x] Checks that the `path_in_computer` is an absolute path and if not reports an user error
- [x] Unit test for the absolute path check