### PR TITLE
fix prev_chunks being stored in finished_config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.31.0
+current_version = 6.31.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.31.0",
+    version="6.31.1",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/chunky_parts.py
+++ b/src/esm_runscripts/chunky_parts.py
@@ -225,6 +225,8 @@ def prev_chunk_info(config):
         return
 
     prev_chunk_models = []
+    if not hasattr(config, "prev_objects"):
+        config.prev_objects = []
     for model in model_named_queue:
         if model == setup_name:
             continue
@@ -238,6 +240,7 @@ def prev_chunk_info(config):
         # generalized
         if finished_config:
             with open(finished_config, "r") as fc:
+                config.prev_objects.append(f"prev_chunk_{model}")
                 config[f"prev_chunk_{model}"] = yaml.load(fc, Loader=yaml.FullLoader)
 
 

--- a/src/esm_runscripts/chunky_parts.py
+++ b/src/esm_runscripts/chunky_parts.py
@@ -225,8 +225,7 @@ def prev_chunk_info(config):
         return
 
     prev_chunk_models = []
-    if not hasattr(config, "prev_objects"):
-        config.prev_objects = []
+    config["general"]["prev_chunk_objs"] = []
     for model in model_named_queue:
         if model == setup_name:
             continue
@@ -240,8 +239,8 @@ def prev_chunk_info(config):
         # generalized
         if finished_config:
             with open(finished_config, "r") as fc:
-                config.prev_objects.append(f"prev_chunk_{model}")
                 config[f"prev_chunk_{model}"] = yaml.load(fc, Loader=yaml.FullLoader)
+            config["general"]["prev_chunk_objs"].append(f"prev_chunk_{model}")
 
 
 ########################################   END OF API ###############################################

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -341,6 +341,19 @@ def _write_finalized_config(config, config_file_path=None):
 
 
 def delete_prev_objects(config):
+    """
+    Delete key-values in the ``config`` which values correspond to ``prev_`` objects,
+    for example, ``prev_run`` (contains values of the config of the previous run) and
+    ``prev_chunk_<model>`` (that contains values of the config of a previous chunk
+    in a offline coupled simulation). This deletion is necessary because otherwise
+    the ``finished_config.yaml`` gets a lot of nested information from the previous
+    runs that keeps growing each new run/chunk.
+
+    Parameters
+    ----------
+    config : dict
+        Dictionary containing the simulation/compilation information
+    """
     for prev_object in getattr(config, "prev_objects", []):
         del config[prev_object]
 

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -331,13 +331,18 @@ def _write_finalized_config(config, config_file_path=None):
     with open(config_file_path, "w") as config_file:
         # Avoid saving ``prev_run`` information in the config file
         config_final = copy.deepcopy(config)  # PrevRunInfo
-        del config_final["prev_run"]  # PrevRunInfo
+        delete_prev_objects(config_final)  # PrevRunInfo
 
         out = yaml.dump(
             config_final, Dumper=EsmConfigDumper, width=10000, indent=4
         )  # PrevRunInfo
         config_file.write(out)
     return config
+
+
+def delete_prev_objects(config):
+    for prev_object in getattr(config, "prev_objects", []):
+        del config[prev_object]
 
 
 def _show_simulation_info(config):

--- a/src/esm_runscripts/prev_run.py
+++ b/src/esm_runscripts/prev_run.py
@@ -64,6 +64,7 @@ class PrevRunInfo(dict):
         # Counter for debuggin
         self._prev_config_count = 0
 
+
     def components_with_prev_run(self):
         """
         Lists components containning variables using the ``prev_run`` feature. Reading

--- a/src/esm_runscripts/sim_objects.py
+++ b/src/esm_runscripts/sim_objects.py
@@ -99,7 +99,7 @@ class SimulationSetup(object):
 
         # 10. Initialize the ``prev_run`` object
         self.config["prev_run"] = prev_run.PrevRunInfo(self.config)
-        self.config.prev_objects = ["prev_run"]
+        self.store_prev_objects()
 
         # 11. Run ``prepare`` recipe (resolve the `ESM-Tools` syntax)
         self.config = prepare.run_job(self.config)
@@ -234,3 +234,13 @@ class SimulationSetup(object):
         import esm_viz as viz
 
         self.config = viz.run_job(self.config)
+
+    #########################     HELPERS      #############################################################
+
+    def store_prev_objects(self):
+        self.config.prev_objects = ["prev_run"]
+        self.config.prev_objects.extend(self.config["general"].get(
+            "prev_chunk_objs", [])
+        )
+        if "prev_chunk_objs" in self.config["general"]:
+            del self.config["general"]["prev_chunk_objs"]

--- a/src/esm_runscripts/sim_objects.py
+++ b/src/esm_runscripts/sim_objects.py
@@ -99,6 +99,7 @@ class SimulationSetup(object):
 
         # 10. Initialize the ``prev_run`` object
         self.config["prev_run"] = prev_run.PrevRunInfo(self.config)
+        self.config.prev_objects = ["prev_run"]
 
         # 11. Run ``prepare`` recipe (resolve the `ESM-Tools` syntax)
         self.config = prepare.run_job(self.config)

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.31.0"
+__version__ = "6.31.1"
 
 from .utils import *


### PR DESCRIPTION
Fixes a problem with offling coupled simulations where the information of all previous runs was written in the finished_config, making that file increasingly large.