### PR TITLE
fixes the clean/install error found by Pengyang

### DIFF
--- a/configs/components/jsbach/jsbach.yaml
+++ b/configs/components/jsbach/jsbach.yaml
@@ -26,6 +26,7 @@ dynamic_vegetations: False
 version: "3.20"
 dataset: r0009
 scenario: ${echam.scenario}
+scenario_type: ${scenario}
 
 config_sources:
         'namelist.jsbach': "${namelist_dir}/namelist.jsbach"


### PR DESCRIPTION
This fixes the error reported by Pengyang: https://github.com/esm-tools/esm_tools/discussions/673#discussioncomment-3667597

Cases tested:
- [x] `esm_master install-awiesm-2.1-wiso`
- [x] `esm_master recomp-awiesm-2.1-wiso`
- [x] `esm_master clean-awiesm-2.1-wiso`
- [x] `esm_master comp-awiesm-2.1-wiso`
