### PR TITLE
fix/esm_tests broken namelist links

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.19.1
+current_version = 6.19.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.19.1",
+    version="6.19.2",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tests/test_utilities.py
+++ b/src/esm_tests/test_utilities.py
@@ -338,17 +338,28 @@ def get_rel_paths_compare_files(info, cfile, v, this_test_dir):
             info, "finished_config", v, this_test_dir
         )
         if len(s_config_yaml) > 0:
-            namelists = extract_namelists(f"{user_info['test_dir']}/{s_config_yaml[0]}")
+            namelists, models = extract_namelists(f"{user_info['test_dir']}/{s_config_yaml[0]}")
             ldir = os.listdir(f"{user_info['test_dir']}/{this_test_dir}")
             ldir.sort()
             for f in ldir:
                 # Take the first run directory
                 if "run_" in f:
                     cf_path = f"{this_test_dir}/{f}/work/"
-                    for n in namelists:
-                        if not os.path.isfile(f"{user_info['test_dir']}/{cf_path}/{n}"):
+                    for n, model in zip(namelists, models):
+                        namelist_path = f"{user_info['test_dir']}/{cf_path}/{n}"
+                        if not os.path.isfile(namelist_path):
                             logger.debug(f"'{cf_path}/{n}' does not exist!")
-                        subpaths.append(f"{cf_path}/{n}")
+                        # Is broken link
+                        if os.path.islink(namelist_path) and not os.path.exists(os.readlink(namelist_path)):
+                            path_in_general_config = (
+                                f"{this_test_dir}/config/{model}/{n}_{f.split('_')[-1]}"
+                            )
+                            if os.path.exists(f"{user_info['test_dir']}/{path_in_general_config}"):
+                                subpaths.append(f"{path_in_general_config}")
+                            else:
+                                logger.debug(f"'{cf_path}/{n}' does not exist!")
+                        else:
+                            subpaths.append(f"{cf_path}/{n}")
                     break
     else:
         subpaths = [f"{this_test_dir}/{cfile}"]
@@ -385,12 +396,15 @@ def extract_namelists(s_config_yaml):
     -------
     namelists : list
         List of namelist names associated to this experiment.
+    components : list
+        List of components associated to the namelists (same order as ``namelists``).
     """
     # Read config file
     with open(s_config_yaml, "r") as c:
         config = yaml.load(c, Loader=yaml.FullLoader)
 
     namelists = []
+    components = []
     # Loop through the components to find the namelists
     for component in config.keys():
         namelists_component = config[component].get("namelists", [])
@@ -400,9 +414,11 @@ def extract_namelists(s_config_yaml):
                 [nml in x for x in config_sources.values()]
             ):
                 namelists.append(nml)
+                components.append(component)
 
     # Adds OASIS ``namcouple``
     if "oasis3mct" in config:
         namelists.append("namcouple")
+        components.append("oasis")
 
-    return namelists
+    return namelists, components

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.19.1"
+__version__ = "6.19.2"
 
 from .utils import *


### PR DESCRIPTION
fixes problems with namelists in the experiments being broken links because the file has been moved to the general experiment config