### PR TITLE
Improvements on filemovements

### DIFF
--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -1294,7 +1294,7 @@ choose_eternal_run_number:
                 start_ndays_source: "${start_ndays}"
                 preprocess_method: "
                     ${general.esm_function_dir}/components/oifs/change_icm_date.sh
-                        ${thisrun_input_dir}/
+                        ${thisrun_work_dir}/
                         ${oifs.input_expid}
                         ${oifs.input_expid}
                         ${initial_date!syear!smonth!sday}
@@ -1318,7 +1318,7 @@ choose_eternal_run_number:
                 start_ndays_source: "${prev_run.oifs.next_ndays}"
                 preprocess_method: "
                     ${general.esm_function_dir}/components/oifs/change_icm_date.sh
-                        ${thisrun_input_dir}/
+                        ${thisrun_work_dir}/
                         ${oifs.input_expid}
                         ${oifs.input_expid}
                         ${pseudo_initial_date!syear!smonth!sday}
@@ -1328,7 +1328,7 @@ choose_eternal_run_number:
                         ${oifs.nx}
                         ${oifs.ensemble_id};
                     ${general.esm_function_dir}/components/oifs/change_rcf_date.sh
-                        ${thisrun_restart_in_dir}/
+                        ${thisrun_work_dir}/
                         ${pseudo_initial_date!syear!smonth!sday}
                         ${oifs.time_step}
                         ${oifs.seconds_since_initial}
@@ -1347,7 +1347,7 @@ choose_general.standalone:
         True:
                 slice_icml: "
                     ${general.esm_function_dir}/components/oifs/slice_icmcl_file.sh
-                        ${thisrun_input_dir}/
+                        ${thisrun_work_dir}/
                         ${icmcl_dir}/${icmcl_file}
                         ${oifs.input_expid}
                         ${start_date!syear!smonth!sday}
@@ -1391,10 +1391,10 @@ prepcompute_recipe:
    - "wait_for_iterative_coupling"
    - "copy_files_to_thisrun"
    - "write_env"
-   - "preprocess"
    - "modify_namelists"
    - "modify_files"
    - "copy_files_to_work"
+   - "preprocess"
    - "report_missing_files"
    # see https://github.com/esm-tools/esm_tools/discussions/774
    # - "add_vcs_info"

--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -1391,10 +1391,10 @@ prepcompute_recipe:
    - "wait_for_iterative_coupling"
    - "copy_files_to_thisrun"
    - "write_env"
+   - "preprocess"
    - "modify_namelists"
    - "modify_files"
    - "copy_files_to_work"
-   - "preprocess"
    - "report_missing_files"
    # see https://github.com/esm-tools/esm_tools/discussions/774
    # - "add_vcs_info"

--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -1294,7 +1294,7 @@ choose_eternal_run_number:
                 start_ndays_source: "${start_ndays}"
                 preprocess_method: "
                     ${general.esm_function_dir}/components/oifs/change_icm_date.sh
-                        ${thisrun_work_dir}/
+                        ${thisrun_input_dir}/
                         ${oifs.input_expid}
                         ${oifs.input_expid}
                         ${initial_date!syear!smonth!sday}
@@ -1318,7 +1318,7 @@ choose_eternal_run_number:
                 start_ndays_source: "${prev_run.oifs.next_ndays}"
                 preprocess_method: "
                     ${general.esm_function_dir}/components/oifs/change_icm_date.sh
-                        ${thisrun_work_dir}/
+                        ${thisrun_input_dir}/
                         ${oifs.input_expid}
                         ${oifs.input_expid}
                         ${pseudo_initial_date!syear!smonth!sday}

--- a/configs/defaults/general.yaml
+++ b/configs/defaults/general.yaml
@@ -1,2 +1,6 @@
 use_database: false
 profile: False
+intermediate_movements:
+- "config"
+- "bin"
+- "input"

--- a/configs/setups/focioifs/focioifs.yaml
+++ b/configs/setups/focioifs/focioifs.yaml
@@ -15,10 +15,10 @@ general:
            - "wait_for_iterative_coupling"
            - "copy_files_to_thisrun"
            - "write_env"
-           - "preprocess"
            - "modify_namelists"
            - "modify_files"
            - "copy_files_to_work"
+           - "preprocess"
            - "report_missing_files"
            # not working, bug already reported at https://github.com/esm-tools/esm_tools/discussions/774
            # - "add_vcs_info"

--- a/configs/setups/focioifs/focioifs.yaml
+++ b/configs/setups/focioifs/focioifs.yaml
@@ -15,10 +15,10 @@ general:
            - "wait_for_iterative_coupling"
            - "copy_files_to_thisrun"
            - "write_env"
+           - "preprocess"
            - "modify_namelists"
            - "modify_files"
            - "copy_files_to_work"
-           - "preprocess"
            - "report_missing_files"
            # not working, bug already reported at https://github.com/esm-tools/esm_tools/discussions/774
            # - "add_vcs_info"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.30.0
+current_version = 6.31.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.30.0",
+    version="6.31.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -1080,7 +1080,7 @@ def avoid_overwriting(config, source, target):
             esm_parser.user_note(
                 "File movement conflict",
                 f"The file ``{date_stamped_target}`` already exists. Skipping movement:\n"
-                f"{soucer} -> {date_stamped_target}"
+                f"{source} -> {date_stamped_target}"
             )
             return target
 

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -1058,7 +1058,9 @@ def avoid_overwriting(config, source, target):
     and creates a link named ``target`` that points at the target with the current time
     stamp.
 
-    Note: This function does not execute the file movement.
+    Note
+    ---- 
+        This function does not execute the file movement.
 
     Parameters
     ----------

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -1084,7 +1084,7 @@ def avoid_overwriting(config, source, target):
 
         date_stamped_target = f"{target}_{config['general']['run_datestamp']}"
         if os.path.isfile(date_stamped_target):
-            esm_parser.user_note(
+            esm_parser.user_error(
                 "File movement conflict",
                 f"The file ``{date_stamped_target}`` already exists. Skipping movement:\n"
                 f"{source} -> {date_stamped_target}"

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -920,7 +920,7 @@ def copy_files(config, filetypes, source, target):
 
     intermediate_movements = config["general"].get(
         "intermediate_movements",
-        ["config", "input"], # DEFAULTS
+        [],
     )
 
     if source == "init":

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -914,6 +914,13 @@ def copy_files(config, filetypes, source, target):
     of high resolution simulations. A better fix is not made because ``filelists`` are
     being entirely reworked, but the fix cannot wait.
 
+    Note
+    ----
+    Relevant variables in this function:
+    
+    intermediate_movements : list
+        List of file types that will be considered in the intermediate step (copy         from source to intermediate and then to work, rather than directly to work)
+
     Parameters
     ----------
     config : dict

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -933,6 +933,7 @@ def copy_files(config, filetypes, source, target):
     successful_files = []
     missing_files = {}
 
+    # See the default intermediate movements list in `configs/defaults/general.yaml`
     intermediate_movements = config["general"].get(
         "intermediate_movements",
         [],

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -911,6 +911,32 @@ def resolve_symlinks(config, file_source):
 
 
 def copy_files(config, filetypes, source, target):
+    """
+    This function has a misleading name. It is not only used for copying, but also
+    for moving or linking, depending on what was specified for the particular file
+    or file type vie the ``file_movements``.
+
+    Note: when the ``target`` is ``thisrun`` (intermediate folders) check whether the
+    type of file is included in ``intermediate_movements``. If it's not, instead of
+    moving the file to the intermediate folder it moves it to ``work``. This is an
+    ugly fix to provide a fast solution to the problem that files are
+    copied/moved/linked twice unnecessarily, and this affects inmensely the performance
+    of high resolution simulations. A better fix is not made because ``filelists`` are
+    being entirely reworked, but the fix cannot wait.
+
+    Parameters
+    ----------
+    config : dict
+        The general configuration
+    filetypes : list
+        List of file types to be copied/linked/moved
+    source : str
+        Specifies the source type, to be chosen between ``init``, ``thisrun``,
+        ``work``.
+    target : str
+        Specifies the target type, to be chosen between ``init``, ``thisrun``,
+        ``work``.
+    """
     if config["general"]["verbose"]:
         print("\n::: Copying files", flush=True)
         helpers.print_datetime(config)
@@ -1042,6 +1068,23 @@ def copy_files(config, filetypes, source, target):
 
 
 def avoid_overwriting(config, source, target):
+    """
+    Function that appends the date stamp to ``target`` if the target already exists.
+    Additionally, if the target exists, it renames it with the previous run time stamp,
+    and creates a link named ``target`` that points at the target with the current time
+    stamp.
+
+    Note: This function does not execute the file movement.
+
+    Parameters
+    ----------
+    config : dict
+        Simulation configuration
+    source : str
+        Path of the source of the file that will be copied/moved/linked
+    target : src
+        Path of the target of the file that will be copied/moved/linked
+    """
     if os.path.isfile(target):
         if filecmp.cmp(source, target):
             return target

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -242,6 +242,15 @@ def copy_files_to_work(config):
     return config
 
 
+def copy_files_init_to_work(config):
+    if config["general"]["verbose"]:
+        print("PREPARING WORK FOLDER")
+    config = copy_files(
+        config, config["general"]["in_filetypes"], source="thisrun", target="work"
+    )
+    return config
+
+
 def _write_finalized_config(config, config_file_path=None):
     """
     Writes <expid>_finished_config.yaml file

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -253,15 +253,6 @@ def copy_files_to_work(config):
     return config
 
 
-def copy_files_init_to_work(config):
-    if config["general"]["verbose"]:
-        print("PREPARING WORK FOLDER")
-    config = copy_files(
-        config, config["general"]["in_filetypes"], source="thisrun", target="work"
-    )
-    return config
-
-
 def _write_finalized_config(config, config_file_path=None):
     """
     Writes <expid>_finished_config.yaml file

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -218,6 +218,17 @@ def wait_for_iterative_coupling(config):
 
 
 def copy_files_to_thisrun(config):
+    """
+    This function was used to copy to intermediate folders in the past. Now the
+    ``copy_files`` function used within, in all file movements, might escape moving
+    files to the intermediate folders, and move them directly to ``work`` if the file
+    type of the file is not included in the variable ``general.intermediate_movements``.
+
+    This is a fast fix, pretty ugly, but works. The reason for not making it better is
+    that we are reworking the whole file movement logic, so it is not worth the time to
+    do a partial rework here.
+    """
+
     if config["general"]["verbose"]:
         print("PREPARING EXPERIMENT")
         # Copy files:

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.30.0"
+__version__ = "6.31.0"
 
 from .utils import *


### PR DESCRIPTION
This PR aims to:
- [x] Remove the intermediate copying by default (except for `config`, `input`, and `forcing`. The defaults can be overridden by `general.intermediate_movement = [list of filetypes that go to the intermediate folders]`
- [ ] [to be done in another PR] Parallelize the file movements (WIP)
- [x] Profiling

This is to reduce the copying times of @tsemmler05, @a270067 and @mjy1011.

@JanStreffing and @mjy1011, this branch is not in it's final stage, but it would be a great help if you can check that is working for an actual simulation. I've tested already a bit but not in depth.