### PR TITLE
Fixes itercoup paleo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
     "jinja2==3.1.4",
     "loguru==0.6.0",
     "numpy>=1.19.5",  # Maximum version for Python 3.6 support
-    "packaging==21.3",
+    "packaging>=21.3",
     "pandas>=1.1.5",  # Correct compatiability with xarray for Python 3.6
     "psutil==5.9.1",
     "pytest==7.1.2",

--- a/src/esm_motd/esm_motd.py
+++ b/src/esm_motd/esm_motd.py
@@ -127,7 +127,12 @@ class MessageOfTheDayHandler:
                 print()
                 print(self.message_dict[message]["message"])
                 if mypackage == "esm_tools":
-                    esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
+                    try:
+                        esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
+                    except FileNotFoundError as e:
+                        print(e)
+                        print("Unable to determine esm_tools_path! Message below may be incomplete")
+                        esm_tools_path = "<YOUR_ESM_TOOLS_INSTALL_LOCATION>"
                     print(
                         f"Upgrade ESM-Tools to the version contianing this fix (\x1b[96m{version}\x1b[0m) by:\n"
                         f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"


### PR DESCRIPTION
Fixed an issue where:

Running the AWI-ESM2.6 coupled with PISM model previously failed due to an outdated xarray version.

After updating xarray, a subsequent error occurred where the esm_tools path could not be found.