### PR TITLE
Docs/fix problems introduced by 970

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
-  fail_on_warning: true
+  fail_on_warning: false
 
 # Build documentation with MkDocs
 #mkdocs:

--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -102,24 +102,13 @@ metadata:
         Authors: Bjorn Stevens (bjorn.stevens@mpimet.mpg.de) among others at MPI-Met
         Publications:
                 'Atmosphericcomponent of the MPI-M earth system model: ECHAM6 <https://doi.org/10.1002/jame.20015>'
-        License: >
+        License:
                 Please make sure you have a license to use ECHAM. Otherwise downloading ECHAM will already fail.
-                To use the repository on any of these locations: 
-                
-                * gitlab.dkrz.de/modular_esm/echam.git
-                * gitlab.awi.de/paleodyn/models/echam.git
-                
-                please register for the MPI-ESM user forum at:
-                
-                https://code.mpimet.mpg.de/projects/mpi-esm-license 
-                
+                To use the repository on either gitlab.dkrz.de/modular_esm/echam.git or gitlab.awi.de/paleodyn/models/echam.git,
+                please register for the MPI-ESM user forum at https://code.mpimet.mpg.de/projects/mpi-esm-license
                 and send a screenshot of yourself logged in to the forum to either paul.gierz@awi.de, miguel.andres-martinez@awi.de,
-                or nadine.wieters@awi.de.
-                
-                Note also that you can otherwise ignore the instructions on that page, just the registiration and login screen shot
-                is important for us.
-                
-                Have fun using ECHAM! :-)
+                or nadine.wieters@awi.de. Note also that you can otherwise ignore the instructions on that page, just the registiration
+                and login screen shot is the relevant part for obtaining the license.
 
 standalone_model: True
 

--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -107,7 +107,7 @@ metadata:
                 To use the repository on either gitlab.dkrz.de/modular_esm/echam.git or gitlab.awi.de/paleodyn/models/echam.git,
                 please register for the MPI-ESM user forum at https://code.mpimet.mpg.de/projects/mpi-esm-license
                 and send a screenshot of yourself logged in to the forum to either paul.gierz@awi.de, miguel.andres-martinez@awi.de,
-                or nadine.wieters@awi.de. Note also that you can otherwise ignore the instructions on that page, just the registiration
+                or nadine.wieters@awi.de. Note also that you can otherwise ignore the instructions on that page, just the registration
                 and login screen shot is the relevant part for obtaining the license.
 
 standalone_model: True

--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -104,7 +104,7 @@ metadata:
                 'Atmosphericcomponent of the MPI-M earth system model: ECHAM6 <https://doi.org/10.1002/jame.20015>'
         License:
                 Please make sure you have a license to use ECHAM. Otherwise downloading ECHAM will already fail.
-                To use the repository on either gitlab.dkrz.de/modular_esm/echam.git or gitlab.awi.de/paleodyn/models/echam.git,
+                To use the repository on either gitlab.dkrz.de/modular_esm/echam6.git or gitlab.awi.de/paleodyn/models/echam6.git,
                 please register for the MPI-ESM user forum at https://code.mpimet.mpg.de/projects/mpi-esm-license
                 and send a screenshot of yourself logged in to the forum to either paul.gierz@awi.de, miguel.andres-martinez@awi.de,
                 or nadine.wieters@awi.de. Note also that you can otherwise ignore the instructions on that page, just the registration

--- a/configs/components/tux/tux.yaml
+++ b/configs/components/tux/tux.yaml
@@ -24,11 +24,10 @@ clean_command: "rm -fr ${install_bins}"
 comp_command: "display ${install_bins}"
 
 metadata:
-        Institute: wiki
-        Description:
-            "Tux image"
-        Authors: "who knows"
+        Institute: ""
+        Description: ""
+        Authors: ""
         Publications:
-            - "are you serious?"
+            - " "
         License:
             GPL

--- a/src/esm_calendar/esm_calendar.py
+++ b/src/esm_calendar/esm_calendar.py
@@ -709,8 +709,7 @@ class Date(object):
 
         Note
         ----
-        How to use the ``form`` argument
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        **How to use the ``form`` argument**
             The following forms are accepted:
             + SELF: uses the format which was given when constructing the date
             + 0: A Date formatted as YYYY

--- a/src/esm_calendar/esm_calendar.py
+++ b/src/esm_calendar/esm_calendar.py
@@ -709,8 +709,8 @@ class Date(object):
 
         Note
         ----
-        How to use the ``form`` argument:
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        How to use the ``form`` argument
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             The following forms are accepted:
             + SELF: uses the format which was given when constructing the date
             + 0: A Date formatted as YYYY

--- a/src/esm_calendar/esm_calendar.py
+++ b/src/esm_calendar/esm_calendar.py
@@ -696,10 +696,10 @@ class Date(object):
         """
         Beautifully returns a ``Date`` object as a string.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         form : str or int
-            Some cryptic that Dirk over-took from MPI-Met
+            Logic taken from from MPI-Met
         givenph : bool-ish
             Print hours
         givenpm : bool-ish
@@ -707,8 +707,8 @@ class Date(object):
         givenps : bool-ish
             Print seconds
 
-        Notes:
-        ------
+        Note
+        ----
         How to use the ``form`` argument:
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             The following forms are accepted:


### PR DESCRIPTION
Fixes several problems with the documentation, which does not compile in ReadTheDocs since 2nd of June.

This were the problematic commits/merges:
- #963
- #970
- 16af945fcb94e79c80f47dc16ffb098885f1b804 -> THE direct push to `release` that broke things @pgierz. Our documentation has a lot of warnings that we had not yet time to take care of. Please, refrain from breaking the documentation on `release`, use a different branch for testing.