### PR TITLE
add 'recover' method to check_error for auto-fix-and-resubmit

### DIFF
--- a/configs/esm_software/esm_runscripts/esm_plugins.yaml
+++ b/configs/esm_software/esm_runscripts/esm_plugins.yaml
@@ -44,6 +44,7 @@ core:
                         - "assemble_filelists"
                         - "wait_for_iterative_coupling"
                         - "copy_files_to_thisrun"
+                        - "apply_recovery_fix"
                         - "modify_namelists"
                         - "modify_files"
                         - "create_new_files"

--- a/configs/esm_software/esm_runscripts/esm_runscripts.yaml
+++ b/configs/esm_software/esm_runscripts/esm_runscripts.yaml
@@ -84,6 +84,7 @@ choose_job_type:
                         - "log_used_files"
                         - "wait_for_iterative_coupling"
                         - "copy_files_to_thisrun"
+                        - "apply_recovery_fix"
                         - "modify_namelists"
                         - "modify_files"
                         - "copy_files_to_work"

--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -47,6 +47,7 @@ general:
                 - "wait_for_iterative_coupling"
                 - "prep_icebergs"                       # Plugin
                 - "copy_files_to_thisrun"
+                - "apply_recovery_fix"
                 - "modify_namelists"
                 - "apply_iceberg_calving_to_namelists"  # Plugin
                 - "modify_files"

--- a/docs/yaml.rst
+++ b/docs/yaml.rst
@@ -989,6 +989,8 @@ specific actions when certain patterns are detected. This is useful for:
 - When a pattern is found:
   - For ``method: warn``: Logs a warning message
   - For ``method: kill``: Terminates the job and logs an error
+  - For ``method: recover``: Stops the compute launcher, applies a fix, and
+    resubmits the same run (see `Automatic recovery`_ below)
 
 **Best Practices**
 
@@ -1003,19 +1005,29 @@ Automatic recovery (``method: recover``)
 
 When ``method: recover`` is used, ESM-Tools will, upon detecting the pattern:
 
-1. Cancel the running compute job (``scancel``)
-2. Persist a recovery state file next to the experiment's ``.date`` file
-   (``<expid>_<setup>.recovery.json``)
+1. Stop the running compute launcher (and its children) while **keeping the
+   ``observe`` process alive**, so control can reach ``maybe_resubmit``.
+   The enclosing batch job is *not* ``scancel``-ed.
+2. Persist a short-lived recovery state file next to the experiment's
+   ``.date`` file (``<expid>_<setup>.recovery.json``) that carries the
+   pending fix to the next process.
 3. Resubmit a fresh ``prepcompute`` → ``compute`` cycle for the **same
-   run_number and date** (no date increment, no loss of progress)
-4. Apply the configured ``fix`` to the component's namelists before the model
-   runs again
+   run_number and date** (no date increment, no loss of progress).
+4. Apply the configured ``fix`` to the component's namelists in the new
+   ``prepcompute`` step (via the ``apply_recovery_fix`` recipe entry) before
+   the model runs again.
+5. Append a row to the long-lived status log
+   (``<expid>_<setup>.recovery_status.dat``) so that every recovered year
+   — and the values that were applied — are visible for later inspection
+   or plotting.
 
 The attempt counter is bumped on every retry for the same trigger; once
-``max_retries`` is exceeded, the job is killed like ``method: kill``.
+``max_retries`` is exceeded, the state is marked as failed in the status
+log and the job is killed like ``method: kill``.
 
-A clean run (no ``recover`` trigger firing) clears the state file
-automatically, so the counter resets for the next unrelated crash.
+A clean run (no ``recover`` trigger firing) marks the year's status row
+as successful (``status=1``) and clears the short-lived state file, so the
+attempt counter resets for the next unrelated crash.
 
 **Additional parameters**
 
@@ -1025,19 +1037,42 @@ automatically, so the counter resets for the next unrelated crash.
   contain either or both of:
 
   - ``namelist_changes``: nested ``namelist -> group -> key: absolute_value``
-    mapping, using the same syntax as the regular ``add_namelist_changes``
+    mapping, using the same syntax as the regular ``add_namelist_changes``.
   - ``namelist_deltas``: nested ``namelist -> group -> key: delta`` mapping.
-    The delta is **added** to the current value read from the namelist in
-    ``thisrun_config_dir`` at retry time, and the result is merged into
-    ``namelist_changes``. Useful for tiny perturbations that knock a model
-    off a numerically unstable trajectory without changing its physics.
+    The delta is **added** to the current value of the namelist entry and
+    the result is merged into ``namelist_changes`` before the namelist is
+    written. The baseline is read from ``thisrun_work_dir`` when available
+    (so repeated same-year retries **accumulate** — attempt *N* ends up at
+    ``value + N*delta``) and falls back to ``thisrun_config_dir`` otherwise.
+    Useful for tiny perturbations that knock a model off a numerically
+    unstable trajectory without changing its physics.
+
+**Files written by the recovery plugin**
+
+* ``<expid>_<setup>.recovery.json`` (scripts dir) — short-lived JSON that
+  carries the pending fix between ``observe`` and the next ``prepcompute``.
+  Removed automatically after a retried run completes cleanly. Deleting it
+  by hand cancels an in-flight recovery.
+* ``<expid>_<setup>.recovery_status.dat`` (scripts dir) — long-lived,
+  append-on-write per-year log. One row per calendar year that ever
+  triggered recovery, of the form::
+
+      <year> <status> [<namelist>:<group>:<key>=<value> ...]
+
+  ``status`` is ``1`` for a year that eventually completed cleanly and
+  ``0`` for a year that is still pending or whose retries were exhausted.
+  Entries (one ``namelist:group:key=value`` token per perturbed field) are
+  generated automatically from the ``fix`` block — whatever the trigger
+  modifies ends up in the log, so this file works for any setup, not just
+  FESOM.
 
 **Example — FESOM temperature blow-up**
 
 FESOM occasionally crashes with
-``--STOP--> found temperture becomes NaN or <-5.0, >60`` when a bit-reproducible
-trajectory hits a numerical edge case. Perturbing ``K_GM_max`` by ``+0.001``
-is usually enough to nudge the trajectory onto a nearby, stable path.
+``--STOP--> found temperture becomes NaN or <-5.0, >60`` when a
+bit-reproducible trajectory hits a numerical edge case. Perturbing
+``K_GM_max`` by ``+0.001`` is usually enough to nudge the trajectory onto
+a nearby, stable path.
 
 .. code-block:: yaml
 
@@ -1054,8 +1089,18 @@ is usually enough to nudge the trajectory onto a nearby, stable path.
                            oce_dyn:
                                K_GM_max: 0.001
 
-On each subsequent retry of the same trigger, the perturbation is re-applied
-to the (already perturbed) value, so attempt N ends up at ``K_GM_max + N*0.001``.
+On each subsequent retry of the same trigger, the perturbation is
+re-applied on top of the perturbed ``work`` namelist, so attempt *N* ends
+up at ``K_GM_max + N*0.001``. The resolved absolute value for each
+attempt is written to ``<expid>_<setup>.recovery_status.dat`` as the
+token ``namelist.oce:oce_dyn:K_GM_max=<value>``, giving a
+post-processable history of the perturbation sequence.
 
-To cancel an in-flight recovery manually, remove the ``*.recovery.json`` file
-from the experiment's ``scripts`` directory.
+**Canceling / cleaning up**
+
+- To cancel an in-flight recovery manually, remove the
+  ``<expid>_<setup>.recovery.json`` file from the experiment's scripts
+  directory.
+- The status file ``<expid>_<setup>.recovery_status.dat`` is purely
+  informational; deleting it only discards the history log and does not
+  affect whether or how a future recovery runs.

--- a/docs/yaml.rst
+++ b/docs/yaml.rst
@@ -1017,7 +1017,7 @@ When ``method: recover`` is used, ESM-Tools will, upon detecting the pattern:
    ``prepcompute`` step (via the ``apply_recovery_fix`` recipe entry) before
    the model runs again.
 5. Append a row to the long-lived status log
-   (``<expid>_<setup>.recovery_status.dat``) so that every recovered year
+   (``<expid>_<setup>.recovery_status.jsonl``) so that every recovered year
    — and the values that were applied — are visible for later inspection
    or plotting.
 
@@ -1026,7 +1026,7 @@ The attempt counter is bumped on every retry for the same trigger; once
 log and the job is killed like ``method: kill``.
 
 A clean run (no ``recover`` trigger firing) marks the year's status row
-as successful (``status=1``) and clears the short-lived state file, so the
+as successful (``status="success"``) and clears the short-lived state file, so the
 attempt counter resets for the next unrelated crash.
 
 **Additional parameters**
@@ -1053,18 +1053,19 @@ attempt counter resets for the next unrelated crash.
   carries the pending fix between ``observe`` and the next ``prepcompute``.
   Removed automatically after a retried run completes cleanly. Deleting it
   by hand cancels an in-flight recovery.
-* ``<expid>_<setup>.recovery_status.dat`` (scripts dir) — long-lived,
-  append-on-write per-year log. One row per calendar year that ever
-  triggered recovery, of the form::
+* ``<expid>_<setup>.recovery_status.jsonl`` (scripts dir) — long-lived,
+  append-on-write per-year log in `JSONL <https://jsonlines.org>`_ format.
+  Each line is a self-describing JSON object::
 
-      <year> <status> [<namelist>:<group>:<key>=<value> ...]
+      {"year": 2384, "status": "success", "values": {"namelist.oce:oce_dyn:K_GM_max": 2000.001}}
 
-  ``status`` is ``1`` for a year that eventually completed cleanly and
-  ``0`` for a year that is still pending or whose retries were exhausted.
-  Entries (one ``namelist:group:key=value`` token per perturbed field) are
-  generated automatically from the ``fix`` block — whatever the trigger
-  modifies ends up in the log, so this file works for any setup, not just
-  FESOM.
+  ``status`` is ``"success"`` for a year that completed cleanly,
+  ``"pending"`` for a retry in progress, or ``"failed"`` when retries
+  were exhausted.
+  The ``values`` dict maps each perturbed field (as
+  ``namelist:group:key``) to its resolved absolute value. Generated
+  automatically from the ``fix`` block, so this file works for any setup,
+  not just FESOM.
 
 **Example — FESOM temperature blow-up**
 
@@ -1092,15 +1093,15 @@ a nearby, stable path.
 On each subsequent retry of the same trigger, the perturbation is
 re-applied on top of the perturbed ``work`` namelist, so attempt *N* ends
 up at ``K_GM_max + N*0.001``. The resolved absolute value for each
-attempt is written to ``<expid>_<setup>.recovery_status.dat`` as the
-token ``namelist.oce:oce_dyn:K_GM_max=<value>``, giving a
-post-processable history of the perturbation sequence.
+attempt is written to ``<expid>_<setup>.recovery_status.jsonl`` as a JSON
+object with the key ``namelist.oce:oce_dyn:K_GM_max`` in its ``values``
+dict, giving a machine-readable history of the perturbation sequence.
 
 **Canceling / cleaning up**
 
 - To cancel an in-flight recovery manually, remove the
   ``<expid>_<setup>.recovery.json`` file from the experiment's scripts
   directory.
-- The status file ``<expid>_<setup>.recovery_status.dat`` is purely
+- The status file ``<expid>_<setup>.recovery_status.jsonl`` is purely
   informational; deleting it only discards the history log and does not
   affect whether or how a future recovery runs.

--- a/docs/yaml.rst
+++ b/docs/yaml.rst
@@ -963,6 +963,8 @@ specific actions when certain patterns are detected. This is useful for:
 * ``method``: Action to take when pattern is found:
   - ``warn``: Log a warning message
   - ``kill``: Terminate the job and log an error
+  - ``recover``: Terminate the job, apply a small fix to the configuration, and
+    resubmit the same run (see `Automatic recovery`_ below)
 * ``message``: Custom message to log when pattern is found
 * ``frequency``: How often to check the log file (in seconds)
 
@@ -993,3 +995,67 @@ specific actions when certain patterns are detected. This is useful for:
 1. Use specific patterns to avoid false positives
 2. Include helpful error messages that explain the issue
 3. Test error conditions to ensure they're properly detected
+
+.. _Automatic recovery:
+
+Automatic recovery (``method: recover``)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When ``method: recover`` is used, ESM-Tools will, upon detecting the pattern:
+
+1. Cancel the running compute job (``scancel``)
+2. Persist a recovery state file next to the experiment's ``.date`` file
+   (``<expid>_<setup>.recovery.json``)
+3. Resubmit a fresh ``prepcompute`` → ``compute`` cycle for the **same
+   run_number and date** (no date increment, no loss of progress)
+4. Apply the configured ``fix`` to the component's namelists before the model
+   runs again
+
+The attempt counter is bumped on every retry for the same trigger; once
+``max_retries`` is exceeded, the job is killed like ``method: kill``.
+
+A clean run (no ``recover`` trigger firing) clears the state file
+automatically, so the counter resets for the next unrelated crash.
+
+**Additional parameters**
+
+* ``max_retries``: Maximum number of automatic retries for this trigger
+  (default: 3). Once exhausted, the behaviour falls back to ``kill``.
+* ``fix``: Dict describing the change to apply before resubmission. May
+  contain either or both of:
+
+  - ``namelist_changes``: nested ``namelist -> group -> key: absolute_value``
+    mapping, using the same syntax as the regular ``add_namelist_changes``
+  - ``namelist_deltas``: nested ``namelist -> group -> key: delta`` mapping.
+    The delta is **added** to the current value read from the namelist in
+    ``thisrun_config_dir`` at retry time, and the result is merged into
+    ``namelist_changes``. Useful for tiny perturbations that knock a model
+    off a numerically unstable trajectory without changing its physics.
+
+**Example — FESOM temperature blow-up**
+
+FESOM occasionally crashes with
+``--STOP--> found temperture becomes NaN or <-5.0, >60`` when a bit-reproducible
+trajectory hits a numerical edge case. Perturbing ``K_GM_max`` by ``+0.001``
+is usually enough to nudge the trajectory onto a nearby, stable path.
+
+.. code-block:: yaml
+
+   fesom:
+       check_error:
+           "temperture becomes NaN":
+               method: "recover"
+               message: "FESOM blow-up detected; perturbing K_GM_max and retrying"
+               frequency: 60
+               max_retries: 3
+               fix:
+                   namelist_deltas:
+                       namelist.oce:
+                           oce_dyn:
+                               K_GM_max: 0.001
+
+On each subsequent retry of the same trigger, the perturbation is re-applied
+to the (already perturbed) value, so attempt N ends up at ``K_GM_max + N*0.001``.
+
+To cancel an in-flight recovery manually, remove the ``*.recovery.json`` file
+from the experiment's ``scripts`` directory.

--- a/src/esm_runscripts/observe.py
+++ b/src/esm_runscripts/observe.py
@@ -5,7 +5,7 @@ import time
 import psutil
 from loguru import logger
 
-from . import database_actions, helpers, logfiles
+from . import database_actions, helpers, logfiles, recovery
 
 
 def run_job(config):
@@ -62,16 +62,22 @@ def init_observe_logs(config):
 def wait_and_observe(config):
     if config["general"]["submitted"]:
         thistime = 0
-        error_check_list = assemble_error_list(config)
+        config = assemble_error_list(config)
         while job_is_still_running(config):
             logger.debug("still running")
             config["general"]["next_test_time"] = thistime
             config = check_for_errors(config)
+            if config["general"].get("recovery_pending"):
+                # A ``recover`` trigger fired; compute was scancelled. Stop
+                # polling and let observe finish so maybe_resubmit can pick up
+                # the pending recovery state.
+                break
             thistime = thistime + 10
             time.sleep(10)
         thistime = thistime + 100000000
         config["general"]["next_test_time"] = thistime
-        config = check_for_errors(config)
+        if not config["general"].get("recovery_pending"):
+            config = check_for_errors(config)
     return config
 
 
@@ -91,6 +97,14 @@ def wake_up_call(config):
             # once the log buffer is not needed anymore, after having flushed
             # its content to stdout.
             os.remove(logger.stdout_sink.path)
+    # A retried run that completes without another ``recover`` trigger clears
+    # any stale recovery state so that attempt counters reset for the next run.
+    if (
+        config["general"]["jobtype"] == "observe_compute"
+        and not config["general"].get("recovery_pending")
+        and recovery.load_state(config)
+    ):
+        recovery.clear_state(config)
     logger.debug("job ended, starting to tidy up now \n")
     return config
 
@@ -104,7 +118,7 @@ def assemble_error_list(config):
         config["general"]["error_list"] = []
         return config
 
-    known_methods = ["warn", "kill"]
+    known_methods = ["warn", "kill", "recover"]
 
     stdout = (
         gconfig["thisrun_log_dir"]
@@ -120,44 +134,63 @@ def assemble_error_list(config):
     )
 
     error_list = [
-        ("error", stdout, "warn", 60, 60, "keyword error detected, watch out")
+        {
+            "model": "general",
+            "trigger": "error",
+            "file": stdout,
+            "method": "warn",
+            "next_check": 60,
+            "frequency": 60,
+            "message": "keyword error detected, watch out",
+            "trigger_cfg": {},
+        }
     ]
 
     for model in config:
-        if "check_error" in config[model]:
-            for trigger in config[model]["check_error"]:
-                search_file = stdout
-                method = "warn"
-                frequency = 60
-                message = "keyword " + trigger + " detected, watch out"
-                if isinstance(config[model]["check_error"][trigger], dict):
-                    if "file" in config[model]["check_error"][trigger]:
-                        search_file = config[model]["check_error"][trigger]["file"]
-                        if search_file == "stdout" or search_file == "stderr":
-                            search_file = stdout
-                        elif "@jobid@" in search_file:
-                            search_file = search_file.replace(
-                                "@jobid@", config["general"]["jobid"]
-                            )
-                    if "method" in config[model]["check_error"][trigger]:
-                        method = config[model]["check_error"][trigger]["method"]
-                        if method not in known_methods:
-                            method = "warn"
-                    if "message" in config[model]["check_error"][trigger]:
-                        message = config[model]["check_error"][trigger]["message"]
-                    if "frequency" in config[model]["check_error"][trigger]:
-                        frequency = config[model]["check_error"][trigger]["frequency"]
-                        try:
-                            frequency = int(frequency)
-                        except:
-                            frequency = 60
-                elif isinstance(config[model]["check_error"][trigger], str):
-                    pass
-                else:
-                    continue
-                error_list.append(
-                    (trigger, search_file, method, frequency, frequency, message)
-                )
+        if not isinstance(config[model], dict) or "check_error" not in config[model]:
+            continue
+        for trigger in config[model]["check_error"]:
+            trigger_cfg = config[model]["check_error"][trigger]
+            search_file = stdout
+            method = "warn"
+            frequency = 60
+            message = "keyword " + trigger + " detected, watch out"
+            if isinstance(trigger_cfg, dict):
+                if "file" in trigger_cfg:
+                    search_file = trigger_cfg["file"]
+                    if search_file == "stdout" or search_file == "stderr":
+                        search_file = stdout
+                    elif "@jobid@" in search_file:
+                        search_file = search_file.replace(
+                            "@jobid@", config["general"]["jobid"]
+                        )
+                if "method" in trigger_cfg:
+                    method = trigger_cfg["method"]
+                    if method not in known_methods:
+                        method = "warn"
+                if "message" in trigger_cfg:
+                    message = trigger_cfg["message"]
+                if "frequency" in trigger_cfg:
+                    try:
+                        frequency = int(trigger_cfg["frequency"])
+                    except (TypeError, ValueError):
+                        frequency = 60
+            elif isinstance(trigger_cfg, str):
+                trigger_cfg = {}
+            else:
+                continue
+            error_list.append(
+                {
+                    "model": model,
+                    "trigger": trigger,
+                    "file": search_file,
+                    "method": method,
+                    "next_check": frequency,
+                    "frequency": frequency,
+                    "message": message,
+                    "trigger_cfg": trigger_cfg if isinstance(trigger_cfg, dict) else {},
+                }
+            )
     config["general"]["error_list"] = error_list
     return config
 
@@ -171,14 +204,13 @@ def check_for_errors(config):
     new_list = []
     error_check_list = config["general"]["error_list"]
     time = config["general"]["next_test_time"]
-    for (
-        trigger,
-        search_file,
-        method,
-        next_check,
-        frequency,
-        message,
-    ) in error_check_list:
+    for entry in error_check_list:
+        trigger = entry["trigger"]
+        search_file = entry["file"]
+        method = entry["method"]
+        next_check = entry["next_check"]
+        frequency = entry["frequency"]
+        message = entry["message"]
         warned = 0
         if next_check <= time:
             if os.path.isfile(search_file):
@@ -197,11 +229,42 @@ def check_for_errors(config):
                                 database_actions.database_entry_crashed(config)
                                 os.system(cancel_job)
                                 sys.exit(42)
+                            elif method == "recover":
+                                logger.error(f"ERROR: {message}")
+                                state = recovery.record_trigger(
+                                    config,
+                                    entry["model"],
+                                    trigger,
+                                    entry["trigger_cfg"],
+                                )
+                                if state is None:
+                                    logger.error(
+                                        "Recovery retry budget exhausted; "
+                                        "killing the run."
+                                    )
+                                    logger.stdout_sink.flush_to_stdout()
+                                    database_actions.database_entry_crashed(config)
+                                    os.system(
+                                        f"scancel {config['general']['jobid']}"
+                                    )
+                                    sys.exit(42)
+                                logger.error(
+                                    "Cancelling the compute job; a fresh "
+                                    "prepcompute will be submitted with the "
+                                    "configured fix applied."
+                                )
+                                logger.stdout_sink.flush_to_stdout()
+                                database_actions.database_entry_crashed(config)
+                                os.system(
+                                    f"scancel {config['general']['jobid']}"
+                                )
+                                config["general"]["recovery_pending"] = True
+                                return config
             next_check += frequency
         if warned == 0:
-            new_list.append(
-                (trigger, search_file, method, next_check, frequency, message)
-            )
+            entry = dict(entry)
+            entry["next_check"] = next_check
+            new_list.append(entry)
     config["general"]["error_list"] = new_list
     return config
 

--- a/src/esm_runscripts/observe.py
+++ b/src/esm_runscripts/observe.py
@@ -102,11 +102,56 @@ def wake_up_call(config):
     if (
         config["general"]["jobtype"] == "observe_compute"
         and not config["general"].get("recovery_pending")
-        and recovery.load_state(config)
     ):
-        recovery.clear_state(config)
+        state = recovery.load_state(config)
+        if state or recovery.has_k_gm_max_status_entry(config):
+            recovery.record_success(config)
+        if state:
+            recovery.clear_state(config)
     logger.debug("job ended, starting to tidy up now \n")
     return config
+
+
+def stop_launcher_process(config, timeout=15):
+    """
+    Stop the monitored compute launcher without cancelling the whole batch job.
+
+    ``recover`` runs inside ``observe_compute``, which itself is executed from the
+    same batch script as the model launcher. Cancelling the full job would kill
+    the observer before it reaches ``maybe_resubmit``.
+    """
+    launcher_pid = config["general"].get("launcher_pid")
+    if launcher_pid in [None, -666]:
+        logger.warning("No launcher PID available for recovery shutdown.")
+        return
+
+    try:
+        launcher = psutil.Process(launcher_pid)
+    except psutil.Error as e:
+        logger.warning(f"Could not attach to launcher PID {launcher_pid}: {e}")
+        return
+
+    procs = launcher.children(recursive=True)
+    procs.append(launcher)
+
+    logger.warning(
+        f"Stopping compute launcher PID {launcher_pid} while keeping observe alive."
+    )
+    for proc in reversed(procs):
+        try:
+            proc.terminate()
+        except psutil.Error:
+            pass
+
+    _, alive = psutil.wait_procs(procs, timeout=timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+        except psutil.Error:
+            pass
+
+    if alive:
+        psutil.wait_procs(alive, timeout=5)
 
 
 def assemble_error_list(config):
@@ -244,21 +289,20 @@ def check_for_errors(config):
                                     )
                                     logger.stdout_sink.flush_to_stdout()
                                     database_actions.database_entry_crashed(config)
+                                    recovery.record_failure(config)
                                     os.system(
                                         f"scancel {config['general']['jobid']}"
                                     )
                                     sys.exit(42)
                                 logger.error(
-                                    "Cancelling the compute job; a fresh "
+                                    "Stopping the compute launcher; a fresh "
                                     "prepcompute will be submitted with the "
                                     "configured fix applied."
                                 )
                                 logger.stdout_sink.flush_to_stdout()
                                 database_actions.database_entry_crashed(config)
-                                os.system(
-                                    f"scancel {config['general']['jobid']}"
-                                )
                                 config["general"]["recovery_pending"] = True
+                                stop_launcher_process(config)
                                 return config
             next_check += frequency
         if warned == 0:

--- a/src/esm_runscripts/observe.py
+++ b/src/esm_runscripts/observe.py
@@ -104,7 +104,7 @@ def wake_up_call(config):
         and not config["general"].get("recovery_pending")
     ):
         state = recovery.load_state(config)
-        if state or recovery.has_k_gm_max_status_entry(config):
+        if state or recovery.has_recovery_status_entry(config):
             recovery.record_success(config)
         if state:
             recovery.clear_state(config)

--- a/src/esm_runscripts/prepcompute.py
+++ b/src/esm_runscripts/prepcompute.py
@@ -5,6 +5,7 @@ import time
 
 from loguru import logger
 
+from . import recovery
 from .batch_system import batch_system
 from .filelists import copy_files, log_used_files
 from .helpers import evaluate
@@ -153,6 +154,16 @@ def modify_files(config):
     #         if filetype == "restart":
     #             nothing = "nothing"
     return config
+
+
+def apply_recovery_fix(config):
+    """
+    If a recovery state file is present, merge its ``fix`` block into the
+    target component's ``namelist_changes`` so that the subsequent
+    ``modify_namelists`` step writes the perturbed values into the namelist.
+    No-op when no recovery is pending.
+    """
+    return recovery.apply_fix_to_config(config)
 
 
 def modify_namelists(config):

--- a/src/esm_runscripts/recovery.py
+++ b/src/esm_runscripts/recovery.py
@@ -1,0 +1,225 @@
+"""
+Auto-recovery plugin for ``esm-runscripts``.
+
+Implements the ``recover`` method of the ``check_error`` feature: when a
+configured error pattern is found in a model log, the compute job is killed and
+a small fix (absolute namelist override and/or additive delta) is applied
+before the same run is resubmitted.
+
+State persists across process boundaries in a JSON file next to the
+experiment's ``.date`` file so that a fresh ``SimulationSetup`` (spawned by
+``resubmit.maybe_resubmit``) can pick up the pending fix.
+"""
+
+import json
+import os
+
+import f90nml
+from loguru import logger
+
+
+def _state_path(config):
+    return (
+        f"{config['general']['experiment_scripts_dir']}"
+        f"/{config['general']['expid']}_{config['general']['setup_name']}"
+        f".recovery.json"
+    )
+
+
+def load_state(config):
+    path = _state_path(config)
+    if not os.path.isfile(path):
+        return None
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Could not read recovery state at {path}: {e}")
+        return None
+
+
+def _write_state(config, state):
+    path = _state_path(config)
+    with open(path, "w") as fh:
+        json.dump(state, fh, indent=2)
+    logger.info(f"Recovery state written to {path}")
+
+
+def clear_state(config):
+    path = _state_path(config)
+    if os.path.isfile(path):
+        os.remove(path)
+        logger.info(f"Cleared recovery state at {path}")
+
+
+def record_trigger(config, component, trigger, trigger_cfg):
+    """
+    Called by observe.py when a ``recover`` trigger fires. Creates or updates
+    the recovery state file, bumping the attempt counter if the same trigger
+    has already fired before.
+
+    Returns the updated state dict, or ``None`` if max_retries is already
+    exhausted (caller should log an error and stop).
+    """
+    max_retries = int(trigger_cfg.get("max_retries", 3))
+    fix = trigger_cfg.get("fix", {}) or {}
+
+    current = load_state(config) or {}
+    prev_attempt = 0
+    if (
+        current.get("active")
+        and current.get("trigger") == trigger
+        and current.get("component") == component
+    ):
+        prev_attempt = int(current.get("attempt", 0))
+
+    attempt = prev_attempt + 1
+    if attempt > max_retries:
+        logger.error(
+            f"Recovery trigger '{trigger}' in component '{component}' has "
+            f"already been retried {prev_attempt} times (max_retries="
+            f"{max_retries}); giving up."
+        )
+        return None
+
+    state = {
+        "active": True,
+        "component": component,
+        "trigger": trigger,
+        "attempt": attempt,
+        "max_retries": max_retries,
+        "run_number": config["general"].get("run_number"),
+        "run_date": str(config["general"].get("current_date")),
+        "fix": fix,
+        "message": trigger_cfg.get("message", ""),
+    }
+    _write_state(config, state)
+    return state
+
+
+def has_pending_recovery(config):
+    state = load_state(config)
+    return bool(state and state.get("active"))
+
+
+def _merge_namelist_changes(target, addition):
+    for nml_name, groups in (addition or {}).items():
+        target.setdefault(nml_name, {})
+        for group, entries in (groups or {}).items():
+            target[nml_name].setdefault(group, {})
+            target[nml_name][group].update(entries or {})
+
+
+def _resolve_deltas(config, component, deltas):
+    """
+    Turn a nested delta spec into absolute namelist_changes by reading the
+    current value from the namelist file in ``thisrun_config_dir`` and adding
+    the delta. Keeps integer/float typing consistent with the source value.
+    """
+    resolved = {}
+    cfg_dir = config[component].get("thisrun_config_dir")
+    if not cfg_dir or not os.path.isdir(cfg_dir):
+        logger.warning(
+            f"Cannot apply namelist_deltas for '{component}': "
+            f"thisrun_config_dir unavailable."
+        )
+        return resolved
+
+    for nml_name, groups in (deltas or {}).items():
+        nml_path = os.path.join(cfg_dir, nml_name)
+        if not os.path.isfile(nml_path):
+            logger.warning(
+                f"Recovery delta targets missing namelist: {nml_path}; skipping."
+            )
+            continue
+        nml = f90nml.read(nml_path)
+        for group, entries in (groups or {}).items():
+            for key, delta in (entries or {}).items():
+                try:
+                    current = nml[group][key]
+                except KeyError:
+                    logger.warning(
+                        f"Recovery delta target {nml_name}:{group}:{key} not "
+                        f"found in namelist; skipping."
+                    )
+                    continue
+                new_value = current + delta
+                if isinstance(current, int) and isinstance(delta, int):
+                    new_value = int(new_value)
+                resolved.setdefault(nml_name, {}).setdefault(group, {})[key] = (
+                    new_value
+                )
+                logger.info(
+                    f"Recovery perturbation: {nml_name}:{group}:{key} "
+                    f"{current} -> {new_value} (delta {delta:+})"
+                )
+    return resolved
+
+
+def apply_fix_to_config(config):
+    """
+    Called from prepcompute. If a recovery state is active, merges its ``fix``
+    block into the target component's ``namelist_changes`` so that the normal
+    ``Namelist.nmls_modify`` step picks it up.
+    """
+    state = load_state(config)
+    if not state or not state.get("active"):
+        return config
+
+    expected_run = config["general"].get("run_number")
+    if state.get("run_number") != expected_run:
+        logger.warning(
+            f"Stale recovery state (run_number={state.get('run_number')} vs "
+            f"current {expected_run}); clearing without applying."
+        )
+        clear_state(config)
+        return config
+
+    component = state["component"]
+    if component not in config:
+        logger.warning(
+            f"Recovery targets component '{component}' which is not in this "
+            f"config; clearing state."
+        )
+        clear_state(config)
+        return config
+
+    logger.warning(
+        "=" * 70
+        + f"\nAPPLYING RECOVERY FIX (attempt {state['attempt']}/"
+        f"{state['max_retries']}) for trigger '{state['trigger']}' in "
+        f"component '{component}'\n"
+        + (f"Reason: {state['message']}\n" if state.get("message") else "")
+        + "=" * 70
+    )
+
+    fix = state.get("fix", {}) or {}
+    absolute = fix.get("namelist_changes", {}) or {}
+    deltas = fix.get("namelist_deltas", {}) or {}
+
+    resolved_deltas = _resolve_deltas(config, component, deltas)
+
+    target = config[component].setdefault("namelist_changes", {})
+    _merge_namelist_changes(target, absolute)
+    _merge_namelist_changes(target, resolved_deltas)
+
+    return config
+
+
+def trigger_recovery_resubmit(config):
+    """
+    Called from ``resubmit.maybe_resubmit`` when a recovery is pending. Skips
+    the normal date increment and directly submits a fresh ``SimulationSetup``
+    for ``prepcompute`` (same run_number, same date). The pending state is
+    left in place so ``apply_fix_to_config`` can consume it.
+    """
+    state = load_state(config)
+    logger.warning(
+        f"Recovery pending (attempt {state['attempt']}/{state['max_retries']}"
+        f") — resubmitting prepcompute for the same run."
+    )
+
+    from . import resubmit
+
+    resubmit.resubmit_SimulationSetup(config, "prepcompute")
+    return config

--- a/src/esm_runscripts/recovery.py
+++ b/src/esm_runscripts/recovery.py
@@ -26,6 +26,14 @@ def _state_path(config):
     )
 
 
+def _k_gm_max_status_path(config):
+    return (
+        f"{config['general']['experiment_scripts_dir']}"
+        f"/{config['general']['expid']}_{config['general']['setup_name']}"
+        f".recovery_k_gm_max_status.dat"
+    )
+
+
 def load_state(config):
     path = _state_path(config)
     if not os.path.isfile(path):
@@ -50,6 +58,157 @@ def clear_state(config):
     if os.path.isfile(path):
         os.remove(path)
         logger.info(f"Cleared recovery state at {path}")
+
+
+def _format_numeric(value):
+    return f"{float(value):.15g}"
+
+
+def _tracking_year(config, state=None):
+    if state and state.get("run_date"):
+        try:
+            return int(str(state["run_date"])[:4])
+        except (TypeError, ValueError):
+            pass
+
+    current_date = config["general"].get("current_date")
+    if current_date is not None:
+        try:
+            return int(current_date.year)
+        except AttributeError:
+            try:
+                return int(str(current_date)[:4])
+            except (TypeError, ValueError):
+                pass
+
+    return None
+
+
+def _load_k_gm_max_status_entries(config):
+    path = _k_gm_max_status_path(config)
+    entries = {}
+    if not os.path.isfile(path):
+        return entries
+
+    with open(path) as fh:
+        for lineno, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parts = stripped.split()
+            if len(parts) != 3:
+                logger.warning(
+                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
+                    "expected 3 columns."
+                )
+                continue
+            try:
+                year = int(parts[0])
+                value = float(parts[1])
+                status = int(parts[2])
+            except ValueError:
+                logger.warning(
+                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
+                    "could not parse numeric fields."
+                )
+                continue
+            entries[year] = (value, status)
+    return entries
+
+
+def _write_k_gm_max_status_entries(config, entries):
+    path = _k_gm_max_status_path(config)
+    with open(path, "w") as fh:
+        for year in sorted(entries):
+            value, status = entries[year]
+            fh.write(f"{year} {_format_numeric(value)} {int(status)}\n")
+    logger.info(f"Recovery k_gm_max status written to {path}")
+
+
+def has_k_gm_max_status_entry(config, year=None):
+    if year is None:
+        year = _tracking_year(config)
+    if year is None:
+        return False
+    return year in _load_k_gm_max_status_entries(config)
+
+
+def _read_k_gm_max_from_namelist(path):
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        nml = f90nml.read(path)
+        return nml["oce_dyn"]["k_gm_max"]
+    except (OSError, KeyError, TypeError, ValueError) as e:
+        logger.warning(f"Could not read k_gm_max from {path}: {e}")
+        return None
+
+
+def _current_k_gm_max(config):
+    work_dir = config["general"].get("thisrun_work_dir")
+    if work_dir:
+        value = _read_k_gm_max_from_namelist(os.path.join(work_dir, "namelist.oce"))
+        if value is not None:
+            return value
+
+    fesom_cfg = config.get("fesom", {})
+    cfg_dir = fesom_cfg.get("thisrun_config_dir")
+    if cfg_dir:
+        value = _read_k_gm_max_from_namelist(os.path.join(cfg_dir, "namelist.oce"))
+        if value is not None:
+            return value
+
+    return None
+
+
+def _pending_k_gm_max(target_changes):
+    return (
+        target_changes.get("namelist.oce", {})
+        .get("oce_dyn", {})
+        .get("k_gm_max")
+    )
+
+
+def update_k_gm_max_status(config, status, value=None, year=None):
+    if year is None:
+        year = _tracking_year(config)
+    if year is None:
+        logger.warning("Could not determine year for recovery k_gm_max status.")
+        return
+
+    entries = _load_k_gm_max_status_entries(config)
+    if value is None and year in entries:
+        value = entries[year][0]
+    if value is None:
+        value = _current_k_gm_max(config)
+    if value is None:
+        logger.warning(
+            f"Could not determine k_gm_max for year {year}; skipping status update."
+        )
+        return
+
+    entries[year] = (float(value), int(status))
+    _write_k_gm_max_status_entries(config, entries)
+
+
+def record_pending_k_gm_max(config, state, target_changes):
+    value = _pending_k_gm_max(target_changes)
+    if value is None:
+        return
+    update_k_gm_max_status(
+        config,
+        status=0,
+        value=value,
+        year=_tracking_year(config, state),
+    )
+
+
+def record_success(config):
+    update_k_gm_max_status(config, status=1)
+
+
+def record_failure(config):
+    update_k_gm_max_status(config, status=0)
 
 
 def record_trigger(config, component, trigger, trigger_cfg):
@@ -110,6 +269,32 @@ def _merge_namelist_changes(target, addition):
             target[nml_name][group].update(entries or {})
 
 
+def _get_recovery_namelist_path(config, component, nml_name):
+    """
+    Return the best namelist path to use as the baseline for additive recovery
+    deltas.
+
+    For retries of the SAME run, ``copy_files_to_thisrun`` refreshes the
+    ``thisrun_config_dir`` from the original inputs before ``apply_recovery_fix``
+    runs. To make additive perturbations accumulate across retries, prefer the
+    namelist from the existing ``work`` directory when present, and fall back to
+    ``thisrun_config_dir`` otherwise.
+    """
+    work_dir = config["general"].get("thisrun_work_dir")
+    if work_dir:
+        work_path = os.path.join(work_dir, nml_name)
+        if os.path.isfile(work_path):
+            return work_path
+
+    cfg_dir = config[component].get("thisrun_config_dir")
+    if cfg_dir:
+        cfg_path = os.path.join(cfg_dir, nml_name)
+        if os.path.isfile(cfg_path):
+            return cfg_path
+
+    return None
+
+
 def _resolve_deltas(config, component, deltas):
     """
     Turn a nested delta spec into absolute namelist_changes by reading the
@@ -118,18 +303,23 @@ def _resolve_deltas(config, component, deltas):
     """
     resolved = {}
     cfg_dir = config[component].get("thisrun_config_dir")
-    if not cfg_dir or not os.path.isdir(cfg_dir):
+    work_dir = config["general"].get("thisrun_work_dir")
+    if (
+        (not cfg_dir or not os.path.isdir(cfg_dir))
+        and (not work_dir or not os.path.isdir(work_dir))
+    ):
         logger.warning(
             f"Cannot apply namelist_deltas for '{component}': "
-            f"thisrun_config_dir unavailable."
+            f"neither thisrun_config_dir nor thisrun_work_dir is available."
         )
         return resolved
 
     for nml_name, groups in (deltas or {}).items():
-        nml_path = os.path.join(cfg_dir, nml_name)
-        if not os.path.isfile(nml_path):
+        nml_path = _get_recovery_namelist_path(config, component, nml_name)
+        if not nml_path:
             logger.warning(
-                f"Recovery delta targets missing namelist: {nml_path}; skipping."
+                f"Recovery delta targets missing namelist '{nml_name}' in "
+                f"thisrun_work_dir/thisrun_config_dir; skipping."
             )
             continue
         nml = f90nml.read(nml_path)
@@ -151,7 +341,7 @@ def _resolve_deltas(config, component, deltas):
                 )
                 logger.info(
                     f"Recovery perturbation: {nml_name}:{group}:{key} "
-                    f"{current} -> {new_value} (delta {delta:+})"
+                    f"{current} -> {new_value} (delta {delta:+}; source {nml_path})"
                 )
     return resolved
 
@@ -202,6 +392,7 @@ def apply_fix_to_config(config):
     target = config[component].setdefault("namelist_changes", {})
     _merge_namelist_changes(target, absolute)
     _merge_namelist_changes(target, resolved_deltas)
+    record_pending_k_gm_max(config, state, target)
 
     return config
 

--- a/src/esm_runscripts/recovery.py
+++ b/src/esm_runscripts/recovery.py
@@ -13,13 +13,12 @@ Two pieces of state are written to the experiment's ``scripts`` directory:
   ``SimulationSetup`` → ``prepcompute`` boundary. Removed once a retried run
   finishes without firing a ``recover`` trigger again.
 
-* ``<expid>_<setup>.recovery_status.dat`` — long-lived per-year log of
+* ``<expid>_<setup>.recovery_status.jsonl`` — long-lived per-year log of
   every run that needed recovery, which namelist entries were perturbed, and
-  whether the retry eventually succeeded. The file is generic: any keys
-  present in the trigger's ``fix.namelist_changes`` / ``fix.namelist_deltas``
-  are flattened to ``<namelist>:<group>:<key>`` tokens and appended to the
-  row for that year. Setup-specific post-processing (e.g. plotting FESOM's
-  ``K_GM_max`` history) can read it without requiring any changes here.
+  whether the retry eventually succeeded. Each line is a self-describing
+  JSON object (JSONL format) with keys ``year``, ``status``, and
+  ``values``. Setup-specific post-processing (e.g. plotting FESOM's
+  ``K_GM_max`` history) can read it with any JSON-aware tool.
 """
 
 import json
@@ -41,7 +40,7 @@ def _status_path(config):
     return (
         f"{config['general']['experiment_scripts_dir']}"
         f"/{config['general']['expid']}_{config['general']['setup_name']}"
-        f".recovery_status.dat"
+        f".recovery_status.jsonl"
     )
 
 
@@ -71,23 +70,6 @@ def clear_state(config):
         logger.info(f"Cleared recovery state at {path}")
 
 
-def _format_value(value):
-    if isinstance(value, float):
-        return f"{value:.15g}"
-    return str(value)
-
-
-def _parse_value(text):
-    try:
-        return int(text)
-    except ValueError:
-        pass
-    try:
-        return float(text)
-    except ValueError:
-        return text
-
-
 def _tracking_year(config, state=None):
     if state and state.get("run_date"):
         try:
@@ -110,11 +92,10 @@ def _tracking_year(config, state=None):
 
 def _load_status_entries(config):
     """
-    Parse the recovery status file. Each non-empty line has the form::
+    Parse the JSONL recovery status file. Each line is a JSON object with
+    keys ``year``, ``status``, and ``values``.
 
-        <year> <status> [<namelist>:<group>:<key>=<value> ...]
-
-    Returns ``{year: {"status": int, "values": {flat_key: value}}}``.
+    Returns ``{year: {"status": str, "values": {flat_key: value}}}``.
     """
     path = _status_path(config)
     entries = {}
@@ -126,29 +107,26 @@ def _load_status_entries(config):
             stripped = line.strip()
             if not stripped:
                 continue
-            parts = stripped.split()
-            if len(parts) < 2:
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError as exc:
                 logger.warning(
-                    f"Malformed recovery status line {lineno} in {path}; "
-                    "expected at least <year> <status>."
+                    f"Malformed JSONL on line {lineno} in {path}: {exc}"
                 )
                 continue
             try:
-                year = int(parts[0])
-                status = int(parts[1])
-            except ValueError:
+                year = int(record["year"])
+                status = str(record["status"])
+            except (KeyError, ValueError, TypeError) as exc:
                 logger.warning(
-                    f"Malformed recovery status line {lineno} in {path}; "
-                    "could not parse year/status."
+                    f"Missing or invalid year/status on line {lineno} "
+                    f"in {path}: {exc}"
                 )
                 continue
-            values = {}
-            for item in parts[2:]:
-                if "=" not in item:
-                    continue
-                key, _, raw = item.partition("=")
-                values[key] = _parse_value(raw)
-            entries[year] = {"status": status, "values": values}
+            entries[year] = {
+                "status": status,
+                "values": record.get("values", {}),
+            }
     return entries
 
 
@@ -157,10 +135,12 @@ def _write_status_entries(config, entries):
     with open(path, "w") as fh:
         for year in sorted(entries):
             entry = entries[year]
-            tokens = [str(year), str(int(entry["status"]))]
-            for key in sorted(entry.get("values", {})):
-                tokens.append(f"{key}={_format_value(entry['values'][key])}")
-            fh.write(" ".join(tokens) + "\n")
+            record = {
+                "year": year,
+                "status": entry["status"],
+                "values": entry.get("values", {}),
+            }
+            fh.write(json.dumps(record) + "\n")
     logger.info(f"Recovery status written to {path}")
 
 
@@ -176,8 +156,8 @@ def update_recovery_status(config, status, values=None, year=None):
     """
     Update (or create) the status row for ``year``. ``values`` is an optional
     flat ``{namelist:group:key: value}`` mapping that is merged into the row's
-    existing values. ``status`` is ``1`` on success, ``0`` for
-    failure / still-pending.
+    existing values. ``status`` is one of ``"success"``, ``"pending"``, or
+    ``"failed"``.
     """
     if year is None:
         year = _tracking_year(config)
@@ -189,7 +169,7 @@ def update_recovery_status(config, status, values=None, year=None):
     merged_values = dict(entries.get(year, {}).get("values", {}))
     if values:
         merged_values.update(values)
-    entries[year] = {"status": int(status), "values": merged_values}
+    entries[year] = {"status": status, "values": merged_values}
     _write_status_entries(config, entries)
 
 
@@ -235,18 +215,18 @@ def record_pending_recovery(config, state, resolved_deltas):
         return
     update_recovery_status(
         config,
-        status=0,
+        status="pending",
         values=flat,
         year=_tracking_year(config, state),
     )
 
 
 def record_success(config):
-    update_recovery_status(config, status=1)
+    update_recovery_status(config, status="success")
 
 
 def record_failure(config):
-    update_recovery_status(config, status=0)
+    update_recovery_status(config, status="failed")
 
 
 def record_trigger(config, component, trigger, trigger_cfg):

--- a/src/esm_runscripts/recovery.py
+++ b/src/esm_runscripts/recovery.py
@@ -2,13 +2,24 @@
 Auto-recovery plugin for ``esm-runscripts``.
 
 Implements the ``recover`` method of the ``check_error`` feature: when a
-configured error pattern is found in a model log, the compute job is killed and
-a small fix (absolute namelist override and/or additive delta) is applied
-before the same run is resubmitted.
+configured error pattern is found in a model log, the running compute
+launcher is stopped and a small fix (absolute namelist override and/or
+additive delta) is applied before the same run is resubmitted.
 
-State persists across process boundaries in a JSON file next to the
-experiment's ``.date`` file so that a fresh ``SimulationSetup`` (spawned by
-``resubmit.maybe_resubmit``) can pick up the pending fix.
+Two pieces of state are written to the experiment's ``scripts`` directory:
+
+* ``<expid>_<setup>.recovery.json`` — short-lived JSON that carries the
+  pending fix across the ``observe`` → ``maybe_resubmit`` → fresh
+  ``SimulationSetup`` → ``prepcompute`` boundary. Removed once a retried run
+  finishes without firing a ``recover`` trigger again.
+
+* ``<expid>_<setup>.recovery_status.dat`` — long-lived per-year log of
+  every run that needed recovery, which namelist entries were perturbed, and
+  whether the retry eventually succeeded. The file is generic: any keys
+  present in the trigger's ``fix.namelist_changes`` / ``fix.namelist_deltas``
+  are flattened to ``<namelist>:<group>:<key>`` tokens and appended to the
+  row for that year. Setup-specific post-processing (e.g. plotting FESOM's
+  ``K_GM_max`` history) can read it without requiring any changes here.
 """
 
 import json
@@ -26,11 +37,11 @@ def _state_path(config):
     )
 
 
-def _k_gm_max_status_path(config):
+def _status_path(config):
     return (
         f"{config['general']['experiment_scripts_dir']}"
         f"/{config['general']['expid']}_{config['general']['setup_name']}"
-        f".recovery_k_gm_max_status.dat"
+        f".recovery_status.dat"
     )
 
 
@@ -60,8 +71,21 @@ def clear_state(config):
         logger.info(f"Cleared recovery state at {path}")
 
 
-def _format_numeric(value):
-    return f"{float(value):.15g}"
+def _format_value(value):
+    if isinstance(value, float):
+        return f"{value:.15g}"
+    return str(value)
+
+
+def _parse_value(text):
+    try:
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        return float(text)
+    except ValueError:
+        return text
 
 
 def _tracking_year(config, state=None):
@@ -84,8 +108,15 @@ def _tracking_year(config, state=None):
     return None
 
 
-def _load_k_gm_max_status_entries(config):
-    path = _k_gm_max_status_path(config)
+def _load_status_entries(config):
+    """
+    Parse the recovery status file. Each non-empty line has the form::
+
+        <year> <status> [<namelist>:<group>:<key>=<value> ...]
+
+    Returns ``{year: {"status": int, "values": {flat_key: value}}}``.
+    """
+    path = _status_path(config)
     entries = {}
     if not os.path.isfile(path):
         return entries
@@ -96,119 +127,126 @@ def _load_k_gm_max_status_entries(config):
             if not stripped:
                 continue
             parts = stripped.split()
-            if len(parts) != 3:
+            if len(parts) < 2:
                 logger.warning(
-                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
-                    "expected 3 columns."
+                    f"Malformed recovery status line {lineno} in {path}; "
+                    "expected at least <year> <status>."
                 )
                 continue
             try:
                 year = int(parts[0])
-                value = float(parts[1])
-                status = int(parts[2])
+                status = int(parts[1])
             except ValueError:
                 logger.warning(
-                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
-                    "could not parse numeric fields."
+                    f"Malformed recovery status line {lineno} in {path}; "
+                    "could not parse year/status."
                 )
                 continue
-            entries[year] = (value, status)
+            values = {}
+            for item in parts[2:]:
+                if "=" not in item:
+                    continue
+                key, _, raw = item.partition("=")
+                values[key] = _parse_value(raw)
+            entries[year] = {"status": status, "values": values}
     return entries
 
 
-def _write_k_gm_max_status_entries(config, entries):
-    path = _k_gm_max_status_path(config)
+def _write_status_entries(config, entries):
+    path = _status_path(config)
     with open(path, "w") as fh:
         for year in sorted(entries):
-            value, status = entries[year]
-            fh.write(f"{year} {_format_numeric(value)} {int(status)}\n")
-    logger.info(f"Recovery k_gm_max status written to {path}")
+            entry = entries[year]
+            tokens = [str(year), str(int(entry["status"]))]
+            for key in sorted(entry.get("values", {})):
+                tokens.append(f"{key}={_format_value(entry['values'][key])}")
+            fh.write(" ".join(tokens) + "\n")
+    logger.info(f"Recovery status written to {path}")
 
 
-def has_k_gm_max_status_entry(config, year=None):
+def has_recovery_status_entry(config, year=None):
     if year is None:
         year = _tracking_year(config)
     if year is None:
         return False
-    return year in _load_k_gm_max_status_entries(config)
+    return year in _load_status_entries(config)
 
 
-def _read_k_gm_max_from_namelist(path):
-    if not path or not os.path.isfile(path):
-        return None
-    try:
-        nml = f90nml.read(path)
-        return nml["oce_dyn"]["k_gm_max"]
-    except (OSError, KeyError, TypeError, ValueError) as e:
-        logger.warning(f"Could not read k_gm_max from {path}: {e}")
-        return None
-
-
-def _current_k_gm_max(config):
-    work_dir = config["general"].get("thisrun_work_dir")
-    if work_dir:
-        value = _read_k_gm_max_from_namelist(os.path.join(work_dir, "namelist.oce"))
-        if value is not None:
-            return value
-
-    fesom_cfg = config.get("fesom", {})
-    cfg_dir = fesom_cfg.get("thisrun_config_dir")
-    if cfg_dir:
-        value = _read_k_gm_max_from_namelist(os.path.join(cfg_dir, "namelist.oce"))
-        if value is not None:
-            return value
-
-    return None
-
-
-def _pending_k_gm_max(target_changes):
-    return (
-        target_changes.get("namelist.oce", {})
-        .get("oce_dyn", {})
-        .get("k_gm_max")
-    )
-
-
-def update_k_gm_max_status(config, status, value=None, year=None):
+def update_recovery_status(config, status, values=None, year=None):
+    """
+    Update (or create) the status row for ``year``. ``values`` is an optional
+    flat ``{namelist:group:key: value}`` mapping that is merged into the row's
+    existing values. ``status`` is ``1`` on success, ``0`` for
+    failure / still-pending.
+    """
     if year is None:
         year = _tracking_year(config)
     if year is None:
-        logger.warning("Could not determine year for recovery k_gm_max status.")
+        logger.warning("Could not determine year for recovery status.")
         return
 
-    entries = _load_k_gm_max_status_entries(config)
-    if value is None and year in entries:
-        value = entries[year][0]
-    if value is None:
-        value = _current_k_gm_max(config)
-    if value is None:
-        logger.warning(
-            f"Could not determine k_gm_max for year {year}; skipping status update."
-        )
+    entries = _load_status_entries(config)
+    merged_values = dict(entries.get(year, {}).get("values", {}))
+    if values:
+        merged_values.update(values)
+    entries[year] = {"status": int(status), "values": merged_values}
+    _write_status_entries(config, entries)
+
+
+def _flatten_fix_values(fix, resolved_deltas):
+    """
+    Flatten the ``fix`` block to ``{namelist:group:key: value}`` entries. The
+    ``namelist_deltas`` section contributes the *resolved* absolute value (not
+    the delta itself) so the log records what actually ended up in the
+    namelist.
+    """
+    flat = {}
+
+    absolute = (fix or {}).get("namelist_changes", {}) or {}
+    for nml, groups in absolute.items():
+        for group, entries in (groups or {}).items():
+            for key, value in (entries or {}).items():
+                flat[f"{nml}:{group}:{key}"] = value
+
+    deltas = (fix or {}).get("namelist_deltas", {}) or {}
+    for nml, groups in deltas.items():
+        for group, entries in (groups or {}).items():
+            for key in (entries or {}):
+                resolved = (
+                    resolved_deltas.get(nml, {})
+                    .get(group, {})
+                    .get(key)
+                )
+                if resolved is not None:
+                    flat[f"{nml}:{group}:{key}"] = resolved
+
+    return flat
+
+
+def record_pending_recovery(config, state, resolved_deltas):
+    """
+    Persist the resolved fix values for the current retry as a status row with
+    ``status=0`` (pending). Called from ``apply_fix_to_config`` so the values
+    survive across process boundaries regardless of which component is being
+    patched.
+    """
+    flat = _flatten_fix_values(state.get("fix", {}), resolved_deltas)
+    if not flat:
         return
-
-    entries[year] = (float(value), int(status))
-    _write_k_gm_max_status_entries(config, entries)
-
-
-def record_pending_k_gm_max(config, state, target_changes):
-    value = _pending_k_gm_max(target_changes)
-    if value is None:
-        return
-    update_k_gm_max_status(
+    update_recovery_status(
         config,
         status=0,
-        value=value,
+        values=flat,
         year=_tracking_year(config, state),
     )
 
 
 def record_success(config):
-    update_k_gm_max_status(config, status=1)
+    update_recovery_status(config, status=1)
 
 
 def record_failure(config):
-    update_k_gm_max_status(config, status=0)
+    update_recovery_status(config, status=0)
 
 
 def record_trigger(config, component, trigger, trigger_cfg):
@@ -298,8 +336,10 @@ def _get_recovery_namelist_path(config, component, nml_name):
 def _resolve_deltas(config, component, deltas):
     """
     Turn a nested delta spec into absolute namelist_changes by reading the
-    current value from the namelist file in ``thisrun_config_dir`` and adding
-    the delta. Keeps integer/float typing consistent with the source value.
+    current value from the component's namelist and adding the delta. Prefers
+    the value from ``thisrun_work_dir`` (so additive deltas accumulate across
+    same-run retries) and falls back to ``thisrun_config_dir``. Keeps
+    integer/float typing consistent with the source value.
     """
     resolved = {}
     cfg_dir = config[component].get("thisrun_config_dir")
@@ -350,7 +390,8 @@ def apply_fix_to_config(config):
     """
     Called from prepcompute. If a recovery state is active, merges its ``fix``
     block into the target component's ``namelist_changes`` so that the normal
-    ``Namelist.nmls_modify`` step picks it up.
+    ``Namelist.nmls_modify`` step picks it up, and appends the resolved values
+    to the long-lived recovery status log.
     """
     state = load_state(config)
     if not state or not state.get("active"):
@@ -392,7 +433,7 @@ def apply_fix_to_config(config):
     target = config[component].setdefault("namelist_changes", {})
     _merge_namelist_changes(target, absolute)
     _merge_namelist_changes(target, resolved_deltas)
-    record_pending_k_gm_max(config, state, target)
+    record_pending_recovery(config, state, resolved_deltas)
 
     return config
 

--- a/src/esm_runscripts/resubmit.py
+++ b/src/esm_runscripts/resubmit.py
@@ -2,7 +2,7 @@ import os
 
 from loguru import logger
 
-from . import chunky_parts, helpers, logfiles, workflow
+from . import chunky_parts, helpers, logfiles, recovery, workflow
 
 
 def submit(config):
@@ -135,6 +135,13 @@ def check_if_check(config):
 
 def maybe_resubmit(config):
     jobtype = config["general"]["jobtype"]
+
+    # Recovery hook: if observe just detected a recoverable error during this
+    # compute, skip the normal chain (tidy / next run) and resubmit
+    # prepcompute for the SAME run_number and date instead.
+    if jobtype == "compute" and config["general"].get("recovery_pending"):
+        recovery.trigger_recovery_resubmit(config)
+        return config
 
     nextrun = resubmit_recursively(config, jobtype=jobtype)
 


### PR DESCRIPTION
When ``method: recover`` is set on a ``check_error`` trigger, observe now cancels the running srun, persists a JSON state file next to the .date file, and lets maybe_resubmit re-launch prepcompute -> compute for the SAME run_number and date. A new prepcompute step (``apply_recovery_fix``) merges the configured ``fix`` block into namelist_changes before the namelist is written: ``namelist_changes`` for absolute overrides, ``namelist_deltas`` for additive perturbations (read current value from thisrun_config_dir, add delta, write back). ``max_retries`` caps attempts per-trigger; clean runs clear any stale state so counters reset.

Primary motivating use case: nudging FESOM off a numerically unstable trajectory by perturbing K_GM_max by +0.001 after a temperature blow-up.