### PR TITLE
possible fix to get rid of _get_real_dir_from_pth_file empty folder error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.61.0
+current_version = 6.61.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.61.0",
+    version="6.61.1",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_motd import *

--- a/src/esm_motd/esm_motd.py
+++ b/src/esm_motd/esm_motd.py
@@ -127,14 +127,23 @@ class MessageOfTheDayHandler:
                 print()
                 print(self.message_dict[message]["message"])
                 if mypackage == "esm_tools":
-                    esm_tools_path = esm_tools._get_real_dir_from_pth_file("motd_flag")
-                    print(
-                        f"Upgrade ESM-Tools to the version contianing this fix (\x1b[96m{version}\x1b[0m) by:\n"
-                        f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"
-                        "\x1b[96m2.\x1b[0m Make sure that your git repo is clean (\x1b[35mgit status\x1b[0m)\n"
-                        "\x1b[96m3.\x1b[0m \x1b[35mgit checkout release\x1b[0m\n"
-                        "\x1b[96m4.\x1b[0m \x1b[35mgit pull\x1b[0m\n"
-                    )
+                    esm_tools_path = esm_tools.get_esm_tools_root_dir()
+                    if esm_tools_path:
+                        print(
+                            f"Upgrade ESM-Tools to the version contianing this fix (\x1b[96m{version}\x1b[0m) by:\n"
+                            f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"
+                            "\x1b[96m2.\x1b[0m Make sure that your git repo is clean (\x1b[35mgit status\x1b[0m)\n"
+                            "\x1b[96m3.\x1b[0m \x1b[35mgit checkout release\x1b[0m\n"
+                            "\x1b[96m4.\x1b[0m \x1b[35mgit pull\x1b[0m\n"
+                        )
+                    else:
+                        print(
+                            f"Upgrade ESM-Tools to the version containing this fix (\x1b[96m{version}\x1b[0m) by:\n"
+                            f"\x1b[96m1.\x1b[0m Navigate to your esm_tools installation directory\n"
+                            "\x1b[96m2.\x1b[0m Make sure that your git repo is clean (\x1b[35mgit status\x1b[0m)\n"
+                            "\x1b[96m3.\x1b[0m \x1b[35mgit checkout release\x1b[0m\n"
+                            "\x1b[96m4.\x1b[0m \x1b[35mgit pull\x1b[0m\n"
+                        )
                 # Deprecated after monorepo rework, rewrite if we ever get to have
                 # more than one package again.
                 else:

--- a/src/esm_motd/esm_motd.py
+++ b/src/esm_motd/esm_motd.py
@@ -127,7 +127,7 @@ class MessageOfTheDayHandler:
                 print()
                 print(self.message_dict[message]["message"])
                 if mypackage == "esm_tools":
-                    esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
+                    esm_tools_path = esm_tools._get_real_dir_from_pth_file("motd_flag")
                     print(
                         f"Upgrade ESM-Tools to the version contianing this fix (\x1b[96m{version}\x1b[0m) by:\n"
                         f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -89,6 +89,10 @@ def _transform(nested_list):
 @caller_wrapper
 def _get_real_dir_from_pth_file(subfolder):
     logger.debug(f"Trying to resolve: {subfolder}")
+    if subfolder == "motd_flag":
+        flag_val = "mymotd_flag"
+    else:
+        flag_val = None
     if subfolder.startswith("/"):
         logger.warning("Subfolder is strange!")
         logger.warning(subfolder)
@@ -151,6 +155,8 @@ def _get_real_dir_from_pth_file(subfolder):
                         break  # Break out of the for loop
             logger.debug(f"actual_package_data_dir={actual_package_data_dir}")
             return actual_package_data_dir
+    if flag_val == "mymotd_flag":
+        return None # I am not sure what should be returned here but it seems necessary due to esm_motd/esm_motd.py changes
     raise FileNotFoundError(
         f"Could not determine where {subfolder}'s path is inside the esm-tools installation! These were searched for info: {site_packages_dirs}"
     )

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -87,12 +87,62 @@ def _transform(nested_list):
 
 
 @caller_wrapper
+def get_esm_tools_root_dir():
+    """
+    Get the root directory of esm_tools installation.
+
+    This function finds the actual root directory of the esm_tools installation,
+    which is useful for providing upgrade instructions or accessing the git repository.
+
+    For editable installs (pip install -e), this returns the git repository directory.
+    For normal installs, this returns the site-packages location.
+
+    Returns
+    -------
+    pathlib.Path or None
+        The root directory of esm_tools, or None if it cannot be determined.
+
+    Notes
+    -----
+    This function is more reliable than _get_real_dir_from_pth_file("") because it:
+    - Works regardless of virtual environment configuration
+    - Doesn't depend on finding .egg-link files
+    - Uses Python's standard __file__ attribute
+    - Handles both editable and normal installations
+    """
+    import pathlib
+
+    try:
+        # Get the location of the esm_tools module
+        # __file__ points to src/esm_tools/__init__.py
+        esm_tools_module_path = pathlib.Path(__file__).parent
+        logger.debug(f"esm_tools module path: {esm_tools_module_path}")
+
+        # For editable install, the structure is typically:
+        # /path/to/repo/src/esm_tools/__init__.py
+        # So we need to go up two levels to get to the repo root
+        potential_root = esm_tools_module_path.parent.parent
+        logger.debug(f"Checking potential root: {potential_root}")
+
+        # Check if this looks like a git repository (editable install)
+        if (potential_root / '.git').exists():
+            logger.debug(f"Found .git directory, returning: {potential_root}")
+            return potential_root
+
+        # For regular install, or if no .git found, return the parent of the module
+        # This is the site-packages or dist-packages directory
+        fallback = esm_tools_module_path.parent
+        logger.debug(f"No .git found, returning fallback: {fallback}")
+        return fallback
+
+    except Exception as e:
+        logger.error(f"Could not determine esm_tools root directory: {e}")
+        return None
+
+
+@caller_wrapper
 def _get_real_dir_from_pth_file(subfolder):
     logger.debug(f"Trying to resolve: {subfolder}")
-    if subfolder == "motd_flag":
-        flag_val = "mymotd_flag"
-    else:
-        flag_val = None
     if subfolder.startswith("/"):
         logger.warning("Subfolder is strange!")
         logger.warning(subfolder)
@@ -155,8 +205,6 @@ def _get_real_dir_from_pth_file(subfolder):
                         break  # Break out of the for loop
             logger.debug(f"actual_package_data_dir={actual_package_data_dir}")
             return actual_package_data_dir
-    if flag_val == "mymotd_flag":
-        return None # I am not sure what should be returned here but it seems necessary due to esm_motd/esm_motd.py changes
     raise FileNotFoundError(
         f"Could not determine where {subfolder}'s path is inside the esm-tools installation! These were searched for info: {site_packages_dirs}"
     )

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.61.0"
+__version__ = "6.61.1"
 
 from .utils import *


### PR DESCRIPTION
Hi

While being on a rather old esm_tools branch, I suddenly had problems using `venv` with this error:
```
esm_runscripts <runscript_with_venv_true> -e expname

Traceback (most recent call last):
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/bin/esm_runscripts", line 7, in <module>
    sys.exit(main())
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages/esm_runscripts/cli.py", line 288, in main
    check_all_esm_packages()
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages/esm_motd/esm_motd.py", line 168, in check_all_esm_packages
    motd.motd_handler("esm_tools", esm_tools.__version__)
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages/esm_motd/esm_motd.py", line 130, in motd_handler
    esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages/esm_tools/__init__.py", line 73, in wrapped_func
    return func(*args, **kwargs)
  File "/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages/esm_tools/__init__.py", line 154, in _get_real_dir_from_pth_file
    raise FileNotFoundError(
FileNotFoundError: Could not determine where 's path is inside the esm-tools installation! These were searched for info: ['/work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/lib/python3.10/site-packages']
Traceback (most recent call last):
  File "/home/a/a270073/.local/bin/esm_runscripts", line 33, in <module>
    sys.exit(load_entry_point('esm-tools', 'console_scripts', 'esm_runscripts')())
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/cli.py", line 289, in main
    setup()
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/sim_objects.py", line 119, in __call__
    self.config = prepexp.run_job(self.config)
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/prepexp.py", line 28, in run_job
    evaluate(config, "prepexp", "prepexp_recipe")
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/helpers.py", line 71, in evaluate
    config = esm_plugin_manager.work_through_recipe(
  File "/home/a/a270073/esm/esm_tools/src/esm_plugin_manager/esm_plugin_manager.py", line 159, in work_through_recipe
    config = getattr(submodule, workitem)(config)
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/virtual_env_builder.py", line 276, in venv_bootstrap
    _source_and_run_bin_in_venv(
  File "/home/a/a270073/esm/esm_tools/src/esm_runscripts/virtual_env_builder.py", line 69, in _source_and_run_bin_in_venv
    return subprocess.check_call(command, shell=shell)
  File "/sw/spack-levante/mambaforge-22.9.0-2-Linux-x86_64-kptncg/lib/python3.10/subprocess.py", line 369, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command 'source /work/ab1095/a270073/out/awicm-1.0-recom/awi-esm-1-1-lr_kh800/esm-hist_vdeta_p25_vdet_p25_i2/.venv_esmtools/bin/activate &&  esm_runscripts awicm_recom_levante_hist.run.yaml -e esm-hist_vdeta_p25_vdet_p25_i2 --contained-run' returned non-zero exit status 1.
```

Together with @pgierz we made the proposed changes.

Hope this helps,
Chris