### PR TITLE
fix.oifs branchoff restarts

### DIFF
--- a/configs/components/oifs/oifs.yaml
+++ b/configs/components/oifs/oifs.yaml
@@ -1414,7 +1414,7 @@ oifs:
                             ${oifs.nx}
                             ${oifs.ensemble_id};
                         ${general.esm_function_dir}/components/oifs/change_rcf_date.sh
-                            ${thisrun_restart_in_dir}/
+                            ${thisrun_work_dir}/
                             ${pseudo_initial_date!syear!smonth!sday}
                             ${oifs.time_step}
                             ${oifs.seconds_since_initial}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.55.4
+current_version = 6.55.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.55.4",
+    version="6.55.5",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.55.4"
+__version__ = "6.55.5"
 
 from .utils import *


### PR DESCRIPTION
changes the directory where the files for preprocessing are (from this_rundir to work), for the branchoff experiment. This was done for the normal restarts but forgotten for the branchoff restarts.

@mathanase reported this issue. I guess we never really checked that branchoff restarts where restarting after our work on reducing the number of files copied unnecessarily (#1162) 