### PR TITLE
esm_tools version in finished_config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.36.1
+current_version = 6.37.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.36.1",
+    version="6.37.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/sim_objects.py
+++ b/src/esm_runscripts/sim_objects.py
@@ -7,13 +7,13 @@ import sys
 from loguru import logger
 
 import esm_parser
+from esm_tools import __version__
 
 from . import (config_initialization, helpers, logfiles, prepare, prepexp,
                prev_run, resubmit, workflow)
 
 
 class SimulationSetup(object):
-
     def __init__(self, command_line_config=None, user_config=None):
         """
         Initializes the ``SimulationSetup`` object, and prepares the ``self.config`` by
@@ -106,6 +106,9 @@ class SimulationSetup(object):
         # 11. Run ``prepare`` recipe (resolve the `ESM-Tools` syntax)
         self.config = prepare.run_job(self.config)
 
+        # 12. Store the ESM-Tools version in the config for later reference
+        self.config["general"]["esm_tools_version"] = __version__
+
     def __call__(self, kill_after_submit=True):
         # Trigger inspect functionalities
         if self.config["general"]["jobtype"] == "inspect":
@@ -166,7 +169,6 @@ class SimulationSetup(object):
     #########################     OBSERVE      #############################################################
 
     def observe(self):
-
         from . import observe
 
         self.config = observe.run_job(self.config)
@@ -241,8 +243,8 @@ class SimulationSetup(object):
 
     def store_prev_objects(self):
         self.config.prev_objects = ["prev_run"]
-        self.config.prev_objects.extend(self.config["general"].get(
-            "prev_chunk_objs", [])
+        self.config.prev_objects.extend(
+            self.config["general"].get("prev_chunk_objs", [])
         )
         if "prev_chunk_objs" in self.config["general"]:
             del self.config["general"]["prev_chunk_objs"]

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.36.1"
+__version__ = "6.37.0"
 
 from .utils import *


### PR DESCRIPTION
Adds the `esm_tools_version` in the config so that each `finsihed_config` contains the version number of ESM-Tools that was used to be created.

@JanStreffing, this is not as good as the `vcs` feature from @pgierz (because we don't get the right hash of the commit id but still just the version that this branch used to depart from release) but unfortunatelly, vcs is not yet finished and it needs a second thought before finishing its implementation.

In the mean time, it would already be helpful to the NRT people to store the version of ESM-Tools they are using for each simulation (virtually 0 extra time added to ESM-Tools).

@antoniofis10000 @mathanase in effect what this implementation does is that when you look at your `finished_config` you can search for the following line:

```yaml
  esm_tools_version: 6.36.1 # no provenance info
```