### PR TITLE
fix/awiesm_pism

### DIFF
--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -150,7 +150,7 @@ general:
         choose_general.iterative_coupling:
             True:
                 required_plugins:
-                    - "https://github.com/esm-tools-plugins/esm_pism"
+                    - "git+https://github.com/esm-tools-plugins/esm_pism"
 
 #########################################################################################
 ########### necessary changes to submodels compared to standalone setups ################

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.55.5
+current_version = 6.55.6
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.55.5",
+    version="6.55.6",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 
 from .dict_to_yaml import *

--- a/src/esm_parser/provenance.py
+++ b/src/esm_parser/provenance.py
@@ -681,7 +681,7 @@ class DictWithProvenance(dict):
                             f"Key ``{key}`` exists in two different yaml files at the same "
                             f"hierarchical level (``{old_category}``) and have different "
                             f"values (``{old_val}``:``{new_val}``). To solve this remove "
-                            f" one of the these two values, or include them into a choose "
+                            f"one of the these two values, or include them into a choose "
                             f"block that avoids the conflict."
                             "\n- @HINT_0@\n- @HINT_1@",
                             hints=[

--- a/src/esm_parser/provenance.py
+++ b/src/esm_parser/provenance.py
@@ -683,7 +683,10 @@ class DictWithProvenance(dict):
                             f"values (``{old_val}``:``{new_val}``). To solve this remove "
                             f"one of the these two values, or include them into a choose "
                             f"block that avoids the conflict."
-                            "\n- @HINT_0@\n- @HINT_1@",
+                            "\n- @HINT_0@\n- @HINT_1@"
+                            "\nNote: if you are developing a feature in the backend and "
+                            "you'd like to force-overwrite this value, use the "
+                            "super_setitem method.",
                             hints=[
                                 {
                                     "type": "prov",
@@ -717,6 +720,16 @@ class DictWithProvenance(dict):
                 final_val.provenance = new_provenance
 
         super().__setitem__(key, final_val)
+
+    def super_setitem(self, key, val):
+        """
+        A method to call the original ``dict.__setitem__`` method without provenance
+        tracking. This is useful when you want to set a value without extending the
+        provenance history, for example when you are setting a value that does not
+        come from a yaml file and you do not want to keep the provenance history, or
+        when resetting a value is blocked due to provenance conflicts.
+        """
+        super().__setitem__(key, val)
 
     def update(self, dictionary, *args, **kwargs):
         """
@@ -968,6 +981,16 @@ class ListWithProvenance(list):
                 val_new.provenance = new_provenance
 
         super().__setitem__(indx, val_new)
+
+    def super_setitem(self, indx, val):
+        """
+        A method to call the original ``list.__setitem__`` method without provenance
+        tracking. This is useful when you want to set a value without extending the
+        provenance history, for example when you are setting a value that does not
+        come from a yaml file and you do not want to keep the provenance history, or
+        when resetting a value is blocked due to provenance conflicts.
+        """
+        super().__setitem__(indx, val)
 
 
 ListWithProvenance.yaml_dump = esm_parser.yaml_dump

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_runscripts/chunky_parts.py
+++ b/src/esm_runscripts/chunky_parts.py
@@ -433,41 +433,25 @@ def _is_last_run_in_chunk(config):
     return config
 
 
-def without_prov_custom_setitem_for_config_general(func):
-    """
-    Decorator to allow custom setitem for config["general"] ignoring the provenance
-    setitem custom method.
-    """
-    def inner(config, *args, **kwargs):
-        general = config.get("general")
-        restore = False
-        if general is not None and hasattr(general, "custom_setitem"):
-            original_custom_setitem = general.custom_setitem
-            restore = True
-            general.custom_setitem = False
-
-        output = func(config, *args, **kwargs)
-
-        if restore:
-            config["general"].custom_setitem = original_custom_setitem
-
-        return output
-    return inner
-
-
-@without_prov_custom_setitem_for_config_general
 def _find_next_model_to_run(config):
     if config["general"]["last_run_in_chunk"]:
-        config["general"]["next_setup_name"] = config["general"]["model_named_queue"][0]
+        config["general"].super_setitem(
+            "next_setup_name", config["general"]["model_named_queue"][0]
+        )
     else:
-        config["general"]["next_setup_name"] = config["general"]["setup_name"]
+        config["general"].super_setitem(
+            "next_setup_name", config["general"]["setup_name"]
+        )
     return config
 
 
-@without_prov_custom_setitem_for_config_general
 def _find_next_chunk_number(config):
     if config["general"]["last_run_in_chunk"]:
-        config["general"]["next_chunk_number"] = config["general"]["chunk_number"] + 1
+        config["general"].super_setitem(
+            "next_chunk_number", config["general"]["chunk_number"] + 1
+        )
     else:
-        config["general"]["next_chunk_number"] = config["general"]["chunk_number"]
+        config["general"].super_setitem(
+            "next_chunk_number", config["general"]["chunk_number"]
+        )
     return config

--- a/src/esm_runscripts/chunky_parts.py
+++ b/src/esm_runscripts/chunky_parts.py
@@ -433,6 +433,29 @@ def _is_last_run_in_chunk(config):
     return config
 
 
+def without_prov_custom_setitem_for_config_general(func):
+    """
+    Decorator to allow custom setitem for config["general"] ignoring the provenance
+    setitem custom method.
+    """
+    def inner(config, *args, **kwargs):
+        general = config.get("general")
+        restore = False
+        if general is not None and hasattr(general, "custom_setitem"):
+            original_custom_setitem = general.custom_setitem
+            restore = True
+            general.custom_setitem = False
+
+        output = func(config, *args, **kwargs)
+
+        if restore:
+            config["general"].custom_setitem = original_custom_setitem
+
+        return output
+    return inner
+
+
+@without_prov_custom_setitem_for_config_general
 def _find_next_model_to_run(config):
     if config["general"]["last_run_in_chunk"]:
         config["general"]["next_setup_name"] = config["general"]["model_named_queue"][0]
@@ -441,6 +464,7 @@ def _find_next_model_to_run(config):
     return config
 
 
+@without_prov_custom_setitem_for_config_general
 def _find_next_chunk_number(config):
     if config["general"]["last_run_in_chunk"]:
         config["general"]["next_chunk_number"] = config["general"]["chunk_number"] + 1

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.55.5"
+__version__ = "6.55.6"
 
 from .utils import *


### PR DESCRIPTION
Closes #1368

Fixes the conflicts between provenance and the iterative coupling by using a decorator to deactivate the custom setitem method defined by the provenance. This method blocks reasigning a value with another value from the same file or a fil of the same hierarchy.

@ackerlar, please go ahead and try it. It solves the problem for me at least for check simulations.