### PR TITLE
fix/recursive resolution of early variables and fix find_key

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.24.3
+current_version = 6.24.4
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.24.3",
+    version="6.24.4",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 
 from .esm_parser import *

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -1541,7 +1541,7 @@ def resolve_choose_with_var(
     var : str
         Name of the variable to be searched inside ``choose_`` blocks.
     config : dict
-        Model configuration to be changed if the ``var`` is resolved by the ``choose_``.
+        Component configuration to be changed if the ``var`` is resolved by the ``choose_``.
     user_config : dict
         User configuration, used to search for the selected case of the ``choose_``.
     model_config : dict
@@ -1554,14 +1554,10 @@ def resolve_choose_with_var(
     sep = ","
     # Find the path to the variable ``var`` in the given ``config``, inside a
     # ``choose_``
-    choose_with_var = find_key(config, var, exc_strings="add_", paths2finds=[], sep=sep)
-    choose_with_var = [
-        x for x in choose_with_var if "choose_" in x and f"choose_{var}" not in x
-    ]
+    choose_with_var = get_chooses_with_var(config, var, sep=sep)
     # Find the path to the variable ``add_var`` in the given ``config``, inside a
     # ``choose_``
-    choose_with_add_var = find_key(config, f"add_{var}", paths2finds=[], sep=sep)
-    choose_with_add_var = [x for x in choose_with_add_var if "choose_" in x]
+    choose_with_add_var = get_chooses_with_var(config, f"add_{var}", sep=sep)
 
     # Resolve first for ``<var>`` and then for ``add_<var>``
     for choose_with_var, lvar in [
@@ -1606,6 +1602,20 @@ def resolve_choose_with_var(
                 config_copy[choose_with_var_new] = config_copy[choose_with_var]
                 del config_copy[choose_with_var]
                 choose_with_var = choose_with_var_new
+
+            # Resolve choose_key in case it is defined within another choose_block
+            for conf in [user_config, setup_config, model_config]:
+                component_config = conf.get(component_with_key, [])
+                if component_config:
+                    resolve_choose_with_var(
+                        choose_key,
+                        component_config,
+                        current_model=component_with_key,
+                        user_config=user_config,
+                        model_config=model_config,
+                        setup_config=setup_config
+                    )
+
             # Find where the case for the ``choose_`` is defined, with priority: user ->
             # setup -> model
             config_to_search_into = None
@@ -1625,6 +1635,63 @@ def resolve_choose_with_var(
                 # the ``var`` value to the ``config``.
                 if config_copy.get(var):
                     config[var] = config_copy.get(var)
+
+
+def get_chooses_with_var(component_config, var, sep=","):
+    """
+    Finds all the paths of a variable ``var`` contained in a case of a ``choose_``
+    (paths that start with ``choose_`` and containing the variable defined by the
+    string ``var``).
+
+    Parameters
+    ----------
+    component_config : dict
+        Config dictionary of a given component
+    var : str
+        Variable contained in the case of a choose
+    sep : str
+        Path separator
+
+    Returns
+    -------
+    choose_paths : list
+        A list of all the paths of the ``var`` vatiable contained in a case of a
+        ``choose_``
+    """
+
+    # Find all paths containing the variable ``var`` and excluding the ``exc_string``
+    paths_with_var = find_key(
+        component_config, var, paths2finds=[], sep=sep
+    )
+
+    # Filter out the paths that do not start with ``choose_`` and the ones including the
+    # target variable
+    choose_paths = []
+    for path_with_var in paths_with_var:
+        # Finds whether the variable containing the string ``var`` is a real variable
+        # or instead, a case of a ``choose_`` block. For example, var="albedo" and
+        # there is a path with ``choose_computer.name,albedo,pool_dir``. This path
+        # needs to be excluded as ``albedo`` in this case is not a var, but a case for
+        # the ``choose_``
+        split_path = path_with_var.split(sep)
+        prev_part = ""
+        for path_part in split_path:
+            if "choose_" not in path_part and "choose_" in prev_part and var in path_part:
+                var_is_variable = False
+            elif path_part == var:
+                var_is_variable = True
+            else:
+                var_is_variable = False
+            prev_part = path_part
+
+        # Filters out choose paths not containing the matching variable
+        if (
+            path_with_var.startswith("choose_")
+            and var_is_variable
+        ):
+            choose_paths.append(path_with_var)
+
+    return choose_paths
 
 
 def basic_add_more_important_tasks(choose_keyword, all_set_variables, task_list):
@@ -2708,9 +2775,9 @@ def find_key(d_search, k_search, exc_strings="", level="", paths2finds=[], sep="
         # If the key meets the criteria, add the path to the paths2finds
         if strings_in_key:
             paths2finds.append(level + str(key))
-        # If the key does not meet the criteria, but its value is a dictionary
-        # keep searching inside (recursion).
-        elif not strings_in_key and isinstance(d_search[key], dict):
+
+        # If the key is a dictionary keep searching inside (recursion).
+        if isinstance(d_search[key], dict):
             paths2finds = find_key(
                 d_search[key],
                 k_search,
@@ -2875,6 +2942,16 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
                 setup_config
             )
             setup_config["general"]["valid_model_names"] = valid_model_names = []
+
+            # Resolve the chooses including versions of the components to be able to
+            # later load the correct yaml files
+            for component in setup_config:
+                resolve_choose_with_var(
+                    "version",
+                    setup_config[component],
+                    current_model=component,
+                    user_config=user_config,
+                    setup_config=setup_config)
         else:
             setup_config["general"].update({"standalone": True})
             setup_config["general"].update({"models": [self.config["model"]]})
@@ -3024,7 +3101,7 @@ class ConfigSetup(GeneralConfig):  # pragma: no cover
 
     def check_user_defined_versions(self, user_config={}, setup_config={}):
         """
-        When running a standalone model, checks whether the users has define the
+        When running a standalone model, checks whether the users has defined the
         variable ``version`` in more than one section and if that's the case
         throws and error. If ``version`` is only defined in the ``general`` section
         it creates a ``version`` with the same value in the model section, ensuring

--- a/src/esm_parser/yaml_to_dict.py
+++ b/src/esm_parser/yaml_to_dict.py
@@ -311,7 +311,7 @@ def check_changes_duplicates(yamldict_all, fpath):
                 changes_no_choose = [x.replace(",", ".") for x in changes_no_choose]
                 esm_parser.user_error(
                     "YAML syntax",
-                    "More than one ``_changes`` out of a ``choose_``in "
+                    "More than one ``_changes`` out of a ``choose_`` in "
                     + fpath
                     + ":\n    - "
                     + "\n    - ".join(changes_no_choose)

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.3"
+__version__ = "6.24.4"
 
 from .utils import *


### PR DESCRIPTION
This PR fixes the following problem affecting the version switching of FESOM in the PR by @JanStreffing #1056:

In *awicm3.yaml*:

```yaml
fesom:
    version: "2.0"
    choose_general.major_version:
        "3.2":
            version: "2.5"
```

When `general.major_version: "3.2"` the `version` was still `"2.0"` because of several bugs in `esm_parser`.

@seb-wahl  I think you have encounter this problem on the past.

To solve the bugs the following changes have been carried out:

- add recursion to resolve_choose_with_var so that variables that depend on other choose_ blocks can be resolved in early stages if needed.
- fix an issue with find_key to always continue searching into dictionaries to avoid returning only the first match within a path.
- add the early resolution of choose blocks containing component versions in early stages so that the correct yaml file of the component can be loaded.
- improve and clean the code for filtering of found paths to search for chooses containing the desired variable.