### PR TITLE
at some point tag FESOM2 2.5 instead of AWI-CM3_v3.2 was selected. Th…

### DIFF
--- a/configs/components/fesom/fesom-2.5.yaml
+++ b/configs/components/fesom/fesom-2.5.yaml
@@ -25,6 +25,8 @@ required_plugins:
 choose_version:
   '2.5':
     branch: "2.5"
+  '2.5-awicm-3.2':
+    branch: "AWI-CM3_v3.2"
 
 destination: "fesom-2.5"
 install_bins: bin/fesom.x

--- a/configs/couplings/fesom-2.5+oifs-43r3-awicm-3.2+xios-2.5/fesom-2.5+oifs-43r3-awicm-3.2+xios-2.5.yaml
+++ b/configs/couplings/fesom-2.5+oifs-43r3-awicm-3.2+xios-2.5/fesom-2.5+oifs-43r3-awicm-3.2+xios-2.5.yaml
@@ -2,7 +2,7 @@ components:
 - xios-2.5
 - rnfmap-awicm-3.1
 - oifs-43r3-awicm-3.2
-- fesom-2.5
+- fesom-2.5-awicm-3.2
 - oasis3mct-4.0-awicm-3.1
 coupling_changes:
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-43r3/src/ifs/module/yommcc.F90

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.27.4
+current_version = 6.27.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.27.4",
+    version="6.27.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.27.4"
+__version__ = "6.27.5"
 
 from .utils import *


### PR DESCRIPTION
…is tag does not run, as a crutial MPI init with OpenIFS fix was missing