### PR TITLE
templates/component

### DIFF
--- a/configs/templates/component_template.yaml
+++ b/configs/templates/component_template.yaml
@@ -1,0 +1,99 @@
+# NAME OF YOUR MODEL OR COMPONENT HERE
+#
+# For more information about the extended YAML syntax, please consult:
+# https://esm-tools.readthedocs.io/en/latest/yaml.html#esm-tools-extended-yaml-syntax
+#
+# For more information about the ESM-Tools feature variables available, please consult:
+# https://esm-tools.readthedocs.io/en/latest/esm_variables.html#esm-tools-variables
+
+model: name of your component
+version: default version
+
+metadata:
+        Institute: where it was developed
+        Description:
+                A brief description here
+        Authors: Authors
+        Publications:
+                - "Main publication for this component here <link_to_the_publication>"
+        License:
+                License details here
+
+git-repository: if your code is hosted in git place here the address
+branch: default branch
+comp_command: command used to compile your component
+install_bins: subpath within ``model_dir`` where the comp command produces the binaries
+clean_command: ${defaults.clean_command}
+executable: medusa_recom_paleo
+
+choose_version:
+    # Here you can place all the variables you would want to control via the version
+    # variable above (for example, you could also add ``git-repository``,
+    # ``comp_command``, ``destination``, ...) 
+    a_version_of_your_choice:
+        branch: name of the branch/tag associated to that version if you use git
+    another_version_of_your_choice:
+        branch: name of the branch/tag associated to that version if you use git
+
+# ``model_dir`` let's ESM-Tools know where is the source code of your component (must
+# be an absolute path). Normally, changed via the runscript. We recommend you leave it
+# as below, changing only the ``name_of_your_model`` part to whatever you defined as 
+# the ``model`` var. This will automatically select the source code for esm_master if
+# the command is operating with a coupled setup
+model_dir: "${general.esm_master.dir}/name_of_your_model-${version}"
+
+# This section takes care of dealing with environment changes you might want to do, to
+# deviated from the defaults define for the specific machine
+# (``configs/machine/<the_machine_used>.yaml``). For more information consult:
+# https://esm-tools.readthedocs.io/en/latest/esm_environment.html#esm-environment
+environment_changes:
+    a_variable_in_the_computer_yaml: here you can over
+    add_module_actions:
+        - module command without ``module`` word (e.g. ``load hdf5``)
+        - module command without ``module`` word (e.g. ``load netcdf``)
+    add_export_vars:
+        VARIABLE_TO_EXPORT: '"value of the variable you want to export"'
+        VARIABLE_TO_EXPORT: '"value of the variable you want to export"'
+
+# Some recommended defaults
+lresume: false
+
+# Some commonly used variables in other ESM-Tools components (but optional)
+input_dir: ${pool_dir}/path/within/the/pool/dir/to/the/input/of/your/component
+namelist_dir: /absolute/path/to/the/namelist/folder
+
+# If your components has namelist the following syntax allows you to control the values
+# of their values. For more information consult:
+# https://esm-tools.readthedocs.io/en/latest/yaml.html#changing-namelists
+namelist_changes:
+    namelist_name:
+        section_in_the_namelist:
+            variable_in_the_namelist: its new value here
+
+namelists:
+    - name of the namelist
+
+# File dictionaries to control the copying/moving/linking of all files associated to
+# the simulation. This syntax will change for something better soon. For more details
+# about this syntax consult:
+# https://esm-tools.readthedocs.io/en/latest/yaml.html#file-dictionaries
+input_files:
+    file_name: file_tag
+input_source:
+    file_tag: /absolute/path/to/the/file
+input_in_work:
+    file_tag: /relative/path/to/the/file/in/the/work/directory
+
+config_files:
+    namelist_name: namelist_tag # Or any other configuration file
+config_sources:
+    namelist_tag: ${namelist_dir}/<namelist_name> # Use ${namelist_dir} here if you
+        # defined it above
+
+create_config:
+    name_of_the_config_you_want_to_create:
+        - "<--append-- line 1"
+        - "<--append-- line 2"
+
+bin_sources:
+    bin_tag: ${model_dir}/bin/${executable} # This would be the normal way to do it

--- a/docs/esm_tools.rst
+++ b/docs/esm_tools.rst
@@ -1,0 +1,50 @@
+=========
+ESM Tools
+=========
+
+The command line interface ``esm_tools`` also has a top-level program you can
+use to interact with several parts of our software.
+
+Usage: Top level commands
+-------------------------
+
+To show all top-level commands::
+
+    $ esm_tools --help
+    Usage: esm_tools [OPTIONS] COMMAND [ARGS]...
+
+    Options:
+      --version  Show the version and exit.
+      --help     Show this message and exit.
+
+    Commands:
+      create-new-config  Opens your $EDITOR and creates a new file for NAME
+      test-state         Prints the state of the last tested experiments.
+
+Usage: Getting the Version
+--------------------------
+
+You can get the version number you currently have with::
+
+    $ esm_tools --version
+    esm_tools, version 6.20.1
+
+Usage: Checking current testing state
+-------------------------------------
+
+You can get the current state of our automatic tests with::
+
+    $ esm_tools test-state
+
+Usage: Making a new component
+-----------------------------
+
+You can get a pre-generated template to add a new component with::
+
+    $ esm_tools create-new-config <MY_NEW_CONFIG_NAME>
+    Creating a new component configuration for my_new_thing
+
+    ...EDITOR OPENS....
+
+    Thank you! The new configuration has been saved. Please commit it (and get in touch with the
+    esm-tools team if you need help)!

--- a/docs/esm_tools.rst
+++ b/docs/esm_tools.rst
@@ -48,3 +48,9 @@ You can get a pre-generated template to add a new component with::
 
     Thank you! The new configuration has been saved. Please commit it (and get in touch with the
     esm-tools team if you need help)!
+
+You can also specify if you are creating a new ``setup`` or a new ``component`` with::
+
+  $ esm_tools create-new-config --type setup <MY_NEW_SETUP_NAME>
+
+Note however that there is (as of this writing) no template available for setups!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Welcome to ESM Tools's documentation!
    yaml_hierarchy
    esm_variables
    Supported_Models
+   esm_tools
    esm_master
    esm_versions
    esm_runscripts

--- a/docs/recipes/add_model_setup.rst
+++ b/docs/recipes/add_model_setup.rst
@@ -3,6 +3,8 @@ Implement a New Model
 
 **Feature available since version:** 4.2
 
+.. note:: since version 6.20.2 a template is available in
+   ``esm_tools/configs/templates/component_template.yaml``
 
 1. Upload your model into a repository such us `gitlab.awi.de`, `gitlab.dkrz.de` or `GitHub`.
    Make sure to set up the right access permissions, so that you comply with the licensing of

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.21.2
+current_version = 6.21.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.21.2",
+    version="6.21.3",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 import functools
 import inspect

--- a/src/esm_tools/cli.py
+++ b/src/esm_tools/cli.py
@@ -1,24 +1,60 @@
 """
 Functionality for displaying the version number
 """
+import shutil
 import sys
+
 import click
-import esm_tools
+
 import esm_tests
+import esm_tools
 
 # click.version_option read the PKG_INFO which contains the wrong version
 # number. Get it directly from __init__.py
 version = esm_tools.__version__
 
+
+@click.group()
 @click.version_option(version=version)
-@click.option("--test-state", is_flag=True, help="Prints the state of the last tested experiments.")
-@click.command()
-def main(test_state):
-    """Console script for esm_tools"""
+def main():
+    pass
 
-    if test_state:
-        esm_tests.test_utilities.print_state_online()
 
+@main.command()
+def test_state():
+    """Prints the state of the last tested experiments."""
+
+    esm_tests.test_utilities.print_state_online()
+
+    return 0
+
+
+@main.command()
+@click.option(
+    "-t",
+    "--type",
+    type=click.Choice(["component", "setup"], case_sensitive=False),
+    help="Creates either a new component (default) or a new setup",
+    default="component",
+    show_default=True,
+)
+@click.argument("name", nargs=1)
+def create_new_config(name, type):
+    """Opens your $EDITOR and creates a new file for NAME"""
+    click.echo(f"Creating a new {type} configuration for {name}")
+    template_file = esm_tools.get_config_filepath(
+        config=f"templates/{type}_template.yaml"
+    )
+    shutil.copy(template_file, f"{name}.yaml")
+    new_config_file = f"{name}.yaml"
+    # TODO(PG): Currently this lands in the current working directory.
+    # Would be nice if this landed already in an git-controlled
+    # editable version and prepared a commit for you:
+    click.edit(filename=new_config_file)
+    click.echo(
+        "Thank you! The new configuration has been saved. Please commit it (and get in touch with the"
+    )
+    click.echo("esm-tools team if you need help)!")
     return 0
 
 

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.2"
+__version__ = "6.21.3"
 
 from .utils import *


### PR DESCRIPTION
Adds a template for a component `YAML` so users wanting to implement a new component don't need to start from scratch.

@jannitzbon, this one is for you :)

You can already start using this template, you probably can ignore a lot of things related to the compilation. Until this is merged, you can copy the template from here: 
[configs/templates/component_template.yaml](https://github.com/esm-tools/esm_tools/blob/6c672b13a9c0fbad84470ca5c9fa02bd5335be90/configs/templates/component_template.yaml)