### PR TITLE
fix(echam.yaml): updates online handbook with correct licence guidelines

### DIFF
--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -102,11 +102,24 @@ metadata:
         Authors: Bjorn Stevens (bjorn.stevens@mpimet.mpg.de) among others at MPI-Met
         Publications:
                 'Atmosphericcomponent of the MPI-M earth system model: ECHAM6 <https://doi.org/10.1002/jame.20015>'
-        License:
+        License: >
                 Please make sure you have a license to use ECHAM. Otherwise downloading ECHAM will already fail.
-                To use the repository on gitlab.dkrz.de/modular_esm/echam.git, register for the MPI-ESM user forum at 
-                https://mpimet.mpg.de/en/science/modeling-with-icon/code-availability/mpi-esm-users-forum and send a screenshot
-                to either dirk.barbi@awi.de, deniz.ural@awi.de or miguel.andres-martinez@awi.de
+                To use the repository on any of these locations: 
+                
+                * gitlab.dkrz.de/modular_esm/echam.git
+                * gitlab.awi.de/paleodyn/models/echam.git
+                
+                please register for the MPI-ESM user forum at:
+                
+                https://code.mpimet.mpg.de/projects/mpi-esm-license 
+                
+                and send a screenshot of yourself logged in to the forum to either paul.gierz@awi.de, miguel.andres-martinez@awi.de,
+                or nadine.wieters@awi.de.
+                
+                Note also that you can otherwise ignore the instructions on that page, just the registiration and login screen shot
+                is important for us.
+                
+                Have fun using ECHAM! :-)
 
 standalone_model: True
 


### PR DESCRIPTION
Updates the docs to no longer run into problems for not being able to find the forum link, as described by https://jira-software.awi.de/browse/HELP-26318