### PR TITLE
ignore provenance for baseline test file diffs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.37.2
+current_version = 6.37.3
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.37.2",
+    version="6.37.3",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tests/output.py
+++ b/src/esm_tests/output.py
@@ -49,7 +49,7 @@ def print_diff(info, sfile, tfile, name, ignore_lines):
     file_t = clean_user_specific_info(info, file_t)
 
     # Pattern of provenance
-    provenance_pattern = r'\s*#\s*[^,]+,line:\d+,col:\d+'
+    provenance_pattern = r'\s*#\s*([^,]+,line:\d+,col:\d+|no provenance info)'
 
     # Check for ignored lines
     new_file_s = []

--- a/src/esm_tests/output.py
+++ b/src/esm_tests/output.py
@@ -22,7 +22,8 @@ compare_files = {"comp": ["comp-"], "run": [".run", "finished_config", "namelist
 
 def print_diff(info, sfile, tfile, name, ignore_lines):
     """
-    Prints the differences between two equivalent configuration files.
+    Prints the differences between two equivalent configuration files. Ignores the
+    provenance comments.
 
     Parameters
     ----------
@@ -47,24 +48,29 @@ def print_diff(info, sfile, tfile, name, ignore_lines):
     # Substitute user lines in target string
     file_t = clean_user_specific_info(info, file_t)
 
+    # Pattern of provenance
+    provenance_pattern = r'\s*#\s*[^,]+,line:\d+,col:\d+'
+
     # Check for ignored lines
     new_file_s = []
     for line in file_s:
         ignore_this = False
+        line_no_prov = re.sub(provenance_pattern, '', line)
         for iline in ignore_lines:
-            if re.search(iline, line):
+            if re.search(iline, line_no_prov):
                 ignore_this = True
         if not ignore_this:
-            new_file_s.append(line)
+            new_file_s.append(line_no_prov)
     file_s = new_file_s
     new_file_t = []
     for line in file_t:
         ignore_this = False
+        line_no_prov = re.sub(provenance_pattern, '', line)
         for iline in ignore_lines:
-            if re.search(iline, line):
+            if re.search(iline, line_no_prov):
                 ignore_this = True
         if not ignore_this:
-            new_file_t.append(line)
+            new_file_t.append(line_no_prov)
     file_t = new_file_t
 
     diffobj = difflib.SequenceMatcher(a=file_s, b=file_t)

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.37.2"
+__version__ = "6.37.3"
 
 from .utils import *


### PR DESCRIPTION
In the baseline tests, when comparing new generated files with the "Truth" ignores the provenance. Comparing the provenance is misleading for example, in the case you added a line at the beginning of a yaml file, instead of getting that variable as the only difference, all the parameters defined in this file pop up as differences because their line number in their provenance has change.

This PR makes sure you only compare values of the parameters, and not their provenance.