### PR TITLE
fix/direnv get_real_path_from_file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.25.7
+current_version = 6.25.8
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.25.7",
+    version="6.25.8",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -96,6 +96,18 @@ def _get_real_dir_from_pth_file(subfolder):
         [],
     )
     logger.debug(site_packages_dirs)
+
+    # Check if the user is running with direnv and removes all other sites
+    direnv = os.getenv("VIRTUAL_ENV")
+    if direnv:
+        logger.debug(f"User running with direnv, removing other sites")
+        site_package_dirs_new = []
+        for site_package_dir in site_packages_dirs:
+            if direnv in site_package_dir:
+                site_package_dirs_new.append(site_package_dir)
+        site_packages_dirs = site_package_dirs_new
+        logger.debug(site_packages_dirs)
+
     for site_package_dir in site_packages_dirs:
         logger.debug(f"Working on {site_package_dir}")
         # Read the pth file:
@@ -374,6 +386,7 @@ def get_config_filepath(config=""):
         cpath = _get_config_filepath_editable_install(config)
     else:
         cpath = _get_config_filepath_standard_install(config)
+    print(cpath)
     return cpath
 
 

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 import functools
 import inspect

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -386,7 +386,7 @@ def get_config_filepath(config=""):
         cpath = _get_config_filepath_editable_install(config)
     else:
         cpath = _get_config_filepath_standard_install(config)
-    print(cpath)
+    logger.debug(cpath)
     return cpath
 
 

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.25.7"
+__version__ = "6.25.8"
 
 from .utils import *


### PR DESCRIPTION
fix a bug on _get_real_dir_from_pth_file not getting the correct paths for direnv

The problem was that even when you run within a direnv, if you had installed a general esm_tools, the binaries used would be the ones from the direnv, but the configuration files would be the ones from the general esm_tools installation.

This is fixed now