### PR TITLE
Bugfix for wrong command example esm_tools --test-state.

### DIFF
--- a/configs/machines/albedo.yaml
+++ b/configs/machines/albedo.yaml
@@ -202,7 +202,7 @@ warning:
             environment variables, pool problems, incorrect or not optimal compiler
             flags... Feel free to try it a report and issue in https://github.com/esm-tools/esm_tools/issues
             labelling it with the ``albedo`` tag, if things don't work as expected. By
-            running ``esm_tools --test-state`` you'll get information of what you can
+            running ``esm_tools test-state`` you'll get information of what you can
             expect to work and what not. Bare in mind that the ESM-Tools configurations
             specific to Albedo will be changing fast on the following weeks, until
             Albedo is fully supported. We recommend against using it for production

--- a/docs/esm_tests.rst
+++ b/docs/esm_tests.rst
@@ -117,7 +117,7 @@ Check test status
 As a user, you can check the ``last-state`` status (the online one of the
 ``esm_tests_info`` repo, ``release`` branch) by running::
 
-    esm_tools --test-state
+    esm_tools test-state
 
 This will give you a summary of the state of compilation and running tests for
 different models, in different computers, and also a date of when the latest actual

--- a/src/esm_tests/test_utilities.py
+++ b/src/esm_tests/test_utilities.py
@@ -208,7 +208,7 @@ def print_state_online(info={}):
     """
     Returns the state of the tested models obtained directly from the repository online.
     This method is aimed to be used externally from ``esm_tests`` (i.e. throw the
-    ``esm_tools --test-state`` command).
+    ``esm_tools test-state`` command).
 
     Parameters
     ----------


### PR DESCRIPTION
I replaced all occurances of `esm_tools --test-state` by `esm_tools test-state`.