### PR TITLE
generalization of the early resolution of chooses with early_choose_v…

### DIFF
--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -423,6 +423,14 @@ def attach_to_config_and_reduce_keyword(
                 config_to_read_from[reduced_keyword] = config_to_read_from[full_keyword]
         # FIXME: Does this only need to work for lists?
         if isinstance(config_to_read_from[full_keyword], list):
+
+            # Deduplicate items
+            new_conf_reduced_keyword = []
+            for elem in config_to_read_from[reduced_keyword]:
+                if elem not in new_conf_reduced_keyword:
+                    new_conf_reduced_keyword.append(elem)
+            config_to_read_from[reduced_keyword] = new_conf_reduced_keyword
+
             for item in config_to_read_from[full_keyword]:
                 model = item
                 if "-" in item:


### PR DESCRIPTION
This PR generalizes the early resolution of chooses with `early_choose_vars` and also the `further_reading` attachments to solve `further_reading` problems encounter by @JanStreffing while having `further_readings` in the `general` section of the coupled setup `awicm3`, under `choose_` blocks. This PR should also improve the overall functioning of the early_choose logic so now any variable included in `early_choose_vars` will actually be resolved early, without needing extra workarounds (unless it needs to be for real resolved very very early, like `include_models` or `version`).