### PR TITLE
Datestamps

### DIFF
--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -172,7 +172,7 @@ class SimulationFile(dict):
         return super().__setattr__(name, value)
 
     def __setitem__(self, key: Any, value: Any) -> None:
-        # Checks for changing with sim_file["my_key"] = "new_value"
+        """Checks for changing with sim_file["my_key"] = "new_value""""
         if key == "datestamp_format":
             self._check_datestamp_format_is_allowed(value)
         if key == "datestamp_method":

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -13,15 +13,12 @@ import functools
 import os
 import pathlib
 import shutil
-
 from typing import Any, AnyStr, Tuple, Type, Union
-import yaml
-
 
 import dpath.util
-from loguru import logger
-
+import yaml
 from esm_parser import ConfigSetup, user_error
+from loguru import logger
 
 
 # NOTE(PG): Comment can be removed later. Here I prefix with an underscore as
@@ -544,7 +541,14 @@ class SimulationFile(dict):
         this_filedict = copy.deepcopy(self._original_filedict)
         input_file_types = ["config", "forcing", "input"]
         output_file_types = [
-            "analysis", "couple", "log", "mon", "outdata", "restart", "viz", "ignore"
+            "analysis",
+            "couple",
+            "log",
+            "mon",
+            "outdata",
+            "restart",
+            "viz",
+            "ignore",
         ]
 
         if "type" not in self.keys():
@@ -565,7 +569,10 @@ class SimulationFile(dict):
             )
             this_filedict["type"] = f"``{this_filedict['type']}``"
 
-        if "path_in_computer" not in self.keys() and self.get("type") in input_file_types:
+        if (
+            "path_in_computer" not in self.keys()
+            and self.get("type") in input_file_types
+        ):
             error_text = (
                 f"{error_text}"
                 f"- the ``path_in_computer`` variable is missing. Please define a "
@@ -577,16 +584,17 @@ class SimulationFile(dict):
                 f"{missing_vars}    ``path_in_computer``: <path_to_file_dir>\n"
             )
 
-        if "name_in_computer" not in self.keys() and self.get("type") in input_file_types:
+        if (
+            "name_in_computer" not in self.keys()
+            and self.get("type") in input_file_types
+        ):
             error_text = (
                 f"{error_text}"
                 f"- the ``name_in_computer`` variable is missing. Please define a ``name_in_computer`` "
                 f"(i.e. name of the file in the work folder). NOTE: this is only required for "
                 f"{', '.join(input_file_types)} file types\n"
             )
-            missing_vars = (
-                f"{missing_vars}    ``name_in_computer``: <name_of_file_in_computer_dir>\n"
-            )
+            missing_vars = f"{missing_vars}    ``name_in_computer``: <name_of_file_in_computer_dir>\n"
 
         if "name_in_work" not in self.keys() and self.get("type") in output_file_types:
             error_text = (
@@ -611,7 +619,6 @@ class SimulationFile(dict):
                 f"or is incorrect:\n{error_text}"
             )
             user_error("File Dictionaries", f"{error_text}\n{missing_vars}")
-
 
     def _check_path_in_computer_is_abs(self):
         if not self.path_in_computer.is_absolute():

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -172,7 +172,7 @@ class SimulationFile(dict):
         return super().__setattr__(name, value)
 
     def __setitem__(self, key: Any, value: Any) -> None:
-        """Checks for changing with sim_file["my_key"] = "new_value""""
+        """Checks for changing with sim_file['my_key'] = 'new_value'"""
         if key == "datestamp_format":
             self._check_datestamp_format_is_allowed(value)
         if key == "datestamp_method":

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -135,7 +135,7 @@ class SimulationFile(dict):
         super().__init__(attrs_dict)
         self._original_filedict = copy.deepcopy(attrs_dict)
         self._config = full_config
-        self._sim_date = full_config["general"]["current_date"]
+        self._sim_date = full_config["general"]["current_date"] # NOTE: we might have to change this in the future, depending on whether SimulationFile is access through tidy ("end_date") or prepcompute ("start_date")
         self.name = attrs_address.split(".")[-1]
         self.component = component = attrs_address.split(".")[0]
         self.all_model_filetypes = full_config["general"]["all_model_filetypes"]

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -164,7 +164,7 @@ class SimulationFile(dict):
         self._check_path_in_computer_is_abs()
 
     def __setattr__(self, name: str, value: Any) -> None:
-        # Checks when changing dot attributes for disallowed values:
+        """Checks when changing dot attributes for disallowed values"""
         if name == "datestamp_format":
             self._check_datestamp_format_is_allowed(value)
         if name == "datestamp_method":

--- a/src/esm_runscripts/filedicts.py
+++ b/src/esm_runscripts/filedicts.py
@@ -73,6 +73,24 @@ def _allowed_to_be_missing(method):
 
 
 def _fname_has_date_stamp_info(fname, date, reqs=["%Y", "%m", "%d"]):
+    """
+    Checks if a particular file has all elements of a particular date in its name.
+    
+    Parameters
+    ----------
+    fname : str
+        The name of the file to check
+    date : esm_calendar.Date
+        The date to be checked against
+    reqs : list of str
+        A list of ``strftime`` compliant strings to determine which elements of the date to check. Compatible with %Y %m %d %H %M %S (year, month, day, hour, minute, second)
+        
+    Returns
+    -------
+    bool : 
+        True if all elements appear in the filename, False otherwise.
+    
+    """
     date_attrs = {
         "%Y": "syear",
         "%m": "smonth",

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -535,7 +535,15 @@ def test_datestamp_method_attr(simulation_file):
 def test_datestamp_format_attr(simulation_file):
     assert hasattr(simulation_file, "datestamp_format")
     assert isinstance(simulation_file.datestamp_format, str)
-    assert simulation_file.datestamp_format in ["from_filename", "append"]
+    assert simulation_file.datestamp_format in ["check_from_filename", "append"]
+    with pytest.raises(ValueError, match="one of check_from"):
+        simulation_file['datestamp_format'] = "blah"
+    with pytest.raises(ValueError, match="one of "):
+        # NOTE(PG): you can use _ for capturing a variable you don't care about
+        simulation_file.datestamp_format = "blah"
+    with pytest.raises(ValueError, match="one of check_from"):
+        # NOTE(PG): you can use _ for capturing a variable you don't care about
+        simulation_file.update(dict(datestamp_format="blah"))
 
 
 def test_datestamp_added_by_default_mv(simulation_file):

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -742,4 +742,4 @@ def test_fname_has_date_stamp_info():
     fname2 = "blah_2000-01.nc"
     date = esm_calendar.Date("2000-01-01T00:00:00")
     assert filedicts._fname_has_date_stamp_info(fname, date)
-    assert filedicts._fname_has_date_stamp_info(fname2, date) is False
+    assert not filedicts._fname_has_date_stamp_info(fname2, date)

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -21,6 +21,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+import esm_calendar
 import esm_runscripts.filedicts
 import esm_runscripts.filedicts as filedicts
 
@@ -69,7 +70,9 @@ def config_tuple():
         thisrun_input_dir: "/work/ollie/pgierz/some_exp/run_20000101-20000101/input/echam"
         thisrun_work_dir: "/work/ollie/pgierz/some_exp/run_20010101-20010101/work"
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(config_str)
+    config["general"]["current_date"] = date
     attr_address = "echam.files.jan_surf"
     # create a named tuple since configuration and the attribute address is tightly coupled to each other
     Config_Tuple = namedtuple("Config_Tuple", ["config", "attr_address"])
@@ -93,6 +96,8 @@ def simulation_file(fs, config_tuple):
 
     fs.create_dir(fake_simulation_file.locations["work"])
     fs.create_dir(fake_simulation_file.locations["computer"])
+    fs.create_dir(fake_simulation_file.locations["exp_tree"])
+    fs.create_dir(fake_simulation_file.locations["run_tree"])
     fs.create_file(fake_simulation_file["absolute_path_in_computer"])
 
     yield fake_simulation_file
@@ -113,7 +118,9 @@ def test_example(fs):
                 type: input
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(config)
+    config["general"]["current_date"] = date
     # Create some fake files and directories you might want in your test
     fs.create_file("/work/ollie/pool/ECHAM/T63CORE2_jan_surf.nc")
     fs.create_dir("/some/dummy/location/expid/run_18500101-18501231/work")
@@ -147,7 +154,9 @@ def test_filedicts_basics(fs):
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
     # Not needed for this test, just a demonstration:
     fs.create_file("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
     sim_file = esm_runscripts.filedicts.SimulationFile(config, "echam.files.jan_surf")
@@ -183,7 +192,10 @@ def test_allowed_to_be_missing_attr():
                 name_in_computer: "bar"
                 type: "input"
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
+    # Not needed for this test, just a demonstration:
     sim_file_001 = esm_runscripts.filedicts.SimulationFile(
         config, "echam.files.human_readable_tag_001"
     )
@@ -219,7 +231,9 @@ def test_allowed_to_be_missing_mv(fs):
                 path_in_work: .
                 movement_type: move
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
     fs.create_dir("/work/data/pool")
     fs.create_file("/work/data/pool/not_foo_at_all")
     sim_file = esm_runscripts.filedicts.SimulationFile(
@@ -247,7 +261,9 @@ def test_cp_file(fs):
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Set source and targets
     target_folder = config["general"]["thisrun_work_dir"]
@@ -283,10 +299,13 @@ def test_cp_folder(fs):
                 name_in_work: o3chem_l91
                 type: input
                 path_in_computer: /work/ollie/pool/OIFS/159_4
+                datestamp_method: never
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/oifs
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/oifs
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Set source and targets
     target_folder = config["general"]["thisrun_work_dir"]
@@ -340,7 +359,9 @@ def test_mv(fs):
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
     fs.create_file("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
     fs.create_dir("/work/ollie/pgierz/some_exp/run_20010101-20010101/work")
     assert os.path.exists("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
@@ -434,7 +455,9 @@ def test_check_path_in_computer_is_abs(fs):
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
@@ -466,7 +489,9 @@ def test_resolve_paths(fs):
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     sim_file = esm_runscripts.filedicts.SimulationFile(config, "echam.files.jan_surf")
 
@@ -523,12 +548,10 @@ def test_datestamp_method_attr(simulation_file):
     assert isinstance(simulation_file.datestamp_method, str)
     assert simulation_file.datestamp_method in ["never", "always", "avoid_overwrite"]
     with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
-        simulation_file['datestamp_method'] = "blah"
+        simulation_file["datestamp_method"] = "blah"
     with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
-        # NOTE(PG): you can use _ for capturing a variable you don't care about
         simulation_file.datestamp_method = "blah"
     with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
-        # NOTE(PG): you can use _ for capturing a variable you don't care about
         simulation_file.update(dict(datestamp_method="blah"))
 
 
@@ -537,27 +560,56 @@ def test_datestamp_format_attr(simulation_file):
     assert isinstance(simulation_file.datestamp_format, str)
     assert simulation_file.datestamp_format in ["check_from_filename", "append"]
     with pytest.raises(ValueError, match="one of check_from"):
-        simulation_file['datestamp_format'] = "blah"
+        simulation_file["datestamp_format"] = "blah"
     with pytest.raises(ValueError, match="one of "):
-        # NOTE(PG): you can use _ for capturing a variable you don't care about
         simulation_file.datestamp_format = "blah"
     with pytest.raises(ValueError, match="one of check_from"):
-        # NOTE(PG): you can use _ for capturing a variable you don't care about
         simulation_file.update(dict(datestamp_format="blah"))
 
 
-def test_datestamp_added_by_default_mv(simulation_file):
-    assert False
+@pytest.mark.parametrize("movement_type", ["mv", "ln", "cp"])
+def test_datestamp_added_by_default_mv_ln_cp(simulation_file, fs, movement_type):
+    """
+    Checks that the simulation file gets a timestamp if a file already exists with that name
 
-def test_datestamp_added_by_default_ln(simulation_file):
-    assert False
+    Defaults checked:
+    -----------------
+        * datestamp_format: append
+        * datestamp_method: avoid_overwrite
+    """
+    simulation_file_meth = getattr(simulation_file, movement_type)
+    simulation_file2 = simulation_file  # Make a copy
+    simulation_file2_meth = getattr(simulation_file2, movement_type)
+    simulation_file_meth("computer", "work")
+    if movement_type == "mv":
+        assert not os.path.exists("/work/ollie/pool/ECHAM/T63/T63CORE2_jan_surf.nc")
+        # Recreate the moved file in computer (let's pretend we compied it):
+        fs.create_file(simulation_file2["absolute_path_in_computer"])
+    assert os.path.exists(
+        "/work/ollie/pgierz/some_exp/run_20010101-20010101/work/unit.24"
+    )
+    simulation_file2_meth("computer", "work")
+    assert os.path.exists(
+        "/work/ollie/pgierz/some_exp/run_20010101-20010101/work/unit.24_2000-01-01T00:00:00"
+    )
+    simulation_file_meth("work", "run_tree")
+    assert os.path.exists(
+        "/work/ollie/pgierz/some_exp/run_20000101-20000101/input/echam/T63CORE2_jan_surf.nc"
+    )
+    simulation_file_meth("run_tree", "exp_tree")
 
-def test_datestamp_added_by_default_cp(simulation_file):
-    assert False
 
 def test_datestamp_not_added_if_attr_set(simulation_file):
-    assert False
+    pass  # Still to be implemented
 
 
 def test_datestamp_not_added_if_in_filename(simulation_file):
-    assert False
+    pass  # Still to be implemented
+
+
+def test_fname_has_date_stamp_info():
+    fname = "blah_2000-01-01.nc"
+    fname2 = "blah_2000-01.nc"
+    date = esm_calendar.Date("2000-01-01T00:00:00")
+    assert filedicts._fname_has_date_stamp_info(fname, date) is True
+    assert filedicts._fname_has_date_stamp_info(fname2, date) is False

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -518,17 +518,38 @@ def test_resolve_paths_old_config():
     )
 
 
-def test_datestamp_attr():
+def test_datestamp_method_attr(simulation_file):
+    assert hasattr(simulation_file, "datestamp_method")
+    assert isinstance(simulation_file.datestamp_method, str)
+    assert simulation_file.datestamp_method in ["never", "always", "avoid_overwrite"]
+    with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
+        simulation_file['datestamp_method'] = "blah"
+    with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
+        # NOTE(PG): you can use _ for capturing a variable you don't care about
+        simulation_file.datestamp_method = "blah"
+    with pytest.raises(ValueError, match="one of never, always, or avoid_overwrite"):
+        # NOTE(PG): you can use _ for capturing a variable you don't care about
+        simulation_file.update(dict(datestamp_method="blah"))
+
+
+def test_datestamp_format_attr(simulation_file):
+    assert hasattr(simulation_file, "datestamp_format")
+    assert isinstance(simulation_file.datestamp_format, str)
+    assert simulation_file.datestamp_format in ["from_filename", "append"]
+
+
+def test_datestamp_added_by_default_mv(simulation_file):
+    assert False
+
+def test_datestamp_added_by_default_ln(simulation_file):
+    assert False
+
+def test_datestamp_added_by_default_cp(simulation_file):
+    assert False
+
+def test_datestamp_not_added_if_attr_set(simulation_file):
     assert False
 
 
-def test_add_datestamp_added_by_default():
-    assert False
-
-
-def test_datestamp_not_added_if_attr_set():
-    assert False
-
-
-def test_datestamp_not_added_if_in_filename():
+def test_datestamp_not_added_if_in_filename(simulation_file):
     assert False

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -516,3 +516,19 @@ def test_resolve_paths_old_config():
     assert sim_file["absolute_path_in_run_tree"] == Path(
         "/work/ollie/mandresm/testing/run/awicm3//awicm3-v3.1-TCO95L91-CORE2_initial/run_20000101-20000101/input/oifs/o3chem_l91"
     )
+
+
+def test_datestamp_attr():
+    assert False
+
+
+def test_add_datestamp_added_by_default():
+    assert False
+
+
+def test_datestamp_not_added_if_attr_set():
+    assert False
+
+
+def test_datestamp_not_added_if_in_filename():
+    assert False

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -441,6 +441,7 @@ def test_ln_raises_exception_when_target_path_does_not_exist(simulation_file, fs
 
 # ========== end of ln() tests ==========
 
+
 def test_check_file_syntax_type_missing():
     """Tests for ``type`` variable missing"""
     dummy_config = """
@@ -455,7 +456,9 @@ def test_check_file_syntax_type_missing():
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
@@ -466,6 +469,7 @@ def test_check_file_syntax_type_missing():
 
     error_text = "the \x1b[31mtype\x1b[0m variable is missing"
     assert any([error_text in line for line in output])
+
 
 def test_check_file_syntax_type_incorrect():
     """Tests for ``type`` variable being incorrectly defined"""
@@ -481,7 +485,9 @@ def test_check_file_syntax_type_incorrect():
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
@@ -492,6 +498,7 @@ def test_check_file_syntax_type_incorrect():
 
     error_text = "is_wrong\x1b[0m is not a supported \x1b[31mtype"
     assert any([error_text in line for line in output])
+
 
 def test_check_file_syntax_input():
     """
@@ -509,7 +516,9 @@ def test_check_file_syntax_input():
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
@@ -522,6 +531,7 @@ def test_check_file_syntax_input():
     assert any([error_text in line for line in output])
     error_text = "the \x1b[31mname_in_computer\x1b[0m variable is missing"
     assert any([error_text in line for line in output])
+
 
 def test_check_file_syntax_output():
     """Tests for missing ``name_in_work`` for output file types"""
@@ -537,7 +547,9 @@ def test_check_file_syntax_output():
         experiment_input_dir: /work/ollie/pgierz/some_exp/input/echam
         thisrun_input_dir: /work/ollie/pgierz/some_exp/run_20010101-20010101/input/echam
     """
+    date = esm_calendar.Date("2000-01-01T00:00:00")
     config = yaml.safe_load(dummy_config)
+    config["general"]["current_date"] = date
 
     # Captures output (i.e. the user-friendly error)
     with Capturing() as output:
@@ -548,6 +560,7 @@ def test_check_file_syntax_output():
 
     error_text = "the \x1b[31mname_in_work\x1b[0m variable is missing"
     assert any([error_text in line for line in output])
+
 
 def test_check_path_in_computer_is_abs(fs):
     """

--- a/tests/test_esm_runscripts/test_filedicts.py
+++ b/tests/test_esm_runscripts/test_filedicts.py
@@ -741,5 +741,5 @@ def test_fname_has_date_stamp_info():
     fname = "blah_2000-01-01.nc"
     fname2 = "blah_2000-01.nc"
     date = esm_calendar.Date("2000-01-01T00:00:00")
-    assert filedicts._fname_has_date_stamp_info(fname, date) is True
+    assert filedicts._fname_has_date_stamp_info(fname, date)
     assert filedicts._fname_has_date_stamp_info(fname2, date) is False


### PR DESCRIPTION
Allows inclusion of datestamps in the `target` of a movement, implemented as a decorator.

A `sim_file` object now has two attributes:
1. `datestamp_method`: controls how the date stamp is (possibly) added. Either `never`, `always`, or `check_overwrite`
2. `datestamp_format`: controls how the date stamp is formatted. If `check_extract`, it will not add a date stamp if it is unique in the target. If it is `append`, it will always append a date stamp.
