### PR TITLE
fix/perl levante

### DIFF
--- a/configs/machines/levante.yaml
+++ b/configs/machines/levante.yaml
@@ -181,6 +181,7 @@ choose_iolibraries:
             - "load ${mod_netcdf_c}"
             - "load ${mod_netcdf_f}"
             - "load ${mod_hdf5}"
+            - "load perl"
 
         add_export_vars:
             IO_LIB_ROOT: "/work/ab0246/HPC_libraries/intel-oneapi-compilers/2022.0.1-gcc-11.2.0/openmpi/4.1.2-intel-2021.5.0"
@@ -210,7 +211,7 @@ choose_iolibraries:
             OASIS3MCT_FC_LIB: '"-L$NETCDFFROOT/lib -lnetcdff"'
 
             # kh 17.02.22 orig mistral, not yet tested on levante (but should work)
-            PERL5LIB: /usr/lib64/perl5
+            PERL5LIB: /sw/spack-levante/perl-5.34.0-mviuwj/lib/5.34.0/
 
             LD_LIBRARY_PATH[(0)]: $HDF5ROOT/lib:$NETCDFROOT/lib:$NETCDFFROOT/lib:$LD_LIBRARY_PATH
 


### PR DESCRIPTION
use the perl installed by spack in levante

Due to some changes in the perl libraries from levante, OpenIFS is not compiling anymore.

This PR will solbe the problem once DKRZ installs all the packages needed for perl in their spack version of perl.