### PR TITLE
Added variable hist_extend_scenario in echam.datasats.yaml

### DIFF
--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -120,8 +120,6 @@ forcing_sources:
                         from: 1851
                         to: 2014
                 # Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} at the beginning of the file.
-                # In case you are running a HIST scenario, change the value of this variable to 
-                # ssp126, ssp119, ssp245, ssp370, or ssp585
                 "${forcing_dir}/ozone/${resolution}_ozone_${ozone_source_file_scenario}_@YEAR@.nc":
                         from: 2015
                         to: 2099

--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -11,6 +11,7 @@ input_sources:
         "vltclim": "${adj_input_dir}/${resolution}${ocean_resolution}_VLTCLIM.nc"
 
 # forcings
+hist_extend_scenario: ssp370
 forcing_sources:
         # sst
         "amipsst":
@@ -115,11 +116,12 @@ forcing_sources:
                 "${forcing_dir}/ozone/${resolution}_ozone_historical_@YEAR@.nc":
                         from: 1851
                         to: 2014
-                # scenario: ssp126, ssp119, ssp245, ssp370, ssp585
-                "${forcing_dir}/ozone/${resolution}_ozone_${scenario}_@YEAR@.nc":
+                # Note: The variable hist_extend_scenario is set to ssp370 by default in line 14.
+                # Change if necessary to ssp126, ssp119, ssp245, ssp370, or ssp585
+                "${forcing_dir}/ozone/${resolution}_ozone_${hist_extend_scenario}_@YEAR@.nc":
                         from: 2015
                         to: 2099
-                "${forcing_dir}/ozone/${resolution}_ozone_${scenario}_2099.nc":
+                "${forcing_dir}/ozone/${resolution}_ozone_${hist_extend_scenario}_2099.nc":
                         from: 2100
 
         "1850ozone": "${forcing_dir}/ozone/${resolution}_ozone_historical_1850.nc"

--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -12,8 +12,6 @@ input_sources:
 
 # forcings
 # Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} by default.
-# In case you are running a HIST scenario, change the value of this variable to 
-# ssp126, ssp119, ssp245, ssp370, or ssp585
 ozone_source_file_scenario: ${scenario}
 forcing_sources:
         # sst

--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -15,8 +15,6 @@ input_sources:
 # In case you are running a HIST scenario, change the value of this variable to 
 # ssp126, ssp119, ssp245, ssp370, or ssp585
 ozone_source_file_scenario: ${scenario}
-#ozone_source_file_scenario: ssp370
-
 forcing_sources:
         # sst
         "amipsst":

--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -11,7 +11,12 @@ input_sources:
         "vltclim": "${adj_input_dir}/${resolution}${ocean_resolution}_VLTCLIM.nc"
 
 # forcings
-hist_extend_scenario: ssp370
+# Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} by default.
+# In case you are running a HIST scenario, change the value of this variable to 
+# ssp126, ssp119, ssp245, ssp370, or ssp585
+ozone_source_file_scenario: ${scenario}
+#ozone_source_file_scenario: ssp370
+
 forcing_sources:
         # sst
         "amipsst":
@@ -116,12 +121,13 @@ forcing_sources:
                 "${forcing_dir}/ozone/${resolution}_ozone_historical_@YEAR@.nc":
                         from: 1851
                         to: 2014
-                # Note: The variable hist_extend_scenario is set to ssp370 by default in line 14.
-                # Change if necessary to ssp126, ssp119, ssp245, ssp370, or ssp585
-                "${forcing_dir}/ozone/${resolution}_ozone_${hist_extend_scenario}_@YEAR@.nc":
+                # Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} by default in line 14.
+                # In case you are running a HIST scenario, change the value of this variable to 
+                # ssp126, ssp119, ssp245, ssp370, or ssp585
+                "${forcing_dir}/ozone/${resolution}_ozone_${ozone_source_file_scenario}_@YEAR@.nc":
                         from: 2015
                         to: 2099
-                "${forcing_dir}/ozone/${resolution}_ozone_${hist_extend_scenario}_2099.nc":
+                "${forcing_dir}/ozone/${resolution}_ozone_${ozone_source_file_scenario}_2099.nc":
                         from: 2100
 
         "1850ozone": "${forcing_dir}/ozone/${resolution}_ozone_historical_1850.nc"

--- a/configs/components/echam/echam.datasets.yaml
+++ b/configs/components/echam/echam.datasets.yaml
@@ -119,7 +119,7 @@ forcing_sources:
                 "${forcing_dir}/ozone/${resolution}_ozone_historical_@YEAR@.nc":
                         from: 1851
                         to: 2014
-                # Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} by default in line 14.
+                # Note: The variable ``ozone_source_file_scenario`` is set to ${scenario} at the beginning of the file.
                 # In case you are running a HIST scenario, change the value of this variable to 
                 # ssp126, ssp119, ssp245, ssp370, or ssp585
                 "${forcing_dir}/ozone/${resolution}_ozone_${ozone_source_file_scenario}_@YEAR@.nc":

--- a/configs/components/echam/echam.yaml
+++ b/configs/components/echam/echam.yaml
@@ -399,6 +399,9 @@ choose_scenario:
                         volcsw: histvolcsw
                         swflux: histswflux
                         MAC-SP: MAC-SP_hist_scenario
+                # For the last year of the hisotical period echam needs an ozone file
+                # of the next year and the ssp370 is given by default
+                ozone_source_file_scenario: ssp370
 
         cmip6hist:
                 scenario_type: cmip6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.24.4
+current_version = 6.24.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.24.4",
+    version="6.24.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.24.4"
+__version__ = "6.24.5"
 
 from .utils import *


### PR DESCRIPTION
I added a variable (`hist_extend_scenario`) to be set to a scenario in order to get the correct echam ozone forcing files for HIST runs.
The same approach has been implemented already in jsbach.datasets.yaml.

Closes #1060 