### PR TITLE
feat: transient forcing checker

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.33.2
+current_version = 6.34.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -105,6 +105,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.33.2",
+    version="6.34.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 
 from .esm_parser import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/namelists.py
+++ b/src/esm_runscripts/namelists.py
@@ -13,9 +13,9 @@ import sys
 import warnings
 
 import f90nml
+from loguru import logger
 
 from esm_parser import user_error
-from loguru import logger
 
 
 class Namelist:
@@ -416,6 +416,8 @@ class Namelist:
                         logger.error("echam:")
                         logger.error("    transient_forcing_table: /path/to/your/table")
                         sys.exit(1)
+                    # TODO(PG): This is a bit harsh, but until we get a better idea, dump the error:
+                    logger.error(e)
                     sys.exit(1)
         return config
 
@@ -465,7 +467,9 @@ class Namelist:
                 nml["dynctl"] = dynctl
             else:
                 logger.debug("Not applying disturbance in echam namelist.")
-                logger.debug(f"Current year: {current_year}, disturbance_years: {disturbance_years}")
+                logger.debug(
+                    f"Current year: {current_year}, disturbance_years: {disturbance_years}"
+                )
         return config
 
     @staticmethod

--- a/src/esm_runscripts/namelists.py
+++ b/src/esm_runscripts/namelists.py
@@ -418,7 +418,6 @@ class Namelist:
                         sys.exit(1)
                     # TODO(PG): This is a bit harsh, but until we get a better idea, dump the error:
                     logger.error(e)
-                    breakpoint()
                     sys.exit(1)
         return config
 

--- a/src/esm_runscripts/namelists.py
+++ b/src/esm_runscripts/namelists.py
@@ -353,7 +353,7 @@ class Namelist:
                         header=None,
                     )
                     co2, n2o, ch4, cecc, cobld, clonp = forcing_table.loc[
-                        config["general"]["current_date"].year
+                        str(config["general"]["current_date"].year)
                     ]
                     radctl["co2vmr"] = co2
                     radctl["n2ovmr"] = n2o
@@ -418,6 +418,7 @@ class Namelist:
                         sys.exit(1)
                     # TODO(PG): This is a bit harsh, but until we get a better idea, dump the error:
                     logger.error(e)
+                    breakpoint()
                     sys.exit(1)
         return config
 

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 import functools
 import inspect

--- a/src/esm_tools/cli.py
+++ b/src/esm_tools/cli.py
@@ -58,5 +58,37 @@ def create_new_config(name, type):
     return 0
 
 
+# TODO(PG): This doesn't belong in the cli.py but whatever...
+@main.command()
+@click.argument("file_name", nargs=1, required=False)
+@click.argument("current_year", nargs=1, required=False)
+def check_transient_forcing(file_name=None, current_year=None):
+    import pandas
+    import questionary
+
+    file_name = file_name or questionary.filepath("Select the file to read").ask()
+    df = pandas.read_csv(
+        file_name,
+        sep=";",
+        index_col=0,
+        header=None,
+    )
+    current_year = (
+        current_year
+        or questionary.text(
+            "Enter a value for year that you know is in the table"
+        ).ask()
+    )
+    # current_year = int(current_year)
+    co2, n2o, ch4, cecc, cobld, clonp = df.loc[current_year]
+    print(f"Forcing table was OK to read at year {current_year}")
+    print(f"CO2: {co2}")
+    print(f"N2O: {n2o}")
+    print(f"CH4: {ch4}")
+    print(f"CECC: {cecc}")
+    print(f"COBLD: {cobld}")
+    print(f"CLONP: {clonp}")
+
+
 if __name__ == "__main__":
     sys.exit(main())

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.33.2"
+__version__ = "6.34.0"
 
 from .utils import *


### PR DESCRIPTION
Adds a checker on the top-level CLI for the transient forcing table. Use as:

```console
$ esm_tools check-transient-forcing [table_path] [year]
```

If not provided, user is prompted. Uses the same machinery as the echam namelist.