### PR TITLE
Added package graphviz to rtd config file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -9,6 +9,7 @@ build:
   apt_packages:
     - libhdf5-dev
     - libnetcdf-dev
+    - graphviz
   os: ubuntu-22.04
   tools:
     python: "3.7"


### PR DESCRIPTION
This PR fixes the building of graphviz graphs in the documentation.

Due to changes in the way readthedocs wants to have the .readthedocs.yaml configured, the graphviz package was missing in the .readthedocs.yaml.

It now builds all the graphviz graphs again. I tested it already on readthedocs: See for example
https://esm-tools.readthedocs.io/en/rtd_fix_graphviz_graphs/esm_runscripts.html#job-phases

Closes #1098