### PR TITLE
Provenance hints to user_note and user_error and error handling for missing coupling direction

### DIFF
--- a/src/esm_master/task.py
+++ b/src/esm_master/task.py
@@ -1,18 +1,16 @@
 import os
-import sys
-import subprocess
-import shlex  # contains shlex.split that respects quoted strings
-
 # deniz: it is better to use more pathlib in the future so that dir/path
 # operations will be more portable (supported since Python 3.4, 2014)
 import pathlib
-
-from .software_package import software_package
-from esm_parser import user_error
+import shlex  # contains shlex.split that respects quoted strings
+import subprocess
+import sys
 
 import esm_environment
 import esm_plugin_manager
+from esm_tools import user_error
 
+from .software_package import software_package
 
 ######################################################################################
 ################################# class "task" #######################################

--- a/src/esm_motd/esm_motd.py
+++ b/src/esm_motd/esm_motd.py
@@ -3,11 +3,12 @@ import urllib
 import urllib.request
 from time import sleep
 
-import esm_parser
-import esm_utilities
 import yaml
 
+import esm_parser
 import esm_tools
+import esm_utilities
+from esm_tools import user_error
 
 
 class MessageOfTheDayError(Exception):
@@ -83,7 +84,7 @@ class MessageOfTheDayHandler:
             if action == "sleep":
                 sleep(time)
             elif action == "error":
-                esm_parser.user_error(
+                user_error(
                     "Version",
                     (
                         f"Version {version} of '{package}' package has been tagged as "

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -2789,7 +2789,9 @@ def find_key(d_search, k_search, exc_strings="", level="", paths2finds=[], sep="
     return paths2finds
 
 
-def user_note(note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``"]):
+def user_note(
+    note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``"], hints=[]
+):
     """
     Notify the user about something. In the future this should also write in the log.
 
@@ -2802,12 +2804,17 @@ def user_note(note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``
     """
     reset_s = colorama.Style.RESET_ALL
 
+    # Convert a list of strings to a single string
     if isinstance(note_text, list):
         new_note_text = ""
         for item in note_text:
             new_note_text = f"{new_note_text}- {item}\n"
         note_text = new_note_text
 
+    # Add hints to the note_text
+    note_text = user_note_hints(note_text, hints)
+
+    # Add color to the note_text
     for dsymbol in dsymbols:
         note_text = re.sub(
             f"{dsymbol}([^{dsymbol}]*){dsymbol}", f"{color}\\1{reset_s}", str(note_text)
@@ -2816,7 +2823,7 @@ def user_note(note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``
     print(f"{note_text}\n")
 
 
-def user_error(error_type, error_text, exit_code=1, dsymbols=["``"]):
+def user_error(error_type, error_text, exit_code=1, dsymbols=["``"], hints=[]):
     """
     User-friendly error using ``sys.exit()`` instead of an ``Exception``.
 
@@ -2830,8 +2837,75 @@ def user_error(error_type, error_text, exit_code=1, dsymbols=["``"]):
         The exit code to send back to the parent process (default to 1)
     """
     error_title = "ERROR: " + error_type
-    user_note(error_title, error_text, color=colorama.Fore.RED, dsymbols=dsymbols)
+    user_note(
+        error_title, error_text, color=colorama.Fore.RED, dsymbols=dsymbols, hints=hints
+    )
     sys.exit(exit_code)
+
+
+def user_note_hints(note_text, hints):
+    """
+    Add hints to the note text. The hints are added to the note text by replacing
+    the placeholders "<HINT_#>" with the actual hints from the hints list.
+
+    Parameters
+    ----------
+    note_text : str
+        The note text with placeholders for the hints. The placeholders are in the
+        form "<HINT_#>", where # is the index of the hint in the hints list.
+    hints : list
+        A list of hints to be added to the note text. Each hint is a dictionary with
+        the following keys:
+        - type: The type of the hint (e.g., "prov" for provenance)
+        - text: The text of the hint. This text can contain a placeholder "<HINT>"
+          which will be replaced with the actual hint corresponding to its index.
+        - object: The object to which the hint applies
+    """
+
+    # Find all hints matching r"<HINT_(\d+)>" in the note_text
+    pattern = r"<HINT_(\d+)>"
+    hint_indexes = [int(x) for x in list(set(re.findall(pattern, note_text)))]
+    hint_indexes.sort()
+
+    # Check whether all hint indexes are represented in the hints list
+    if hint_indexes != list(range(len(hints))):
+        raise ValueError(
+            "The hint indexes in the note_text do not match the hints list."
+        )
+
+    # Loop through the hints and replace the placeholders in the note_text
+    for indx, hint in enumerate(hints):
+        # Hint type provenance
+        if hint["type"] == "prov":
+            hint_text = hint["text"]
+            mapping_with_provenance = hint["object"]
+
+            # Get the provenance
+            provenance = None
+            if hasattr(mapping_with_provenance, "get_first_provenance"):
+                provenance = mapping_with_provenance.get_first_provenance()
+            else:
+                logging.debug("No provenance found for %s", mapping_with_provenance)
+            # If the provenance is found, replace the placeholder with the provenance,
+            # otherwise remove the placeholder (provenance might not always exist)
+            if provenance:
+                prov_string = (
+                    f"``{provenance['yaml_file']}``,"
+                    f"line:``{provenance['line']}``,"
+                    f"col:``{provenance['col']}``"
+                )
+                # Replace the HINT placeholder of the hint with the provenance string
+                hint_text = hint["text"].replace("<HINT>", prov_string)
+                # Replace the HINT placeholder on the note message with the final hint
+                note_text = note_text.replace(f"<HINT_{indx}>", hint_text)
+            else:
+                note_text = note_text.replace(f"<HINT_{indx}>", "")
+        else:
+            raise NotImplementedError(
+                f"Hint type {hint['type']} is not implemented yet."
+            )
+
+    return note_text
 
 
 class GeneralConfig(dict):  # pragma: no cover

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -53,19 +53,15 @@ until nothing is left.
 Specific documentation for classes and functions are given below:
 """
 # Python 2 and 3 version agnostic compatiability:
-from __future__ import print_function
-from __future__ import unicode_literals
-from __future__ import division
-from __future__ import absolute_import
-
-import pdb
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
 # Python Standard Library imports
 import collections
 import copy
 import logging
 import os
-import re
+import pdb
 import shutil
 import socket
 import subprocess
@@ -79,21 +75,20 @@ else:
 
 # Always import externals before any non standard library imports
 
+import coloredlogs
 # Third-Party Imports
 import numpy
-import coloredlogs
-import colorama
 import yaml
-
-# functions reading in dict from file
-from .yaml_to_dict import *
-from .provenance import *
-
-# Date class
-from esm_calendar import Date
 
 # Loader for package yamls
 import esm_tools
+# Date class
+from esm_calendar import Date
+from esm_tools import user_error, user_note
+
+from .provenance import *
+# functions reading in dict from file
+from .yaml_to_dict import *
 
 # Logger and related constants
 logger = logging.getLogger("root")
@@ -2787,130 +2782,6 @@ def find_key(d_search, k_search, exc_strings="", level="", paths2finds=[], sep="
             )
 
     return paths2finds
-
-
-def user_note(
-    note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``"], hints=[]
-):
-    """
-    Notify the user about something. In the future this should also write in the log.
-
-    Parameters
-    ----------
-    note_heading : str
-        Note type used for the heading.
-    text : str
-        Text clarifying the note.
-    """
-    reset_s = colorama.Style.RESET_ALL
-
-    # Convert a list of strings to a single string
-    if isinstance(note_text, list):
-        new_note_text = ""
-        for item in note_text:
-            new_note_text = f"{new_note_text}- {item}\n"
-        note_text = new_note_text
-
-    # Add hints to the note_text
-    note_text = user_note_hints(note_text, hints)
-
-    # Add color to the note_text
-    for dsymbol in dsymbols:
-        note_text = re.sub(
-            f"{dsymbol}([^{dsymbol}]*){dsymbol}", f"{color}\\1{reset_s}", str(note_text)
-        )
-    print(f"\n{color}{note_heading}\n{'-' * len(note_heading)}{reset_s}")
-    print(f"{note_text}\n")
-
-
-def user_error(error_type, error_text, exit_code=1, dsymbols=["``"], hints=[]):
-    """
-    User-friendly error using ``sys.exit()`` instead of an ``Exception``.
-
-    Parameters
-    ----------
-    error_type : str
-        Error type used for the error heading.
-    text : str
-        Text clarifying the error.
-    exit_code : int
-        The exit code to send back to the parent process (default to 1)
-    """
-    error_title = "ERROR: " + error_type
-    user_note(
-        error_title, error_text, color=colorama.Fore.RED, dsymbols=dsymbols, hints=hints
-    )
-    sys.exit(exit_code)
-
-
-def user_note_hints(note_text, hints):
-    """
-    Add hints to the note text. The hints are added to the note text by replacing
-    the placeholders "@HINT_#@" with the actual hints from the hints list.
-
-    Parameters
-    ----------
-    note_text : str
-        The note text with placeholders for the hints. The placeholders are in the
-        form "@HINT_#@", where # is the index of the hint in the hints list.
-    hints : list
-        A list of hints to be added to the note text. Each hint is a dictionary with
-        the following keys:
-        - type: The type of the hint (e.g., "prov" for provenance)
-        - text: The text of the hint. This text can contain a placeholder "@HINT@"
-          which will be replaced with the actual hint corresponding to its index.
-        - object: The object to which the hint applies
-
-    Returns
-    -------
-    note_text : str
-        The note text with the placeholders replaced with the hints.
-    """
-
-    # Find all hints matching r"@HINT_(\d+)@" in the note_text
-    pattern = r"@HINT_(\d+)@"
-    hint_indexes = [int(x) for x in list(set(re.findall(pattern, note_text)))]
-    hint_indexes.sort()
-
-    # Check whether all hint indexes are represented in the hints list
-    if hint_indexes != list(range(len(hints))):
-        raise ValueError(
-            "The hint indexes in the note_text do not match the hints list."
-        )
-
-    # Loop through the hints and replace the placeholders in the note_text
-    for indx, hint in enumerate(hints):
-        # Hint type provenance
-        if hint["type"] == "prov":
-            hint_text = hint["text"]
-            mapping_with_provenance = hint["object"]
-
-            # Get the provenance
-            provenance = None
-            if hasattr(mapping_with_provenance, "get_first_provenance"):
-                provenance = mapping_with_provenance.get_first_provenance()
-            else:
-                logging.debug("No provenance found for %s", mapping_with_provenance)
-            # If the provenance is found, replace the placeholder with the provenance,
-            # otherwise remove the placeholder (provenance might not always exist)
-            if provenance:
-                prov_string = (
-                    f"``{provenance['yaml_file']}``,"
-                    f"line:``{provenance['line']}``,"
-                    f"col:``{provenance['col']}``"
-                )
-                # Replace the HINT placeholder of the hint with the provenance string
-                hint_text = hint["text"].replace("@HINT@", prov_string)
-                # Replace the HINT placeholder on the note message with the final hint
-                note_text = note_text.replace(f"@HINT_{indx}@", hint_text)
-            else:
-                note_text = note_text.replace(f"@HINT_{indx}@", "")
-        else:
-            raise NotImplementedError(
-                f"Hint type {hint['type']} is not implemented yet."
-            )
-
-    return note_text
 
 
 class GeneralConfig(dict):  # pragma: no cover

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -2860,6 +2860,11 @@ def user_note_hints(note_text, hints):
         - text: The text of the hint. This text can contain a placeholder "<HINT>"
           which will be replaced with the actual hint corresponding to its index.
         - object: The object to which the hint applies
+
+    Returns
+    -------
+    note_text : str
+        The note text with the placeholders replaced with the hints.
     """
 
     # Find all hints matching r"<HINT_(\d+)>" in the note_text

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -2846,18 +2846,18 @@ def user_error(error_type, error_text, exit_code=1, dsymbols=["``"], hints=[]):
 def user_note_hints(note_text, hints):
     """
     Add hints to the note text. The hints are added to the note text by replacing
-    the placeholders "<HINT_#>" with the actual hints from the hints list.
+    the placeholders "@HINT_#@" with the actual hints from the hints list.
 
     Parameters
     ----------
     note_text : str
         The note text with placeholders for the hints. The placeholders are in the
-        form "<HINT_#>", where # is the index of the hint in the hints list.
+        form "@HINT_#@", where # is the index of the hint in the hints list.
     hints : list
         A list of hints to be added to the note text. Each hint is a dictionary with
         the following keys:
         - type: The type of the hint (e.g., "prov" for provenance)
-        - text: The text of the hint. This text can contain a placeholder "<HINT>"
+        - text: The text of the hint. This text can contain a placeholder "@HINT@"
           which will be replaced with the actual hint corresponding to its index.
         - object: The object to which the hint applies
 
@@ -2867,8 +2867,8 @@ def user_note_hints(note_text, hints):
         The note text with the placeholders replaced with the hints.
     """
 
-    # Find all hints matching r"<HINT_(\d+)>" in the note_text
-    pattern = r"<HINT_(\d+)>"
+    # Find all hints matching r"@HINT_(\d+)@" in the note_text
+    pattern = r"@HINT_(\d+)@"
     hint_indexes = [int(x) for x in list(set(re.findall(pattern, note_text)))]
     hint_indexes.sort()
 
@@ -2900,11 +2900,11 @@ def user_note_hints(note_text, hints):
                     f"col:``{provenance['col']}``"
                 )
                 # Replace the HINT placeholder of the hint with the provenance string
-                hint_text = hint["text"].replace("<HINT>", prov_string)
+                hint_text = hint["text"].replace("@HINT@", prov_string)
                 # Replace the HINT placeholder on the note message with the final hint
-                note_text = note_text.replace(f"<HINT_{indx}>", hint_text)
+                note_text = note_text.replace(f"@HINT_{indx}@", hint_text)
             else:
-                note_text = note_text.replace(f"<HINT_{indx}>", "")
+                note_text = note_text.replace(f"@HINT_{indx}@", "")
         else:
             raise NotImplementedError(
                 f"Hint type {hint['type']} is not implemented yet."

--- a/src/esm_parser/provenance.py
+++ b/src/esm_parser/provenance.py
@@ -523,6 +523,23 @@ class DictWithProvenance(dict):
 
         return provenance_dict
 
+    def get_first_provenance(self):
+        """
+        Recursively loops through the dictionary keys and returns the first provenance
+        found in the nested values.
+
+        Returns
+        -------
+        first_provenance : esm_parser.provenance.Provenance
+            The first provenance found in the nested values
+        """
+        first_provenance = None
+        for key, val in self.items():
+            if isinstance(val, PROVENANCE_MAPPINGS):
+                return val.get_first_provenance()
+            elif hasattr(val, "provenance"):
+                return val.provenance[-1]
+
     def __setitem__(self, key, val):
         """
         Any time an item in a DictWithProvenance is set, extend the old provenance of
@@ -772,6 +789,23 @@ class ListWithProvenance(list):
                 provenance_list.append(None)
 
         return provenance_list
+
+    def get_first_provenance(self):
+        """
+        Recursively loops through the list elements and returns the first provenance
+        found in the nested values.
+
+        Returns
+        -------
+        first_provenance : esm_parser.provenance.Provenance
+            The first provenance found in the nested values
+        """
+        first_provenance = None
+        for elem in self:
+            if isinstance(elem, PROVENANCE_MAPPINGS):
+                return elem.get_first_provenance()
+            elif hasattr(elem, "provenance"):
+                return elem.provenance[-1]
 
     def __setitem__(self, indx, val):
         """

--- a/src/esm_parser/provenance.py
+++ b/src/esm_parser/provenance.py
@@ -523,7 +523,7 @@ class DictWithProvenance(dict):
 
         return provenance_dict
 
-    def get_first_provenance(self):
+    def extract_first_nested_values_provenance(self):
         """
         Recursively loops through the dictionary keys and returns the first provenance
         found in the nested values.
@@ -536,7 +536,7 @@ class DictWithProvenance(dict):
         first_provenance = None
         for key, val in self.items():
             if isinstance(val, PROVENANCE_MAPPINGS):
-                return val.get_first_provenance()
+                return val.extract_first_nested_values_provenance()
             elif hasattr(val, "provenance"):
                 return val.provenance[-1]
 
@@ -790,7 +790,7 @@ class ListWithProvenance(list):
 
         return provenance_list
 
-    def get_first_provenance(self):
+    def extract_first_nested_values_provenance(self):
         """
         Recursively loops through the list elements and returns the first provenance
         found in the nested values.
@@ -803,7 +803,7 @@ class ListWithProvenance(list):
         first_provenance = None
         for elem in self:
             if isinstance(elem, PROVENANCE_MAPPINGS):
-                return elem.get_first_provenance()
+                return elem.extract_first_nested_values_provenance()
             elif hasattr(elem, "provenance"):
                 return elem.provenance[-1]
 

--- a/src/esm_parser/yaml_to_dict.py
+++ b/src/esm_parser/yaml_to_dict.py
@@ -11,6 +11,7 @@ from ruamel.yaml.nodes import ScalarNode
 
 import esm_parser
 import esm_tools
+from esm_tools import user_error
 
 from .provenance import *
 
@@ -135,7 +136,7 @@ def create_env_loader(tag="!ENV", loader=yaml.SafeLoader):
                 for env_var in envvar_matches:
                     # first check if the variable exists in the shell environment
                     if not os.getenv(env_var):
-                        esm_parser.user_error(
+                        user_error(
                             f"{env_var} is not defined",
                             f"{env_var} is not an environment variable. Exiting",
                         )
@@ -227,10 +228,10 @@ def yaml_file_to_dict(filepath):
         except yaml.scanner.ScannerError as yaml_error:
             logger.debug(f"Your file {filepath + extension} has syntax issues!")
             error = EsmConfigFileError(filepath + extension, yaml_error)
-            esm_parser.user_error("Yaml syntax", f"{error}")
+            user_error("Yaml syntax", f"{error}")
         except Exception as error:
             logger.exception(error)
-            esm_parser.user_error(
+            user_error(
                 "Yaml syntax",
                 f"Syntax error in ``{filepath}``\n\n``Details:\n``{error}",
             )
@@ -331,7 +332,7 @@ def check_changes_duplicates(yamldict_all, fpath):
             # If more than one ``_changes`` without ``choose_`` return error
             if len(changes_no_choose) > 1:
                 changes_no_choose = [x.replace(",", ".") for x in changes_no_choose]
-                esm_parser.user_error(
+                user_error(
                     "YAML syntax",
                     "More than one ``_changes`` out of a ``choose_`` in "
                     + fpath
@@ -347,7 +348,7 @@ def check_changes_duplicates(yamldict_all, fpath):
                 changes_group.remove(changes_no_choose[0])
                 if len(changes_group) > 0:
                     changes_group = [x.replace(",", ".") for x in changes_group]
-                    esm_parser.user_error(
+                    user_error(
                         "YAML syntax",
                         "The general ``"
                         + changes_no_choose[0]
@@ -394,7 +395,7 @@ def check_changes_duplicates(yamldict_all, fpath):
                                 ","
                             )[0]
                         if case == sub_case:
-                            esm_parser.user_error(
+                            user_error(
                                 "YAML syntax",
                                 "The following ``_changes`` can be accessed "
                                 + "simultaneously in "
@@ -413,7 +414,7 @@ def check_changes_duplicates(yamldict_all, fpath):
                     else:
                         # If these ``choose_`` are different they can be accessed
                         # simultaneously, then it returns an error
-                        esm_parser.user_error(
+                        user_error(
                             "YAML syntax",
                             "The following ``_changes`` can be accessed "
                             + "simultaneously in "
@@ -452,7 +453,7 @@ def check_changes_duplicates(yamldict_all, fpath):
                 add_group.remove(add_no_choose[0])
                 if len(add_group) > 0:
                     add_group = [x.replace(",", ".") for x in add_group]
-                    esm_parser.user_error(
+                    user_error(
                         "YAML syntax",
                         "The general ``"
                         + add_no_choose[0]
@@ -469,7 +470,7 @@ def check_changes_duplicates(yamldict_all, fpath):
 def check_for_empty_components(yaml_load, fpath):
     for key, value in yaml_load.items():
         if not value:
-            esm_parser.user_error(
+            user_error(
                 "YAML syntax",
                 f"The component ``{key}`` is empty in the file ``{fpath}``. ESM-Tools does"
                 + " not support empty components, either add some variables to the "
@@ -540,7 +541,7 @@ def check_duplicates(src):
             value = loader.construct_object(value_node, deep=deep)
 
             if key in mapping:
-                esm_parser.user_error(
+                user_error(
                     "Duplicated variables",
                     "Key ``{0}`` is duplicated {1}\n\n".format(
                         key, str(key_node.start_mark).replace("  ", "").split(",")[0]
@@ -623,7 +624,7 @@ class EnvironmentConstructor(RoundTripConstructor):
                         self.env_variables.append((env_var, rval))
                         return rval
                     else:
-                        esm_parser.user_error(
+                        user_error(
                             f"{env_var} is not defined",
                             f"{env_var} is not an environment variable. Exiting",
                         )

--- a/src/esm_runscripts/batch_system.py
+++ b/src/esm_runscripts/batch_system.py
@@ -4,9 +4,11 @@ import stat
 import sys
 import textwrap
 
-import esm_environment
-from esm_parser import find_variable, user_error, user_note
 from loguru import logger
+
+import esm_environment
+from esm_parser import find_variable
+from esm_tools import user_error, user_note
 
 from . import dataprocess, helpers, prepare
 from .pbs import Pbs
@@ -814,7 +816,7 @@ class batch_system:
             cpus_per_proc = config[model].get("cpus_per_proc", omp_num_threads)
             # Check for CPUs and OpenMP threads
             if omp_num_threads > cpus_per_proc:
-                esm_parser.user_error(
+                user_error(
                     "OpenMP configuration",
                     (
                         "The number of OpenMP threads cannot be larger than the number"
@@ -826,7 +828,7 @@ class batch_system:
         elif "nproca" in config[model] and "nprocb" in config[model]:
             # ``nproca``/``nprocb`` not compatible with ``omp_num_threads``
             if omp_num_threads > 1:
-                esm_parser.user_note(
+                user_note(
                     "nproc",
                     "``nproca``/``nprocb`` not compatible with ``omp_num_threads``",
                 )

--- a/src/esm_runscripts/cli.py
+++ b/src/esm_runscripts/cli.py
@@ -15,7 +15,7 @@ import sys
 from loguru import logger
 
 from esm_motd import check_all_esm_packages
-from esm_parser import user_error
+from esm_tools import user_error
 
 from .helpers import SmartSink
 from .sim_objects import *

--- a/src/esm_runscripts/compute.py
+++ b/src/esm_runscripts/compute.py
@@ -9,12 +9,13 @@ import f90nml
 import questionary
 import yaml
 from colorama import Back, Fore, Style, init
+from loguru import logger
 
 import esm_calendar
 import esm_parser
 import esm_runscripts
 import esm_tools
-from loguru import logger
+from esm_tools import user_error, user_note
 
 from .batch_system import batch_system
 from .filelists import copy_files, log_used_files
@@ -444,7 +445,7 @@ def update_runscript(fromdir, scriptsdir, tfile, gconfig, file_type):
             # If the --update flag is used, notify that the target script will
             # be updated and do update it
             if gconfig["update"]:
-                esm_parser.user_note(
+                user_note(
                     f"Original {file_type} different from target",
                     differences + "\n" + f"{scriptsdir + '/' + tfile} will be updated!",
                 )
@@ -454,7 +455,7 @@ def update_runscript(fromdir, scriptsdir, tfile, gconfig, file_type):
             # If the --update flag is not called, exit with an error showing the
             # user how to proceed
             else:
-                esm_parser.user_note(
+                user_note(
                     f"Original {file_type} different from target",
                     differences
                     + "\n"
@@ -546,7 +547,7 @@ def copy_tools_to_thisrun(config):
         # exit right away to prevent further recursion. There might still be
         # running instances of esmr_runscripts and something like
         # `killall esm_runscripts` might be required
-        esm_parser.user_error(error_type, error_text)
+        user_error(error_type, error_text)
 
     # If ``fromdir`` and ``scriptsdir`` are the same, this is already a computing
     # simulation which means we want to use the script in the experiment folder,

--- a/src/esm_runscripts/config_initialization.py
+++ b/src/esm_runscripts/config_initialization.py
@@ -4,6 +4,7 @@ import sys
 
 import esm_parser
 import esm_tools
+from esm_tools import user_error
 
 from . import chunky_parts
 
@@ -161,7 +162,7 @@ def get_user_config_from_command_line(command_line_config):
     except SystemExit as sysexit:
         sys.exit(sysexit)
     except:
-        esm_parser.user_error(
+        user_error(
             "Syntax error",
             f"An error occurred while reading the config file "
             f"``{command_line_config['runscript_abspath']}`` from the command line.",
@@ -284,7 +285,7 @@ def check_account(config):
     # Check if the 'account' variable is needed and missing
     if config["computer"].get("accounting", False):
         if "account" not in config["general"]:
-            esm_parser.user_error(
+            user_error(
                 "Missing account info",
                 f"You cannot run simulations in '{config['computer']['name']}' "
                 "without providing an 'account' variable in the 'general' section, whose "

--- a/src/esm_runscripts/coupler.py
+++ b/src/esm_runscripts/coupler.py
@@ -159,14 +159,29 @@ class coupler_class:
                             sys.exit(0)
 
                     direction_info = None
-                    if "coupling_directions" in full_config[self.name]:
-                        if (
-                            right_grid + "->" + left_grid
-                            in full_config[self.name]["coupling_directions"]
-                        ):
-                            direction_info = full_config[self.name][
-                                "coupling_directions"
-                            ][right_grid + "->" + left_grid]
+                    coupling_directions = full_config[self.name].get(
+                        "coupling_directions"
+                    )
+                    if coupling_directions:
+                        direction = f"{right_grid}->{left_grid}"
+                        direction_info = coupling_directions.get(direction)
+                        if not direction_info:
+                            first_provenance = (
+                                coupling_directions.get_first_provenance()
+                            )
+                            location_hint = ""
+                            if first_provenance:
+                                yaml_file = first_provenance.get("yaml_file")
+                                line = first_provenance.get("line")
+                                location_hint = (
+                                    f" (for example near ``{yaml_file},line:{line}``)"
+                                )
+                            esm_parser.user_error(
+                                "Missing coupling direction",
+                                f"The ``{direction}`` does not exist in "
+                                f"``{self.name}.coupling_directions``. You can solve "
+                                f"this by defining it there{location_hint}."
+                            )
                     transf_info = None
                     if "coupling_methods" in full_config[self.name]:
                         if interpolation in full_config[self.name]["coupling_methods"]:

--- a/src/esm_runscripts/coupler.py
+++ b/src/esm_runscripts/coupler.py
@@ -1,7 +1,8 @@
 import sys
 
-import esm_parser
 from loguru import logger
+
+from esm_tools import user_error
 
 known_couplers = ["oasis3mct", "yac"]
 
@@ -166,7 +167,7 @@ class coupler_class:
                         direction = f"{right_grid}->{left_grid}"
                         direction_info = coupling_directions.get(direction)
                         if not direction_info:
-                            esm_parser.user_error(
+                            user_error(
                                 "Missing coupling direction",
                                 f"The ``{direction}`` does not exist in "
                                 f"``{self.name}.coupling_directions``. You can solve "
@@ -186,7 +187,7 @@ class coupler_class:
                                 interpolation
                             ]
                         else:
-                            esm_parser.user_error(
+                            user_error(
                                 "Missing coupling method",
                                 f"The coupling method ``{interpolation}`` defined in "
                                 f"the ``{self.name}.coupling_target_fields`` is not "

--- a/src/esm_runscripts/coupler.py
+++ b/src/esm_runscripts/coupler.py
@@ -166,21 +166,18 @@ class coupler_class:
                         direction = f"{right_grid}->{left_grid}"
                         direction_info = coupling_directions.get(direction)
                         if not direction_info:
-                            first_provenance = (
-                                coupling_directions.get_first_provenance()
-                            )
-                            location_hint = ""
-                            if first_provenance:
-                                yaml_file = first_provenance.get("yaml_file")
-                                line = first_provenance.get("line")
-                                location_hint = (
-                                    f" (for example near ``{yaml_file},line:{line}``)"
-                                )
                             esm_parser.user_error(
                                 "Missing coupling direction",
                                 f"The ``{direction}`` does not exist in "
                                 f"``{self.name}.coupling_directions``. You can solve "
-                                f"this by defining it there{location_hint}."
+                                f"this by defining it there<HINT_0>.",
+                                hints=[
+                                    {
+                                        "type": "prov",
+                                        "object": coupling_directions,
+                                        "text": " (for example near <HINT>)",
+                                    },
+                                ],
                             )
                     transf_info = None
                     if "coupling_methods" in full_config[self.name]:

--- a/src/esm_runscripts/coupler.py
+++ b/src/esm_runscripts/coupler.py
@@ -170,12 +170,12 @@ class coupler_class:
                                 "Missing coupling direction",
                                 f"The ``{direction}`` does not exist in "
                                 f"``{self.name}.coupling_directions``. You can solve "
-                                f"this by defining it there<HINT_0>.",
+                                f"this by defining it there@HINT_0@.",
                                 hints=[
                                     {
                                         "type": "prov",
                                         "object": coupling_directions,
-                                        "text": " (for example near <HINT>)",
+                                        "text": " (for example near @HINT@)",
                                     },
                                 ],
                             )

--- a/src/esm_runscripts/filelists.py
+++ b/src/esm_runscripts/filelists.py
@@ -11,12 +11,12 @@ import sys
 
 import f90nml
 import yaml
-
-import esm_parser
 from loguru import logger
 
-from . import helpers
-from . import jinja
+import esm_parser
+from esm_tools import user_error
+
+from . import helpers, jinja
 
 
 def rename_sources_to_targets(config):
@@ -146,7 +146,7 @@ def complete_targets(config):
                                 f"The input file variable {category} of {filetype}_sources can not be fully resolved:\n\n"
                                 + yaml.dump(file_source, indent=4)
                             )
-                            esm_parser.user_error(error_type, error_text)
+                            user_error(error_type, error_text)
                         else:
                             config[model][filetype + "_targets"][
                                 category
@@ -306,7 +306,7 @@ def target_subfolders(config):
                     # * only in targets if denotes subfolder
                     # TODO: change with user_error()
                     if not descr in config[model][filetype + "_sources"]:
-                        esm_parser.user_error(
+                        user_error(
                             "Filelists",
                             f"No source found for target ``{name}`` in model "
                             f"``{model}``\n",
@@ -390,7 +390,7 @@ def get_target_name_from_wildcard(config, model, filename, filetype, descr):
 
     Raises
     ------
-    user_error : esm_parser.user_error
+    user_error : user_error
         If source and target wildcard patterns do not match (different number of ``*``
         in the patterns), raises a user friendly error
     """
@@ -407,7 +407,7 @@ def get_target_name_from_wildcard(config, model, filename, filetype, descr):
     wild_card_target = target_filename.split("*")
     # Check for syntax mistakes
     if len(wild_card_target) != len(wild_card_source):
-        esm_parser.user_error(
+        user_error(
             "Wild card",
             (
                 "The wild card pattern of the source "
@@ -502,7 +502,7 @@ def find_valid_year(config, year):
 
     error_type = "Year Error"
     error_text = f"Sorry, no entry found for year {year} in config {config}"
-    esm_parser.user_error(error_type, error_text)
+    user_error(error_type, error_text)
 
 
 def replace_year_placeholder(config):
@@ -1271,7 +1271,7 @@ def avoid_overwriting(config, source, target):
 
         date_stamped_target = f"{target}_{config['general']['run_datestamp']}"
         if os.path.isfile(date_stamped_target):
-            esm_parser.user_error(
+            user_error(
                 "File movement conflict",
                 f"The file ``{date_stamped_target}`` already exists. Skipping movement:\n"
                 f"{source} -> {date_stamped_target}",
@@ -1287,7 +1287,7 @@ def avoid_overwriting(config, source, target):
         target = date_stamped_target
 
     elif os.path.isdir(target):
-        esm_parser.user_error(
+        user_error(
             "File operation not supported",
             f"The target ``{target}`` is a folder, and this should not be happening "
             "here. Please, open an issue in www.github.com/esm-tools/esm_tools",
@@ -1531,7 +1531,7 @@ def complete_all_file_movements(config):
                     if file_in_fm in mconfig.get(
                         "restart_in_files", {}
                     ) or file_in_fm in mconfig.get("restart_out_files", {}):
-                        esm_parser.user_error(
+                        user_error(
                             "Movement direction not specified",
                             f"'{model}.file_movements.{file_in_fm}' refers to a "
                             + "restart file which can be moved/copied/link in two "

--- a/src/esm_runscripts/helpers.py
+++ b/src/esm_runscripts/helpers.py
@@ -8,8 +8,8 @@ from loguru import logger
 import esm_parser
 import esm_plugin_manager
 import esm_tools
-from loguru import logger
 from esm_profile import print_profile_summary
+from esm_tools import user_error
 
 
 def vprint(message, config):
@@ -206,7 +206,7 @@ def update_reusable_filetypes(config, reusable_filetypes=None):
     for update_filetype in update_filetypes:
         # Check if that file type exists/makes sense. Otherwise, through an error
         if update_filetype not in potentially_reusable_filetypes:
-            esm_parser.user_error(
+            user_error(
                 "update-filetypes",
                 f"``{update_filetype}`` specified by you in ``--update-filetypes`` is "
                 + "not a ESM-Tools file type. Please, select one (or more) of the "

--- a/src/esm_runscripts/jinja.py
+++ b/src/esm_runscripts/jinja.py
@@ -3,7 +3,7 @@ import os
 from jinja2 import StrictUndefined, Template, UndefinedError
 from loguru import logger
 
-import esm_parser
+from esm_tools import user_error
 
 
 def render_template(config, source, target):
@@ -40,7 +40,7 @@ def render_template(config, source, target):
         content = template.render(config)
     except UndefinedError as e:
         missing_variable = e.message.split("'")[3]
-        esm_parser.user_error(
+        user_error(
             "Jinja",
             f"Error rendering template from ``{source}`` to ``{target}``. Variable "
             f"``{missing_variable}`` is not defined in any configuration file.",

--- a/src/esm_runscripts/namelists.py
+++ b/src/esm_runscripts/namelists.py
@@ -15,7 +15,7 @@ import warnings
 import f90nml
 from loguru import logger
 
-from esm_parser import user_error
+from esm_tools import user_error
 
 
 class Namelist:

--- a/src/esm_runscripts/oasis.py
+++ b/src/esm_runscripts/oasis.py
@@ -4,10 +4,9 @@ import subprocess
 import sys
 
 import questionary
-
-from esm_parser import user_error
 from loguru import logger
 
+from esm_tools import user_error
 
 
 class oasis:

--- a/src/esm_runscripts/prepare.py
+++ b/src/esm_runscripts/prepare.py
@@ -5,12 +5,13 @@ import sys
 
 import questionary
 import yaml
+from loguru import logger
 
 import esm_parser
 import esm_utilities
 from esm_calendar import Calendar, Date
 from esm_plugin_manager import install_missing_plugins
-from loguru import logger
+from esm_tools import user_error, user_note
 
 from . import batch_system, helpers
 
@@ -222,7 +223,7 @@ def model_env_into_computer(config):
                     model0 = env_vars[key][1]
                     while True:
                         # Warn the user about the overwriting of the variable
-                        esm_parser.user_note("Environment conflict", f"In '{model0}':")
+                        user_note("Environment conflict", f"In '{model0}':")
                         esm_parser.pprint_config({key: env_vars[key][0]})
                         logging.info("\nIn '" + model + "':")
                         esm_parser.pprint_config({key: value})
@@ -248,7 +249,7 @@ def model_env_into_computer(config):
                         # If the user selects ``n`` raise a user error with recommendations
                         elif user_answer == "n":
                             config[model]["env_overwrite"] = False
-                            esm_parser.user_error(
+                            user_error(
                                 "Environment conflict",
                                 "You were not happy with the environment variable "
                                 + f"'{key}' in '{model0}' being overwritten by the same "
@@ -719,7 +720,7 @@ def add_vcs_info(config):
         vcs_versions["esm_tools"] = helpers.get_all_git_info(f"{esm_tools_repo}/../")
     else:
         # FIXME(PG): This should absolutely never happen. The error message could use a better wording though...
-        esm_parser.user_error(
+        user_error(
             "esm_tools doesn't know where it's own install location is. Something is very seriously wrong."
         )
     with open(exp_vcs_info_file, "w") as f:
@@ -775,7 +776,7 @@ def check_vcs_info_against_last_run(config):
         not config["general"].get("allow_vcs_differences", False)
         and current_vcs_info != last_vcs_info
     ):
-        esm_parser.user_error(
+        user_error(
             "VCS Differences",
             """
             You have differences in either the model code or in the esm-tools between two runs!
@@ -871,7 +872,7 @@ def check_config_for_warnings_errors(config):
     """
 
     # Initialize the trigger variables (i.e. ``error`` and ``warning``))
-    triggers = {"error": {"note_function": esm_parser.user_error}}
+    triggers = {"error": {"note_function": user_error}}
 
     # Find conditions to warn (avoid warning more than once)
     last_jobtype = config["general"].get("last_jobtype", "")
@@ -880,7 +881,7 @@ def check_config_for_warnings_errors(config):
 
     # Only warn if it is an interactive session or while submitted
     if not isresubmitted or isinteractive:
-        triggers["warning"] = {"note_function": esm_parser.user_note}
+        triggers["warning"] = {"note_function": user_note}
 
     # Loop through the triggers
     for trigger, trigger_info in triggers.items():

--- a/src/esm_runscripts/prepexp.py
+++ b/src/esm_runscripts/prepexp.py
@@ -6,10 +6,11 @@ import sys
 
 import questionary
 from colorama import Fore
+from loguru import logger
 
 import esm_parser
 import esm_tools
-from loguru import logger
+from esm_tools import user_error, user_note
 
 from . import filelists
 from .helpers import end_it_all, evaluate, write_to_log
@@ -121,7 +122,7 @@ def copy_tools_to_thisrun(config):
         # exit right away to prevent further recursion. There might still be
         # running instances of esmr_runscripts and something like
         # `killall esm_runscripts` might be required
-        esm_parser.user_error(error_type, error_text)
+        user_error(error_type, error_text)
 
     # If ``fromdir`` and ``scriptsdir`` are different, we are not in the experiment.
     # In this case, update the runscript if necessary.
@@ -194,7 +195,7 @@ def _call_esm_runscripts_internally(config, command, exedir):
     else:
         error_type = "runtime error in function ``_call_esm_runscripts_internally``"
         error_text = f"{exedir} does not exists. Aborting."
-        esm_parser.user_error(error_type, error_text)
+        user_error(error_type, error_text)
 
     logger.debug(command)
 
@@ -447,7 +448,7 @@ def update_runscript(fromdir, scriptsdir, tfile, gconfig, file_type):
             # If the --update flag is used, notify that the target script will
             # be updated and do update it
             if gconfig["update"]:
-                esm_parser.user_note(
+                user_note(
                     f"Original {file_type} different from target",
                     f"{differences}\n{scriptsdir}/{tfile} will be updated!",
                 )
@@ -457,7 +458,7 @@ def update_runscript(fromdir, scriptsdir, tfile, gconfig, file_type):
             # If the --update flag is not called, exit with an error showing the
             # user how to proceed
             else:
-                esm_parser.user_note(
+                user_note(
                     f"Original {file_type} different from target",
                     differences
                     + "\n"

--- a/src/esm_runscripts/prev_run.py
+++ b/src/esm_runscripts/prev_run.py
@@ -3,10 +3,11 @@ import sys
 
 import questionary
 import yaml
+from loguru import logger
 
 import esm_parser
 from esm_calendar import Calendar, Date
-from loguru import logger
+from esm_tools import user_error, user_note
 
 
 class PrevRunInfo(dict):
@@ -241,7 +242,7 @@ class PrevRunInfo(dict):
                 )
                 # Dates don't match
                 if calc_prev_date_stamp != prev_date_stamp and self.warn:
-                    esm_parser.user_note(
+                    user_note(
                         f"End date of the previous configuration file for '{component}'"
                         + " not coinciding:",
                         (
@@ -330,7 +331,7 @@ class PrevRunInfo(dict):
                     "prev_run_config_file"
                 )
                 if not user_prev_run_config_full_path:
-                    esm_parser.user_error(
+                    user_error(
                         "'prev_run_config_file' not defined",
                         "You are trying to run a branchoff experiment that uses the "
                         + f"'prev_run' functionality for '{component}' without "
@@ -368,7 +369,7 @@ class PrevRunInfo(dict):
 
         # Check for errors
         if not os.path.isdir(config_dir):
-            esm_parser.user_error(
+            user_error(
                 "Config folder not existing",
                 (
                     f"The config folder {config_dir} does not exist. "
@@ -430,7 +431,7 @@ class PrevRunInfo(dict):
                     )
                 else:
                     # Error
-                    esm_parser.user_error(
+                    user_error(
                         "Too many possible config files",
                         "There is more than one config file with the same final date "
                         + "as the one required for the continuation of this experiment."
@@ -450,7 +451,7 @@ class PrevRunInfo(dict):
             prev_run_config_file = user_prev_run_config_file
             prev_run_config_path = f"{config_dir}/{prev_run_config_file}"
             if not os.path.isfile(prev_run_config_path):
-                esm_parser.user_error(
+                user_error(
                     "'prev_run_config_file' incorrectly defined",
                     f"The file defined in the '{component}.prev_run_config_path' "
                     + f"({prev_run_config_path}) does not exist.",

--- a/src/esm_runscripts/slurm.py
+++ b/src/esm_runscripts/slurm.py
@@ -7,8 +7,10 @@ import shutil
 import subprocess
 import sys
 
-import esm_parser
 from loguru import logger
+
+import esm_parser
+from esm_tools import user_note
 
 
 class Slurm:
@@ -234,7 +236,7 @@ class Slurm:
                 elif not config[model].get("execution_command") and not config[
                     model
                 ].get("executable"):
-                    esm_parser.user_note(
+                    user_note(
                         "Execution command",
                         f"Execution command for ``{model}`` not found. This is okay "
                         "if this component has no binary to be called, but if it does"

--- a/src/esm_tests/repos.py
+++ b/src/esm_tests/repos.py
@@ -1,10 +1,11 @@
 import os
-import questionary
 
+import questionary
 from loguru import logger
 
+from esm_tools import user_error
+
 from .test_utilities import sh
-from esm_parser import user_error
 
 
 def update_resources_submodule(info, verbose=True):

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -38,6 +38,8 @@ import pkg_resources
 import yaml
 from loguru import logger
 
+from .error_handling import *
+
 # Setup Loguru for the following cases:
 # A) If user sets
 if os.environ.get("DEBUG_ESM_TOOLS"):

--- a/src/esm_tools/error_handling.py
+++ b/src/esm_tools/error_handling.py
@@ -102,8 +102,8 @@ def user_note_hints(note_text, hints):
 
             # Get the provenance
             provenance = None
-            if hasattr(mapping_with_provenance, "get_first_provenance"):
-                provenance = mapping_with_provenance.get_first_provenance()
+            if hasattr(mapping_with_provenance, "extract_first_nested_values_provenance"):
+                provenance = mapping_with_provenance.extract_first_nested_values_provenance()
             else:
                 logging.debug("No provenance found for %s", mapping_with_provenance)
             # If the provenance is found, replace the placeholder with the provenance,

--- a/src/esm_tools/error_handling.py
+++ b/src/esm_tools/error_handling.py
@@ -1,0 +1,128 @@
+import re
+import sys
+
+import colorama
+
+
+def user_note(
+    note_heading, note_text, color=colorama.Fore.YELLOW, dsymbols=["``"], hints=[]
+):
+    """
+    Notify the user about something. In the future this should also write in the log.
+
+    Parameters
+    ----------
+    note_heading : str
+        Note type used for the heading.
+    text : str
+        Text clarifying the note.
+    """
+    reset_s = colorama.Style.RESET_ALL
+
+    # Convert a list of strings to a single string
+    if isinstance(note_text, list):
+        new_note_text = ""
+        for item in note_text:
+            new_note_text = f"{new_note_text}- {item}\n"
+        note_text = new_note_text
+
+    # Add hints to the note_text
+    note_text = user_note_hints(note_text, hints)
+
+    # Add color to the note_text
+    for dsymbol in dsymbols:
+        note_text = re.sub(
+            f"{dsymbol}([^{dsymbol}]*){dsymbol}", f"{color}\\1{reset_s}", str(note_text)
+        )
+    print(f"\n{color}{note_heading}\n{'-' * len(note_heading)}{reset_s}")
+    print(f"{note_text}\n")
+
+
+def user_error(error_type, error_text, exit_code=1, dsymbols=["``"], hints=[]):
+    """
+    User-friendly error using ``sys.exit()`` instead of an ``Exception``.
+
+    Parameters
+    ----------
+    error_type : str
+        Error type used for the error heading.
+    text : str
+        Text clarifying the error.
+    exit_code : int
+        The exit code to send back to the parent process (default to 1)
+    """
+    error_title = "ERROR: " + error_type
+    user_note(
+        error_title, error_text, color=colorama.Fore.RED, dsymbols=dsymbols, hints=hints
+    )
+    sys.exit(exit_code)
+
+
+def user_note_hints(note_text, hints):
+    """
+    Add hints to the note text. The hints are added to the note text by replacing
+    the placeholders "@HINT_#@" with the actual hints from the hints list.
+
+    Parameters
+    ----------
+    note_text : str
+        The note text with placeholders for the hints. The placeholders are in the
+        form "@HINT_#@", where # is the index of the hint in the hints list.
+    hints : list
+        A list of hints to be added to the note text. Each hint is a dictionary with
+        the following keys:
+        - type: The type of the hint (e.g., "prov" for provenance)
+        - text: The text of the hint. This text can contain a placeholder "@HINT@"
+          which will be replaced with the actual hint corresponding to its index.
+        - object: The object to which the hint applies
+
+    Returns
+    -------
+    note_text : str
+        The note text with the placeholders replaced with the hints.
+    """
+
+    # Find all hints matching r"@HINT_(\d+)@" in the note_text
+    pattern = r"@HINT_(\d+)@"
+    hint_indexes = [int(x) for x in list(set(re.findall(pattern, note_text)))]
+    hint_indexes.sort()
+
+    # Check whether all hint indexes are represented in the hints list
+    if hint_indexes != list(range(len(hints))):
+        raise ValueError(
+            "The hint indexes in the note_text do not match the hints list."
+        )
+
+    # Loop through the hints and replace the placeholders in the note_text
+    for indx, hint in enumerate(hints):
+        # Hint type provenance
+        if hint["type"] == "prov":
+            hint_text = hint["text"]
+            mapping_with_provenance = hint["object"]
+
+            # Get the provenance
+            provenance = None
+            if hasattr(mapping_with_provenance, "get_first_provenance"):
+                provenance = mapping_with_provenance.get_first_provenance()
+            else:
+                logging.debug("No provenance found for %s", mapping_with_provenance)
+            # If the provenance is found, replace the placeholder with the provenance,
+            # otherwise remove the placeholder (provenance might not always exist)
+            if provenance:
+                prov_string = (
+                    f"``{provenance['yaml_file']}``,"
+                    f"line:``{provenance['line']}``,"
+                    f"col:``{provenance['col']}``"
+                )
+                # Replace the HINT placeholder of the hint with the provenance string
+                hint_text = hint["text"].replace("@HINT@", prov_string)
+                # Replace the HINT placeholder on the note message with the final hint
+                note_text = note_text.replace(f"@HINT_{indx}@", hint_text)
+            else:
+                note_text = note_text.replace(f"@HINT_{indx}@", "")
+        else:
+            raise NotImplementedError(
+                f"Hint type {hint['type']} is not implemented yet."
+            )
+
+    return note_text


### PR DESCRIPTION
- Error handling for #1268
- adds `get_first_provenance` method to more easily use the first occurrence of provenance in a dictionary or list to report suggestions in the error messages
- adds hint functionality to `user_error` and `user_note`: if you add a list of hints as input to one of this methods, you can add `<HINT_#>` placeholders to your message for `user_note` and `user_error`. These place holders will be substituted using the hint's properties you define for each hint.

For #1268 it generates this user error now:
![Screenshot 2025-01-21 at 19 23 12](https://github.com/user-attachments/assets/74403d70-71c5-43d4-be2e-f3aff357fb89)

Closes #1268