### PR TITLE
1229 awicm3 v33 oifs expects different repository names for xios and oasis

### DIFF
--- a/configs/couplings/fesom-2.5-refactoring+oifs-48r1+xios-2.5/fesom-2.5-refactoring+oifs-48r1+xios-2.5.yaml
+++ b/configs/couplings/fesom-2.5-refactoring+oifs-48r1+xios-2.5/fesom-2.5-refactoring+oifs-48r1+xios-2.5.yaml
@@ -5,6 +5,8 @@ components:
 - fesom-2.5-refactoring
 - oasis3mct-5.0-smhi
 coupling_changes:
+- sed -i 's/xios-2.5+/xios/g' oifs-48r1/bundle.yml
+- sed -i 's/oasis3-mct-5.2/oasis/g' oifs-48r1/bundle.yml
 - sed -i '/CPLNG_ACTIVE = /s/.FALSE./.TRUE./g' oifs-48r1/ifs-source/arpifs/module/yommcc.F90
 - sed -i '/COUPLENEMOECE = /s/.TRUE./.FALSE./g' oifs-48r1/ifs-source/arpifs/module/yommcc.F90
 - sed -i '/COUPLEFESOM2 = /s/.FALSE./.TRUE./g' oifs-48r1/ifs-source/arpifs/module/yommcc.F90


### PR DESCRIPTION
This PR solves the problem, that in AWICM3-v3.3 OIFS expects the folder xios and oasis to have different names.

Adde specific coupling config file for AWICM3-3v.3

closes #1229 