### PR TITLE
fix get_rel_paths_compare_files

### DIFF
--- a/src/esm_tests/test_utilities.py
+++ b/src/esm_tests/test_utilities.py
@@ -389,11 +389,12 @@ def get_rel_paths_compare_files(info, cfile, v, this_test_dir):
     subpaths_source = subpaths
     subpaths_target = []
     datestamp_format = re.compile(r"_[\d]{8}-[\d]{8}$")
+    run_dir_format = re.compile(r"^run_[\d]{8}$")
     for sp in subpaths:
         sp_t = ""
         pieces = sp.split("/")
         for p in pieces:
-            if "run_" not in p:
+            if not run_dir_format.match(p):
                 sp_t += f"/{p}"
         # Remove the datestamp
         if datestamp_format.findall(sp_t):


### PR DESCRIPTION
Solves an issue in `esm_tests` found by @seb-wahl where one of the `subpaths_target` returned by `get_rel_paths_compare_files` was a directory instead of a file.

This happened when some of the files to be tracked contained `run_` string in their name, because `run_` string was used to discard the path component `run_YYYYMMDD` to compute a target path independent of the run time stamp. This filtering out of path components containing `run_` was accidentally filtering out the `foci-moz-restart-pictrl_run_compute_18500101-18500101.run` file so the target path for that file was missing the file name.

The fix includes filtering out for a regex pattern that matches `run_YYYYMMDD`.