### PR TITLE
fix: circumvent the vcs check 

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.13.8
+current_version = 6.13.9
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.13.8",
+    version="6.13.9",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/prepare.py
+++ b/src/esm_runscripts/prepare.py
@@ -744,18 +744,29 @@ def check_vcs_info_against_last_run(config):
     config : dict
         The experiment configuration
     """
-    if config['general']['run_number'] == 1:
+    # FIXME(PG): Sometimes general.run_number is None (shows up as null in the
+    # config), so this check is absolutely the worst way of doing it, but
+    # whatever...
+    if config['general']['run_number'] == 1 or config["general"]["run_number"] is None:
         return config  # No check needed on the very first run
     exp_vcs_info_file = f"{config['general']['thisrun_log_dir']}/{config['general']['expid']}_vcs_info.yaml"
     # FIXME(PG): This file might not exist if people erase every run folder...
     last_exp_vcs_info_file = f"{config['prev_run']['general']['thisrun_log_dir']}/{config['general']['expid']}_vcs_info.yaml"
 
-    with open(exp_vcs_info_file, "r") as f:
-        current_vcs_info = yaml.safe_load(f)
-    with open(last_exp_vcs_info_file, "r") as f:
-        last_vcs_info = yaml.safe_load(f)
+    try:
+        with open(exp_vcs_info_file, "r") as f:
+            current_vcs_info = yaml.safe_load(f)
+    except IOError:
+        logger.warning(f"Unable to open {exp_vcs_info_file}, skipping check...")
+        return config
+    try:
+        with open(last_exp_vcs_info_file, "r") as f:
+            last_vcs_info = yaml.safe_load(f)
+    except IOError:
+        logger.warning(f"Unable to open {last_exp_vcs_info_file}, skipping_check...")
+        return config
     if not config["general"].get("allow_vcs_differences", False) and current_vcs_info != last_vcs_info:
-        esm_parser.user_error("""
+        esm_parser.user_error("VCS Differences", """
             You have differences in either the model code or in the esm-tools between two runs! 
 
             If you are **sure** that this is OK, you can set 'general.allow_vcs_differences' to True to avoid this check.

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.13.8"
+__version__ = "6.13.9"
 
 from .utils import *


### PR DESCRIPTION
While I am not sure why this happens, sometimes the VCS Info file is not in the correct location. This circumvents the check if one of the two files cannot be opened. This seems to happen with non-yearly runs.

Closes #778 and Closes #782 

Ping as info for @antoniofis10000 and @fernandadialzira