### PR TITLE
fixes default iodefs so that we use 2 layer servers

### DIFF
--- a/namelists/oifs/43r3/xios/TCO319_DART/iodef.xml
+++ b/namelists/oifs/43r3/xios/TCO319_DART/iodef.xml
@@ -5,16 +5,16 @@
   <context id="xios">
     <variable_definition>
       <variable_group id="server" > <!-- Tune 2-level servers for performance purposes -->
-        <variable id="using_server2"        type="bool"> false </variable>
+        <variable id="using_server2"        type="bool"> true </variable>
         <variable id="ratio_server2"        type="int" > 50    </variable>
-        <variable id="number_pools_server2" type="int" > 2     </variable>
+        <variable id="number_pools_server2" type="int" > 1     </variable>
         <variable id="server2_dist_file_memory"       type="bool"  > false </variable>
         <variable id="server2_dist_file_memory_ratio" type="double"> 0.5   </variable>
       </variable_group>
 
       <variable_group id="buffer" > <!-- Tune both "buffer" variables for performance purposes -->
         <variable id="optimal_buffer_size" type="string"> performance </variable>
-        <variable id="buffer_size_factor"  type="double"> 1.0         </variable>
+        <variable id="buffer_size_factor"  type="double"> 2.0         </variable>
       </variable_group>
 
       <variable_group id="parameters" >

--- a/namelists/oifs/43r3/xios/TCO639_DART/iodef.xml
+++ b/namelists/oifs/43r3/xios/TCO639_DART/iodef.xml
@@ -5,16 +5,16 @@
   <context id="xios">
     <variable_definition>
       <variable_group id="server" > <!-- Tune 2-level servers for performance purposes -->
-        <variable id="using_server2"        type="bool"> false </variable>
+        <variable id="using_server2"        type="bool"> true </variable>
         <variable id="ratio_server2"        type="int" > 50    </variable>
-        <variable id="number_pools_server2" type="int" > 2     </variable>
+        <variable id="number_pools_server2" type="int" > 1     </variable>
         <variable id="server2_dist_file_memory"       type="bool"  > false </variable>
         <variable id="server2_dist_file_memory_ratio" type="double"> 0.5   </variable>
       </variable_group>
 
       <variable_group id="buffer" > <!-- Tune both "buffer" variables for performance purposes -->
         <variable id="optimal_buffer_size" type="string"> performance </variable>
-        <variable id="buffer_size_factor"  type="double"> 1.0         </variable>
+        <variable id="buffer_size_factor"  type="double"> 2.0         </variable>
       </variable_group>
 
       <variable_group id="parameters" >

--- a/namelists/oifs/43r3/xios/TCO639_ROS2/iodef.xml
+++ b/namelists/oifs/43r3/xios/TCO639_ROS2/iodef.xml
@@ -5,16 +5,16 @@
   <context id="xios">
     <variable_definition>
       <variable_group id="server" > <!-- Tune 2-level servers for performance purposes -->
-        <variable id="using_server2"        type="bool"> false </variable>
+        <variable id="using_server2"        type="bool"> true </variable>
         <variable id="ratio_server2"        type="int" > 50    </variable>
-        <variable id="number_pools_server2" type="int" > 2     </variable>
+        <variable id="number_pools_server2" type="int" > 1     </variable>
         <variable id="server2_dist_file_memory"       type="bool"  > false </variable>
         <variable id="server2_dist_file_memory_ratio" type="double"> 0.5   </variable>
       </variable_group>
 
       <variable_group id="buffer" > <!-- Tune both "buffer" variables for performance purposes -->
         <variable id="optimal_buffer_size" type="string"> performance </variable>
-        <variable id="buffer_size_factor"  type="double"> 1.0         </variable>
+        <variable id="buffer_size_factor"  type="double"> 2.0         </variable>
       </variable_group>
 
       <variable_group id="parameters" >

--- a/namelists/oifs/43r3/xios/TCO639_SO3/iodef.xml
+++ b/namelists/oifs/43r3/xios/TCO639_SO3/iodef.xml
@@ -5,16 +5,16 @@
   <context id="xios">
     <variable_definition>
       <variable_group id="server" > <!-- Tune 2-level servers for performance purposes -->
-        <variable id="using_server2"        type="bool"> false </variable>
+        <variable id="using_server2"        type="bool"> true </variable>
         <variable id="ratio_server2"        type="int" > 50    </variable>
-        <variable id="number_pools_server2" type="int" > 2     </variable>
+        <variable id="number_pools_server2" type="int" > 1     </variable>
         <variable id="server2_dist_file_memory"       type="bool"  > false </variable>
         <variable id="server2_dist_file_memory_ratio" type="double"> 0.5   </variable>
       </variable_group>
 
       <variable_group id="buffer" > <!-- Tune both "buffer" variables for performance purposes -->
         <variable id="optimal_buffer_size" type="string"> performance </variable>
-        <variable id="buffer_size_factor"  type="double"> 1.0         </variable>
+        <variable id="buffer_size_factor"  type="double"> 2.0         </variable>
       </variable_group>
 
       <variable_group id="parameters" >

--- a/namelists/oifs/43r3/xios/TCO639_jane/iodef.xml
+++ b/namelists/oifs/43r3/xios/TCO639_jane/iodef.xml
@@ -5,16 +5,16 @@
   <context id="xios">
     <variable_definition>
       <variable_group id="server" > <!-- Tune 2-level servers for performance purposes -->
-        <variable id="using_server2"        type="bool"> false </variable>
+        <variable id="using_server2"        type="bool"> true </variable>
         <variable id="ratio_server2"        type="int" > 50    </variable>
-        <variable id="number_pools_server2" type="int" > 2     </variable>
+        <variable id="number_pools_server2" type="int" > 1     </variable>
         <variable id="server2_dist_file_memory"       type="bool"  > false </variable>
         <variable id="server2_dist_file_memory_ratio" type="double"> 0.5   </variable>
       </variable_group>
 
       <variable_group id="buffer" > <!-- Tune both "buffer" variables for performance purposes -->
         <variable id="optimal_buffer_size" type="string"> performance </variable>
-        <variable id="buffer_size_factor"  type="double"> 1.0         </variable>
+        <variable id="buffer_size_factor"  type="double"> 2.0         </variable>
       </variable_group>
 
       <variable_group id="parameters" >

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.23.4
+current_version = 6.23.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.23.4",
+    version="6.23.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.23.4"
+__version__ = "6.23.5"
 
 from .utils import *


### PR DESCRIPTION
Some of the seldom used default iodef xml files were configured wrongly, resulting in OIFS-XIOS output files that are split by region instead of by variable. This fixes the problem.