### PR TITLE
awiesm-2.1-recom-scen single fesom awiesm version

### DIFF
--- a/configs/components/fesom/fesom-2.1.yaml
+++ b/configs/components/fesom/fesom-2.1.yaml
@@ -33,33 +33,14 @@ choose_version:
   2.1-wiso:
     branch: wiso
     wiso_code: true
-  2.1-recom:
-    branch: awiesm2-recom-wiso-mass
-    wiso_code: true
-    git-repository:
-    - https://gitlab.dkrz.de/FESOM/fesom2.git
-  2.1-recom-par_tracers: # MA: for Kai testing ESM-Tools in Levante
-    branch: feature/par_tracers
-    git-repository:
-    - https://gitlab.dkrz.de/FESOM/fesom2.git
-    destination: fesom-2.1-recom-par_tracers
-  2.1-recom-par_tracers_mpi: # kh 13.04.22 for testing FESOM-REcoM MPI based tracer loop parallelization with ESM-Tools in Levante
+  2.1-recom: # kh 13.04.22 for testing FESOM-REcoM MPI based tracer loop parallelization with ESM-Tools in Levante
     branch: awiesm2-recom-mpi # YY: merged with awiesm2-recom-wiso-mass
     git-repository:
     - https://gitlab.dkrz.de/FESOM/fesom2.git
-# kh 08.03.22 todo: merge conflict (if enabled)
-#   include_models:
-#       - recom
-# YY: 29.04.22 to compile wiso code
     wiso_code: true
-
-# PAR-TRACERS specific configurations
-par_tracers: "$(( 'par_tracers' in  '${fesom.version}' ))"
-choose_fesom.par_tracers:
-    True:
-        namelist_dir: "${model_dir}/config/"
-        asforcing: CORE2
-        nproc: 1024
+    namelist_dir: "${model_dir}/config/"
+    asforcing: CORE2
+    nproc: 1024
 
 destination: "fesom-2.1"
 install_bins: bin/fesom.x

--- a/configs/couplings/fesom-2.1-recom-par_tracers_mpi+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-recom-par_tracers_mpi+echam-6.3.05p2-wiso+recom-2.0.yaml
+++ b/configs/couplings/fesom-2.1-recom-par_tracers_mpi+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-recom-par_tracers_mpi+echam-6.3.05p2-wiso+recom-2.0.yaml
@@ -1,6 +1,6 @@
 components:
 - echam-6.3.05p2-wiso
-- fesom-2.1-recom-par_tracers_mpi
+- fesom-2.1-recom
 
 # kh 09.06.22
 - oasis3mct-2.8-paleodyn-multi-group-support

--- a/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0.yaml
+++ b/configs/couplings/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0/fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0.yaml
@@ -1,7 +1,0 @@
-components:
-- echam-6.3.05p2-wiso
-- fesom-2.1-recom
-- oasis3mct-2.8-paleodyn
-coupling_changes:
-- sed -i '/ECHAM6_COUPLED/s/OFF/ON/g' echam-6.3.05p2-wiso/config/mh-linux
-- sed -ir '/..FC_DEFINE}__cpl_mpiom/s/..FC_DEFINE}__cpl_mpiom//g' echam-6.3.05p2-wiso/configure.ac

--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -66,7 +66,6 @@ general:
         - '2.1'
         - '2.1-wiso'
         - '2.1-recom'
-        - '2.1-recom-par-tracers'
 
         choose_version:
           '2.1':
@@ -80,13 +79,6 @@ general:
             fesom_Dflags: "-DFESOM_COUPLED=ON"
             with_recom: false
           '2.1-recom':
-            couplings:
-            - fesom-2.1-wiso+echam-6.3.05p2-wiso+recom-2.0
-            add_include_models:
-            - recom
-            fesom_Dflags: "-DFESOM_COUPLED=ON -DRECOM_COUPLED=ON"
-            with_recom: true
-          '2.1-recom-par-tracers':
             couplings:
             - fesom-2.1-recom-par_tracers_mpi+echam-6.3.05p2-wiso+recom-2.0
             add_include_models:
@@ -153,9 +145,6 @@ echam:
                         version: "6.3.05p2-wiso"
                         model_dir: ${general.model_dir}/echam-${echam.version}
                 "2.1-recom":
-                        version: "6.3.05p2-wiso"
-                        model_dir: ${general.model_dir}/echam-${echam.version}
-                "2.1-recom-par-tracers":
                         version: "6.3.05p2-wiso"
                         model_dir: ${general.model_dir}/echam-${echam.version}
 
@@ -274,10 +263,6 @@ fesom:
                         version: "2.1-recom"
                         ALE_scheme: 'zstar'
                         namelist_dir: ${fesom.model_dir}/config/
-                "2.1-recom-par-tracers":
-                        version: "2.1-recom-par-tracers"
-                        ALE_scheme: 'zstar'
-                        namelist_dir: ${fesom.model_dir}/config/
 
         # General namelist_changes for coupled FESOM
         # ------------------------------------------
@@ -388,10 +373,8 @@ recom:
                 True:
                         version: "2.0"
 
-                        choose_general.version:
-                            "2.1-recom-par-tracers":
-                                #5.7.22 Ying: par-tracers only with ciso
-                                use_ciso: true
+                        #5.7.22 Ying: par-tracers only with ciso
+                        use_ciso: true
 
                         add_choose_computer.name:
                             levante:


### PR DESCRIPTION
Takes `2.1-recom-par-tracers-mpi` version and makes it the default for setups with AWIESM-2.1-REcoM.