### PR TITLE
fix: proper repr for Date objects

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.21.11
+current_version = 6.21.12
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.21.11",
+    version="6.21.12",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_calendar import *

--- a/src/esm_calendar/esm_calendar.py
+++ b/src/esm_calendar/esm_calendar.py
@@ -441,14 +441,7 @@ class Date(object):
     fromlist = from_list
 
     def __repr__(self):
-        return "Date(%s-%s-%sT%s:%s:%s)" % (
-            self.year,
-            self.month,
-            self.day,
-            self.hour,
-            self.minute,
-            self.second,
-        )
+        return f"Date({self.year:02}-{self.month:02}-{self.day:02}T{self.hour:02}:{self.minute:02}:{self.second:02})"
 
     def __getitem__(self, item):
         return (self.year, self.month, self.day, self.hour, self.minute, self.second)[
@@ -701,41 +694,59 @@ class Date(object):
         self, form="SELF", givenph=None, givenpm=None, givenps=None
     ):  # basically format_date
         """
-        Needs a docstring!
-        The following forms are accepted:
-        + SELF: uses the format which was given when constructing the date
-        + 0: A Date formated as YYYY
+        Beautifully returns a ``Date`` object as a string.
 
-        In [5]: test.format(form=1)
-        Out[5]: '1850-01-01_00:00:00'
+        Parameters:
+        -----------
+        form : str or int
+            Some cryptic that Dirk over-took from MPI-Met
+        givenph : bool-ish
+            Print hours
+        givenpm : bool-ish
+            Print minutes
+        givenps : bool-ish
+            Print seconds
 
-        In [6]: test.format(form=2)
-        Out[6]: '1850-01-01T00:00:00'
+        Notes:
+        ------
+        How to use the ``form`` argument:
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            The following forms are accepted:
+            + SELF: uses the format which was given when constructing the date
+            + 0: A Date formatted as YYYY
 
-        In [7]: test.format(form=3)
-        Out[7]: '1850-01-01 00:00:00'
+            In [5]: test.format(form=1)
+            Out[5]: '1850-01-01_00:00:00'
 
-        In [8]: test.format(form=4)
-        Out[8]: '1850 01 01 00 00 00'
+            In [6]: test.format(form=2)
+            Out[6]: '1850-01-01T00:00:00'
 
-        In [9]: test.format(form=5)
-        Out[9]: '01 Jan 1850 00:00:00'
+            In [7]: test.format(form=3)
+            Out[7]: '1850-01-01 00:00:00'
 
-        In [10]: test.format(form=6)
-        Out[10]: '18500101_00:00:00'
+            In [8]: test.format(form=4)
+            Out[8]: '1850 01 01 00 00 00'
 
-        In [11]: test.format(form=7)
-        Out[11]: '1850-01-01_000000'
+            In [9]: test.format(form=5)
+            Out[9]: '01 Jan 1850 00:00:00'
 
-        In [12]: test.format(form=8)
-        Out[12]: '18500101000000'
+            In [10]: test.format(form=6)
+            Out[10]: '18500101_00:00:00'
 
-        In [13]: test.format(form=9)
-        Out[13]: '18500101_000000'
+            In [11]: test.format(form=7)
+            Out[11]: '1850-01-01_000000'
 
-        In [14]: test.format(form=10)
-        Out[14]: '01/01/1850 00:00:00'
+            In [12]: test.format(form=8)
+            Out[12]: '18500101000000'
+
+            In [13]: test.format(form=9)
+            Out[13]: '18500101_000000'
+
+            In [14]: test.format(form=10)
+            Out[14]: '01/01/1850 00:00:00'
         """
+        # Programmer notes to not be ever included in the doc-string: Paul really, Really, REALLY
+        # dislikes this function. It rubs me in the wrong way.
         if form == "SELF":
             form = self._date_format.form
 
@@ -743,11 +754,12 @@ class Date(object):
         pm = self._date_format.printminutes
         ps = self._date_format.printseconds
 
-        if not givenph == None:
+        # These variables are....utterly pointless
+        if givenph is not None:
             ph = givenph
-        if not givenpm == None:
+        if givenpm is not None:
             pm = givenpm
-        if not givenps == None:
+        if givenps is not None:
             ps = givenps
         ndate = list(
             map(

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.11"
+__version__ = "6.21.12"
 
 from .utils import *


### PR DESCRIPTION
Hi Nadine,

here's a code-review practice for you 😃. I made the `__repr__` of the `Date` objects a bit fancier and made some small formatting changes to the doc-strings. If you have any questions about why I did certain changes, feel free to ask as a review comment!

If you're happy, you can approve and then use the GitHub CI to bump the version numbers.