### PR TITLE
Bugfix for correct awicm3 general version in choose block

### DIFF
--- a/configs/setups/awicm3/awicm3.yaml
+++ b/configs/setups/awicm3/awicm3.yaml
@@ -368,7 +368,7 @@ fesom:
                         nproc: 144
                 TL159_CORE2:
                         nproc: 72
-        
+
         comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON ..;   make install -j `nproc --all`
 
         opbnd_dir: ""
@@ -409,13 +409,13 @@ fesom:
                                 namelist.oce:
                                         oce_tra:
                                                 surf_relax_s: "${surf_relax_s}"
-                        
+
                         # Remove ICMCL_INIT forcing, which is only required for standalone simulations (form v3.2 onwards contains seasonal leaf area index, veg albedo etc.)
                         remove_forcing_files:
                                 - ICMCL_INIT
-                        
+
                         choose_general.version:
-                                "2.0-awicm-3.1-recom":
+                                "v3.1.2_recom":
                                         subversion: "-recom"
                                         comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON -DRECOM_COUPLED=ON ..;   make install -j `nproc --all`
                                 "*":
@@ -888,7 +888,7 @@ oasis3mct:
                 rstos.nc: rstos.nc
         remove_config_files:
                 - cf
-        
+
 
 
 computer:

--- a/configs/setups/awicm3/awicm3.yaml
+++ b/configs/setups/awicm3/awicm3.yaml
@@ -21,7 +21,7 @@ general:
         - 'v3.1'
         - 'v3.1.1'
         - 'v3.1.2'
-        - 'v3.1.2_recom'
+        - 'v3.1.2-recom'
         - 'v3.2'
         - 'master'
         - 'frontiers-xios'
@@ -54,7 +54,7 @@ general:
             - xios
             add_further_reading:
             - xios/xios.env.yaml
-          v3.1.2_recom:
+          v3.1.2-recom:
             major_version: v3.1
             couplings:
             - fesom-2.0-awicm-3.1-recom+oifs-43r3-awicm-3.1.2+xios-2.5
@@ -369,7 +369,7 @@ fesom:
                 TL159_CORE2:
                         nproc: 72
 
-        comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON ..;   make install -j `nproc --all`
+        comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON ${recom_Dflag}..;   make install -j `nproc --all`
 
         opbnd_dir: ""
         tide_forcing_dir: ""
@@ -403,7 +403,7 @@ fesom:
                                         oce_tra:
                                                 surf_relax_s: "${surf_relax_s}"
                 "v3.1":
-                        version: "2.0${subversion}"
+                        version: "2.0${recom_str4ver}"
                         namelist_dir: "${esm_namelist_dir}/fesom2/2.0/awicm3/v3.1/"
                         add_namelist_changes:
                                 namelist.oce:
@@ -414,12 +414,6 @@ fesom:
                         remove_forcing_files:
                                 - ICMCL_INIT
 
-                        choose_general.version:
-                                "v3.1.2_recom":
-                                        subversion: "-recom"
-                                        comp_command: mkdir -p build; cd build; cmake -DOIFS_COUPLED=ON -DFESOM_COUPLED=ON -DRECOM_COUPLED=ON ..;   make install -j `nproc --all`
-                                "*":
-                                        subversion: ""
                 "v3.2":
                         version: "2.5"
                         namelist_dir: "${esm_namelist_dir}/fesom2/2.5/awicm3/v3.2/"
@@ -518,6 +512,17 @@ fesom:
         coupling_fields:
                 "[[awicm3_fields-->FIELD]]":
                         grid: feom
+
+
+        # REcoM options
+        with_recom: '$(( "recom" in "${general.version}"))'
+        choose_fesom.with_recom:
+            True:
+                recom_str4ver: "-recom"
+                recom_Dflag: "-DRECOM_COUPLED=ON"
+            False:
+                recom_str4ver: ""
+                recom_Dflag: "-DRECOM_COUPLED=OFF"
 
 
 # It is possible for the esm_tools to modify the fesom io namelist, in case you don't want to make your own copy and edit that.


### PR DESCRIPTION
This PR corrects a small bugfix in awicm3.yaml for setting the right choose in a `choose_general.version` block.