### PR TITLE
Add build.os key to .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,6 +23,6 @@ sphinx:
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
-#python:
-#  install:
-#        - requirements: docs/.rtd_reqs.txt
+python:
+  install:
+        - requirements: docs/.rtd_reqs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,6 +24,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: "3.7"
   install:
         - requirements: docs/.rtd_reqs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.7"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,8 +8,7 @@ version: 2
 build:
   apt_packages:
     - libhdf5-dev
-    - python3-netcdf4
-    - python3-h5netcdf
+    - libnetcdf-dev
   os: ubuntu-22.04
   tools:
     python: "3.7"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
-  #tools:
-  #  python: "3.7"
+  tools:
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.7"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,6 +8,7 @@ version: 2
 build:
   apt_packages:
     - libhdf5-dev
+    - python3-netcdf4
   os: ubuntu-22.04
   tools:
     python: "3.7"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,8 @@ version: 2
 
 build:
   os: ubuntu-22.04
-  tools:
-    python: "3.7"
+  #tools:
+  #  python: "3.7"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,6 +6,8 @@
 version: 2
 
 build:
+  apt_packages:
+    - libhdf5-dev
   os: ubuntu-22.04
   tools:
     python: "3.7"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,6 +23,6 @@ sphinx:
 formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
-python:
-  install:
-        - requirements: docs/.rtd_reqs.txt
+#python:
+#  install:
+#        - requirements: docs/.rtd_reqs.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -25,4 +25,6 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-        - requirements: docs/.rtd_reqs.txt
+    - requirements: docs/.rtd_reqs.txt
+    - method: pip
+      path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ build:
   apt_packages:
     - libhdf5-dev
     - python3-netcdf4
+    - python3-h5netcdf
   os: ubuntu-22.04
   tools:
     python: "3.7"

--- a/docs/.rtd_reqs.txt
+++ b/docs/.rtd_reqs.txt
@@ -15,4 +15,5 @@ sphinx-toolbox
 sqlalchemy
 pyyaml
 xdgenvpy
+sphinx-rtd-theme
 .

--- a/docs/.rtd_reqs.txt
+++ b/docs/.rtd_reqs.txt
@@ -15,3 +15,4 @@ sphinx-toolbox
 sqlalchemy
 pyyaml
 xdgenvpy
+.

--- a/docs/.rtd_reqs.txt
+++ b/docs/.rtd_reqs.txt
@@ -15,4 +15,3 @@ sphinx-toolbox
 sqlalchemy
 pyyaml
 xdgenvpy
-.


### PR DESCRIPTION
Because of the following error message on readthedocs.org, I added the suggested build.os key in .readthedocs.yml

> The configuration key "build.os" is required to build your documentation. Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os