### PR TITLE
fix the esm_master logger

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.42.1
+current_version = 6.42.2
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -114,6 +114,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.42.1",
+    version="6.42.2",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 
 from . import database

--- a/src/esm_master/cli.py
+++ b/src/esm_master/cli.py
@@ -2,10 +2,13 @@
 import argparse
 import sys
 
+from loguru import logger
+
+from esm_motd import check_all_esm_packages
+
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 from . import __version__
-from esm_motd import check_all_esm_packages
 from .esm_master import main_flow
 
 
@@ -99,6 +102,13 @@ def main():
 
     if not no_motd:
         check_all_esm_packages()
+
+    # Logger setup
+    logger.add(sys.stderr, level="ERROR", format="{message}")
+    if verbose:
+        logger.add(sys.stdout, level="DEBUG", format="{message}")
+    else:
+        logger.add(sys.stdout, level="INFO", format="{message}")
 
     main_flow(parsed_args, target)
 

--- a/src/esm_master/general_stuff.py
+++ b/src/esm_master/general_stuff.py
@@ -294,6 +294,6 @@ class version_control_infos:
 
     def output(self):
         print()
-        self.config.yaml_dump()
+        esm_parser.dict_to_yaml.yaml_dump(self.config)
         print("Known repos: " + str(self.known_repos))
         print("Known vcs-commands: " + str(self.known_todos))

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.42.1"
+__version__ = "6.42.2"
 
 from .utils import *


### PR DESCRIPTION
Fixes the logger for the esm_master.

As it currently was, none of the logger messages coming from `esm_runscripts` functions were printed because there was no definition on where to print this messages for `esm_master`.