### PR TITLE
trigger an error if using esm_runscripts with generic.yaml without ch…

### DIFF
--- a/configs/machines/generic.yaml
+++ b/configs/machines/generic.yaml
@@ -54,7 +54,7 @@ choose_general.check:
                     is only aimed for local testing of ESM-Tools functionalities and dry
                     check runs (``esm_runscripts -c``).\n
 
-                    If you are running in a HPC and you're seeing this message, it's
+                    If you are running on an HPC and you're seeing this message, it's
                     likely that the HOSTNAME of your machine does not matches the
                     pattern defined in ``configs/machines/all_machines.yaml``. Please,
                     check that your machine is included in that file and that the

--- a/configs/machines/generic.yaml
+++ b/configs/machines/generic.yaml
@@ -42,3 +42,24 @@ cxx: "unset"
 
 further_reading:
         - batch_system/slurm.yaml
+
+choose_general.check:
+    False:
+        error:
+            generic.yaml:
+                message: "
+                    You are trying to run an actual simulation with the environment from
+                    ``configs/machines/generic.yaml``. This is not allowed, you should
+                    always run using a specific machine file. The ``generic.yaml`` file
+                    is only aimed for local testing of ESM-Tools functionalities and dry
+                    check runs (``esm_runscripts -c``).\n
+
+                    If you are running in a HPC and you're seeing this message, it's
+                    likely that the HOSTNAME of your machine does not matches the
+                    pattern defined in ``configs/machines/all_machines.yaml``. Please,
+                    check that your machine is included in that file and that the
+                    ``configs/machines/<your_machine>.yaml`` exists.\n
+
+                    For more info on how to implement a new machine in ESM-Tools check:
+                    https://esm-tools.readthedocs.io/en/latest/cookbook.html#implement-a-new-hpc-machine\\
+                    "

--- a/configs/machines/generic.yaml
+++ b/configs/machines/generic.yaml
@@ -55,7 +55,7 @@ choose_general.check:
                     check runs (``esm_runscripts -c``).\n
 
                     If you are running on an HPC and you're seeing this message, it's
-                    likely that the HOSTNAME of your machine does not matches the
+                    likely that the HOSTNAME of your machine does not match the
                     pattern defined in ``configs/machines/all_machines.yaml``. Please,
                     check that your machine is included in that file and that the
                     ``configs/machines/<your_machine>.yaml`` exists.\n

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.21.12
+current_version = 6.21.13
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.21.12",
+    version="6.21.13",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.21.12"
+__version__ = "6.21.13"
 
 from .utils import *


### PR DESCRIPTION
Triggers an error if using esm_runscripts with generic.yaml without check mode off to prevent ESM-Tools not catching problems in the recognition of the machine file during runtime, as described in #959 

Closes #959 

One can replicate this error by running `esm_runscripts` in your local computer without `-c`.