### PR TITLE
fix/esm_master_runscripts albedo

### DIFF
--- a/configs/machines/albedo.yaml
+++ b/configs/machines/albedo.yaml
@@ -10,7 +10,7 @@ sh_interpreter: "/usr/bin/bash"
 # Batch system and configuration:
 batch_system: "slurm"
 accounting: false
-add_further_reading:
+further_reading:
   - batch_system/slurm.yaml
 partitions:
         compute:

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -72,6 +72,11 @@ import subprocess
 import sys
 import warnings
 
+if sys.version_info > (3, 9):
+    from collections.abc import Mapping
+else:
+    from collections import Mapping
+
 # Always import externals before any non standard library imports
 
 # Third-Party Imports
@@ -573,7 +578,7 @@ def new_dict_merge(dct, merge_dct, winner="to_be_included"):
         if (
             k in dct
             and isinstance(dct[k], dict)
-            and isinstance(merge_dct[k], collections.Mapping)
+            and isinstance(merge_dct[k], Mapping)
         ):
             new_dict_merge(dct[k], merge_dct[k], winner)
         else:
@@ -615,7 +620,7 @@ def dict_merge(dct, merge_dct, resolve_nested_adds=False, **kwargs):
         if (
             k in dct
             and isinstance(v, dict)
-            and isinstance(merge_dct[k], collections.Mapping)
+            and isinstance(merge_dct[k], Mapping)
         ):
             # NOTE(PG): this is a very bad hack and doesn't belong here at all.
             # Maybe instead the yaml_file_to_dict needs to say something like


### PR DESCRIPTION
Closes #861 

Fixes:
- problems where `esm_master` was crashing due to a change in the python module `collections`, from version 3.9 to 3.10
- crash of simulation submissions via `esm_runscript`

After this, ESM-Tools can perform normal operations with Python 3.10 distributed in `Albedo`.