### PR TITLE
awicm3-v3.3.1 release

### DIFF
--- a/configs/setups/awicm3/awicm3.yaml
+++ b/configs/setups/awicm3/awicm3.yaml
@@ -26,6 +26,7 @@ general:
         - 'v3.2.1'
         - 'v3.2.2'
         - 'v3.3.0'
+        - 'v3.3.1'
         - 'develop'
         - 'frontiers-xios'
 
@@ -93,6 +94,14 @@ general:
             oasis_with_yac: True
             xios_interp_order: 1
           v3.3.0:
+            major_version: v3.3
+            couplings:
+            - fesom-2.6.8+oifs-43r3-awicm-3.2.4+xios-2.5
+            add_include_models:
+            - xios
+            oasis_with_yac: False
+            xios_interp_order: 1
+          v3.3.1:
             major_version: v3.3
             couplings:
             - fesom-2.6.8+oifs-43r3-awicm-3.2.4+xios-2.5
@@ -568,6 +577,12 @@ rnfmap:
                         choose_general.version:
                                 "v3.3.0":
                                         version: awicm-3.1
+                                "v3.3.1":
+                                        version: awicm-3.1
+                                        add_namelist_changes:
+                                                namelist.runoffmapper:
+                                                        NAMRNFMAP:
+                                                                CalvingEnthalpy: .true.
                                 "*":
                                         version: v1.1
                 "v3.4":
@@ -750,6 +765,8 @@ oasis3mct:
         # This variable is only used for major versions of v3.3
         choose_general.version:
                 "v3.3.0":
+                        calving_coupling_mode: 'hydr_oce:enth_oce <--gauswgt_c-- R_Runoff_oce:R_Calving_oce'
+                "v3.3.1":
                         calving_coupling_mode: 'hydr_oce:enth_oce <--gauswgt_c-- R_Runoff_oce:R_Calving_oce'
                 "*":
                         calving_coupling_mode: 'hydr_oce:calv_oce <--gauswgt_c-- R_Runoff_oce:R_Calving_oce' 

--- a/runscripts/awicm3/v3.3.1/awicm3-v3.3.0-levante-TCO95L91-CORE2.yaml
+++ b/runscripts/awicm3/v3.3.1/awicm3-v3.3.0-levante-TCO95L91-CORE2.yaml
@@ -1,0 +1,59 @@
+general:
+    user: !ENV ${USER}
+    setup_name: "awicm3"
+    version: "v3.3.1"
+    account: "ab0995"
+    compute_time: "03:30:00"
+    initial_date: "1650-01-01"
+    final_date: "1651-01-02"
+    base_dir: "/work/ab0995/a270186/esm_tools/runtime/awicm3-v3.3.1/"
+    nday: 1
+    nmonth: 0
+    nyear: 0
+    use_venv: false
+    
+computer:
+    taskset: true
+
+awicm3:
+    postprocessing: false
+    model_dir: "/work/ab0995/a270186/esm_tools/model_codes/${general.setup_name}-${general.version}/"
+
+fesom:
+    resolution: "CORE2"
+    mesh_dir: "/work/ab0995/a270186/model_inputs/fesom2/mesh/CORE2/"
+    restart_rate: 1
+    restart_unit: "d"
+    restart_first: 1
+    time_step: 1800
+    nproc: 768
+    omp_num_threads: 4
+    tar_binary_restarts: true
+    lresume: false
+
+oifs:
+    resolution: "TCO95"
+    levels: "L91"
+    prepifs_expid: aack
+    input_expid: awi3
+    wam: true
+    lresume: false
+    time_step: 3600
+    nproc: 384
+    omp_num_threads: 4
+    add_namelist_changes:
+        fort.4:
+            NAERAD:
+                LCMIP6: true
+                NCMIPFIXYR: 1850
+                SSPNAME: 'pictrl'
+
+oasis3mct:
+    lresume: true # Set to false to generate the rst files for first leg
+    time_step: 3600
+
+xios:
+    with_model: oifs
+    nproc: 8
+    omp_num_threads: 32
+


### PR DESCRIPTION
Hi @mandresm,

I found a bug in the runoff mapper in all awicm3-v3.x releases. 

Since in the esm-tools default rnfmap namelist `namelist.runoffmapper` the parameter `CalvingEnthalpy` is not defined, rnfmap did not convert the calving mass flux to a calving heat flux and thus sent a mass flux instead of a heat flux to fesom. Fesom, however, always interpreted this incoming flux as a heat flux. 

In order for rnfmap to properly work, the parameter `CalvingEnthalpy= .true.` must be added to `namelist.runoffmapper`. 

I discussed this with @JanStreffing today and we decided to not patch the previous releases but make a new release v3.3.1 based on the latest release. In awicm3-develop this is not an issue.

This MR contains the updated awicm3.yaml file and a single runscript for v3.3.1 for use on levante.

Best
Finn