### PR TITLE
allow more flexibility in oasis restart file names

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.24.1
+current_version = 6.24.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.24.1",
+    version="6.24.2",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/oasis.py
+++ b/src/esm_runscripts/oasis.py
@@ -497,7 +497,7 @@ class oasis:
                 # check if restart file with ini_restart_date in filename is in the restart
                 # folder of the parent experiment to be branched off from:
                 glob_search_file = (
-                    f"{restart_file_path}_????????-"
+                    f"{restart_file_path}*"
                     f"{config['ini_restart_date'].year}"
                     f"{config['ini_restart_date'].month:02}"
                     f"{config['ini_restart_date'].day:02}"

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.1"
+__version__ = "6.24.2"
 
 from .utils import *


### PR DESCRIPTION
Hi all
as we use different naming conventions in FOCI for oasis restart files (to be compatible with our old runtime environment):
```yaml
    restart_in_sources:
         sstocean: sstocean_${parent_expid}_${echam.parent_date!syear!smonth!sday}
```
the current implementation in `oasis.py` fails for us. I suggest to use my more flexible approach which still enforces a restart file ending on the end date of the previous leg.