### PR TITLE
add tykky installation and documentation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -74,9 +74,9 @@ To install `ESM-Tools` in a `tykky` environment first load the module::
 
     module load tykky
 
-Then build the containerize environment using the ``utils/tykky_env.yaml`` distributed inside the ``esm_tools`` source::
+Then build the containerize environment using the ``environment.yaml`` distributed inside the ``esm_tools`` source::
 
-    conda-containerize new --mamba --prefix $TYKKY_PATH/esm_tools utils/tykky_env.yaml
+    conda-containerize new --mamba --prefix $TYKKY_PATH/esm_tools environment.yaml
 
 After this, a new `tykky` environment would have been created with the name ``esm_tools``. Activate that environment by running::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,10 +48,46 @@ A possible (default) output can be ``~/.local/bin/esm_tools``.
     .. note::
     The version that is available via ``pip`` is not the most recent version. We strongly recommend to install the most recent version of `ESM-Tools` using the install script described above (see also :ref:`get_esm-tools:Get ESM-Tools` and :ref:`installation:Installing in local environment`).
 
+
 Installing in a conda environment
 -----------------------------------
 
-First create a conda environment using
+First create a conda environment using the provided ``environment.yml`` file::
+
+    conda env create -f environment.yml -n esm_tools
+
+Then activate the environment::
+
+    conda activate esm_tools
+
+Now you can install `ESM-Tools` using the provided ``install.sh`` script::
+
+    ./install.sh
+
+
+Installing using Tykky (in ecmwf-atos)
+--------------------------------------
+
+You can also install `ESM-Tools` using a ``tykky`` environment. `tykky` builds a conda environment within a container, so it's use is very similar to `conda`,
+but with the advantages and the hurdles of containers. In the ECMWF machine you are encouraged by their admins to use `tykky` for python installations.
+To install `ESM-Tools` in a `tykky` environment first load the module::
+
+    module load tykky
+
+Then build the containerize environment using the ``utils/tykky_env.yaml`` distributed inside the ``esm_tools`` source::
+
+    conda-containerize new --mamba --prefix $TYKKY_PATH/esm_tools utils/tykky_env.yaml
+
+After this, a new `tykky` environment would have been created with the name ``esm_tools``. Activate that environment by running::
+
+    tykky activate esm_tools
+
+Now, you can use the standard ``install.sh`` script to install `ESM-Tools`::
+
+    ./install.sh
+
+Remember to ``module load tykky`` and ``tykky activate esm_tools`` every time you make a new login into the machine so that you can use `ESM-Tools`.
+
 
 Installing in an encapsulated environment using ``direnv``
 ----------------------------------------------------------
@@ -106,28 +142,6 @@ It enables us now to install `ESM-Tools` within this specific environment (see a
 .. note::
 
     Please note, that all calls of `ESM-Tools` commands for this particular installed version needs to be done within the folder that holds the ``direnv`` environment.
-
-
-Installing using Tykky (in ecmwf-atos)
---------------------------------------
-
-In The ECMWF machine you are encourage to use ``tykky``, a container wrapper for installations. To install `ESM-Tools` in a `tykky` environment first load the module::
-
-    module load tykky
-
-Then build the containerize environment using the ``utils/tykky_env.yaml`` distributed inside the ``esm_tools`` source::
-
-    conda-containerize new --mamba --prefix $TYKKY_PATH/esm_tools utils/tykky_env.yaml
-
-After this, a new `tykky` environment would have been created with the name ``esm_tools``. Activate that environment by running::
-
-    tykky activate esm_tools
-
-Now, you can use the standard ``install.sh`` script to install `ESM-Tools`::
-
-    ./install.sh
-
-Remember to ``module load tykky`` and ``tykky activate esm_tools`` every time you make a new login into the machine so that you can use `ESM-Tools`.
 
 
 Update ESM-Tools

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -51,8 +51,7 @@ A possible (default) output can be ``~/.local/bin/esm_tools``.
 Installing in a conda environment
 -----------------------------------
 
-Work in progress. We are still testing it.
-
+First create a conda environment using
 
 Installing in an encapsulated environment using ``direnv``
 ----------------------------------------------------------
@@ -107,6 +106,28 @@ It enables us now to install `ESM-Tools` within this specific environment (see a
 .. note::
 
     Please note, that all calls of `ESM-Tools` commands for this particular installed version needs to be done within the folder that holds the ``direnv`` environment.
+
+
+Installing using Tykky (in ecmwf-atos)
+--------------------------------------
+
+In The ECMWF machine you are encourage to use ``tykky``, a container wrapper for installations. To install `ESM-Tools` in a `tykky` environment first load the module::
+
+    module load tykky
+
+Then build the containerize environment using the ``utils/tykky_env.yaml`` distributed inside the ``esm_tools`` source::
+
+    conda-containerize new --mamba --prefix $TYKKY_PATH/esm_tools utils/tykky_env.yaml
+
+After this, a new `tykky` environment would have been created with the name ``esm_tools``. Activate that environment by running::
+
+    tykky activate esm_tools
+
+Now, you can use the standard ``install.sh`` script to install `ESM-Tools`::
+
+    ./install.sh
+
+Remember to ``module load tykky`` and ``tykky activate esm_tools`` every time you make a new login into the machine so that you can use `ESM-Tools`.
 
 
 Update ESM-Tools

--- a/environment.yaml
+++ b/environment.yaml
@@ -17,26 +17,32 @@ channels:
   - conda-forge
 dependencies:
   - python=3.9
-  - Click>=7.0
-  - PyGithub
-  - colorama
-  - coloredlogs
-  - emoji
-  - f90nml
-  - gitpython=3.1.37
+  - Click>=8.0.4
+  - PyGithub=1.55
+  - colorama=0.4.5
+  - coloredlogs=15.0.1
+  - emoji=1.7.0
+  - f90nml=1.4.2
+  - gitpython=3.1.41
   - jinja2=3.1.4
-  - loguru
-  - numpy
-  - packaging
-  - pandas>=1.0
+  - loguru=0.6.0
+  - numpy>=1.19.5
+  - packaging=21.3
+  - pandas>=1.1.5
   - pip=23.3
-  - psutil
-  - pytest
+  - psutil=5.9.1
+  - pytest=7.1.2
   - pyyaml=6.0.1
-  - questionary
-  - ruamel.yaml==0.17.32
-  - semver
-  - sqlalchemy
-  - tabulate
-  - tqdm
-  - typing_extensions>=3.10.0.0
+  - questionary=1.10.0
+  - ruamel.yaml=0.17.32
+  - semver=2.13.0
+  - setuptools=67.6.1
+  - sqlalchemy=1.4.39
+  - tabulate=0.8.10
+  - typing_extensions>=4.1.1
+  - pydantic>=1.10.13
+  - h5netcdf>=0.8.1
+  - pip:
+    - gfw-creator==0.2.2
+    - tqdm==4.66.3
+    - xdgenvpy==2.3.5

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,6 @@
 # boolean variable to exit the program on error
 shall_exit=false
 
-
 # prints the error message as the first argument and exits the program with non-zero status
 function quit_install () {
     echo ""
@@ -60,6 +59,16 @@ fi
 if [ ! -z ${VIRTUAL_ENV+x} ]; then
     echo "Detected virtual environment $VIRTUAL_ENV"
     pip install -e .
+elif [ ! -z ${TYKKY_PREFIX+x} ]; then
+    echo "======================="
+    echo "Using TYKKY environment"
+    echo "======================="
+    echo "WARNING: The use of a tykky environment for using ESM-Tools is currently not supported Use at your own risk"
+    ESM_TOOLS_SRC_PATH="$(dirname "$(realpath "$0")")"
+    echo $ESM_TOOLS_SRC_PATH
+    echo "pip install -e ${ESM_TOOLS_SRC_PATH}" > esm_tools_tikky_install.sh
+    conda-containerize update ${TYKKY_PREFIX} --post-install esm_tools_tikky_install.sh
+    rm esm_tools_tikky_install.sh
 elif [ ! -z ${CONDA_PREFIX+x} ]; then
     echo "======================="
     echo "Using CONDA environment"

--- a/install.sh
+++ b/install.sh
@@ -63,7 +63,7 @@ elif [ ! -z ${TYKKY_PREFIX+x} ]; then
     echo "======================="
     echo "Using TYKKY environment"
     echo "======================="
-    echo "WARNING: The use of a tykky environment for using ESM-Tools is currently not supported Use at your own risk"
+    echo "WARNING: The use of a tykky environment for using ESM-Tools is currently not supported. Use at your own risk"
     ESM_TOOLS_SRC_PATH="$(dirname "$(realpath "$0")")"
     echo $ESM_TOOLS_SRC_PATH
     echo "pip install -e ${ESM_TOOLS_SRC_PATH}" > esm_tools_tikky_install.sh
@@ -73,7 +73,6 @@ elif [ ! -z ${CONDA_PREFIX+x} ]; then
     echo "======================="
     echo "Using CONDA environment"
     echo "======================="
-    echo "WARNING: The use of a conda environment is currently not recommended. Use only for testing purposes!"
     ${CONDA_PREFIX}/bin/pip install -e .
 else
     echo "Standard install to user directory (likely ${HOME}/.local)"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.49.2
+current_version = 6.50.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.49.2",
+    version="6.50.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.49.2"
+__version__ = "6.50.0"
 
 from .utils import *

--- a/utils/tykky_env.yaml
+++ b/utils/tykky_env.yaml
@@ -1,0 +1,8 @@
+name: esm_tools
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - ipykernel
+  - pip=23.0.1
+  - setuptools=67.6.1


### PR DESCRIPTION
- Improves the `environment.yaml` to be used with `conda` and `tykky`
- Adds installation support for Tykky container builder for conda environments wrapper thing: https://docs.csc.fi/computing/containers/tykky/
- Adds documentation for building `conda` and `tykky` environments

Working for ECMWF Atos. The new part inside `install.sh` was inspired by `Removing a containerised conda environment` in https://confluence.ecmwf.int/display/UDOC/HPC2020%3A+Containerised+software+installations+with+Tykky

Documentation for this type of installation is included in this PR: https://esm-tools.readthedocs.io/en/feat-tykky_installation/installation.html#installing-using-tykky-in-ecmwf-atos