### PR TITLE
fixed error messages and initialization of subjob_cluster in workflow…

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.21.4
+current_version = 6.21.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.21.4",
+    version="6.21.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/workflow.py
+++ b/src/esm_runscripts/workflow.py
@@ -132,7 +132,7 @@ def order_clusters(config):
                 not gw_config["subjob_clusters"][subjob_cluster]["run_after"]
                 in gw_config["subjob_clusters"]
             ):
-                print(f"Unknown cluster {subjob_cluster['run_after']}.")
+                print(f"Unknown cluster {gw_config['subjob_clusters'][subjob_cluster]['run_after']}.")
                 sys.exit(-1)
 
             calling_cluster = gw_config["subjob_clusters"][subjob_cluster]["run_after"]
@@ -156,7 +156,7 @@ def order_clusters(config):
                 not gw_config["subjob_clusters"][subjob_cluster]["run_before"]
                 in gw_config["subjob_clusters"]
             ):
-                print(f"Unknown cluster {subjob_cluster['run_before']}.")
+                print(f"Unknown cluster {gw_config['subjob_clusters'][subjob_cluster]['run_before']}.")
                 sys.exit(-1)
 
             called_cluster = gw_config["subjob_clusters"][subjob_cluster]["run_before"]
@@ -330,7 +330,13 @@ def init_total_workflow(config):
         config["general"]["workflow"]["subjobs"] = prepcompute
         config["general"]["workflow"]["subjobs"].update(compute)
         config["general"]["workflow"]["subjobs"].update(tidy)
-
+    else:
+        if not "prepcompute" in config["general"]["workflow"]["subjobs"]:
+            config["general"]["workflow"]["subjobs"].update(prepcompute)
+        if not "compute" in config["general"]["workflow"]["subjobs"]:
+            config["general"]["workflow"]["subjobs"].update(compute)
+        if not "tidy" in config["general"]["workflow"]["subjobs"]:
+            config["general"]["workflow"]["subjobs"].update(tidy)    
     if not "last_task_in_queue" in config["general"]["workflow"]:
         config["general"]["workflow"]["last_task_in_queue"] = "tidy"
     if not "first_task_in_queue" in config["general"]["workflow"]:

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.4"
+__version__ = "6.21.5"
 
 from .utils import *


### PR DESCRIPTION
I started working with the workflow manager and came across two issues in `src/esm_runscripts/workflow.py`

- First, some error messages about unknown clusters could not be displayed correctly (lines 135 and 159) because of a mistake in the string formatting. I fixed these lines by providing the (hopefully) correct reference.

- Second, after fixing the error messages, I found another issue related to why they were called in the first place. In `initial_total_workflow`, the subjobs `prepcompute`, `compute` and `tidy` are only initialized if the field `subjobs` is not included in the `workflow` config section of the runscript. However, these should be added by default (according to the documentation (https://esm-tools.readthedocs.io/en/latest/workflow.html#). I suggest to fix this by addings these three jobs with the default settings if they are not provided with different settings in the `subjob` field of the `workflow` section:

```
    if not "subjobs" in config["general"]["workflow"]:
        config["general"]["workflow"]["subjobs"] = prepcompute
        config["general"]["workflow"]["subjobs"].update(compute)
        config["general"]["workflow"]["subjobs"].update(tidy)
    else:
        if not "prepcompute" in config["general"]["workflow"]["subjobs"]:
            config["general"]["workflow"]["subjobs"].update(prepcompute)
        if not "compute" in config["general"]["workflow"]["subjobs"]:
            config["general"]["workflow"]["subjobs"].update(compute)
        if not "tidy" in config["general"]["workflow"]["subjobs"]:
            config["general"]["workflow"]["subjobs"].update(tidy) 
```
After this fix, I was able to initialize an iterative coupling run.