### PR TITLE
feat/finished_config in esm_master

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.48.0
+current_version = 6.49.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.48.0",
+    version="6.49.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 
 from . import database

--- a/src/esm_master/esm_master.py
+++ b/src/esm_master/esm_master.py
@@ -20,6 +20,7 @@ from .compile_info import setup_and_model_infos
 
 from .task import Task
 
+from esm_parser import yaml_dump
 
 def main_flow(parsed_args, target):
 
@@ -91,15 +92,10 @@ def main_flow(parsed_args, target):
     user_task.validate()
     user_task.generate_task_script()
 
-    if parsed_args.get("check", False):
-        # deniz: if the environment variable ESM_MASTER_DEBUG is also set dump
-        # the contents of the current config to stdout for more investigation
-        if os.environ.get("ESM_MASTER_DEBUG", None):
-            print()
-            print("Contents of the complete_config:")
-            print("--------------------------------")
-            print(yaml.dump(complete_config, default_flow_style=False, indent=4))
+    # Print config
+    yaml_dump(complete_config, config_file_path=f"{complete_config['general']['model_dir']}/finished_config.yaml")
 
+    if parsed_args.get("check", False):
         print("esm_master: check mode is activated. Not executing the actions above")
         return 0
 

--- a/src/esm_master/esm_master.py
+++ b/src/esm_master/esm_master.py
@@ -93,7 +93,10 @@ def main_flow(parsed_args, target):
     user_task.generate_task_script()
 
     # Print config
-    yaml_dump(complete_config, config_file_path=f"{complete_config['general']['model_dir']}/finished_config.yaml")
+    model_nested_dirs = complete_config["general"]["model_dir"].split("/")
+    model_name = model_nested_dirs.pop(-1)
+    finished_config_path = f'{"/".join(model_nested_dirs)}/{model_name}-finished_config.yaml'
+    yaml_dump(complete_config, config_file_path=finished_config_path)
 
     if parsed_args.get("check", False):
         print("esm_master: check mode is activated. Not executing the actions above")

--- a/src/esm_master/task.py
+++ b/src/esm_master/task.py
@@ -384,6 +384,12 @@ class Task:
             os.remove("./dummy_script.sh")
         except OSError:
             print("No dummy script to remove!")
+        try:
+            source_fc = f"./{self.package.destination}-finished_config.yaml"
+            target_fc = f"./{self.package.destination}/finished_config.yaml"
+            os.rename(source_fc, target_fc)
+        except OSError:
+            print(f"Problems moving ``{source_fc}`` to ``{target_fc}``")
         for task in self.ordered_tasks:
             if task.todo in ["conf", "comp"]:
                 try:

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.48.0"
+__version__ = "6.49.0"
 
 from .utils import *


### PR DESCRIPTION
I think @JanStreffing, @joakimkjellsson and @seb-wahl might enjoy this feature considering all the envieronment_changes issues one typically has with esm_master. Not the solution to the problem but you'll know at least from which yamls and lines the problems are coming from.

After running esm_master commands now you'll be able to find a `finished_config.yaml` in the setup folder (e.g. `awicm3-v3.2`) that contains the config used by esm_master, with provenance of the values.

I think it can be merge pretty fast, as long as the CI is not reporting crashes