### PR TITLE
Fix recover resubmission and persist k_gm_max status

### DIFF
--- a/configs/setups/awiesm/awiesm.yaml
+++ b/configs/setups/awiesm/awiesm.yaml
@@ -47,6 +47,7 @@ general:
                 - "wait_for_iterative_coupling"
                 - "prep_icebergs"                       # Plugin
                 - "copy_files_to_thisrun"
+                - "apply_recovery_fix"
                 - "modify_namelists"
                 - "apply_iceberg_calving_to_namelists"  # Plugin
                 - "modify_files"

--- a/src/esm_runscripts/observe.py
+++ b/src/esm_runscripts/observe.py
@@ -102,11 +102,56 @@ def wake_up_call(config):
     if (
         config["general"]["jobtype"] == "observe_compute"
         and not config["general"].get("recovery_pending")
-        and recovery.load_state(config)
     ):
-        recovery.clear_state(config)
+        state = recovery.load_state(config)
+        if state or recovery.has_k_gm_max_status_entry(config):
+            recovery.record_success(config)
+        if state:
+            recovery.clear_state(config)
     logger.debug("job ended, starting to tidy up now \n")
     return config
+
+
+def stop_launcher_process(config, timeout=15):
+    """
+    Stop the monitored compute launcher without cancelling the whole batch job.
+
+    ``recover`` runs inside ``observe_compute``, which itself is executed from the
+    same batch script as the model launcher. Cancelling the full job would kill
+    the observer before it reaches ``maybe_resubmit``.
+    """
+    launcher_pid = config["general"].get("launcher_pid")
+    if launcher_pid in [None, -666]:
+        logger.warning("No launcher PID available for recovery shutdown.")
+        return
+
+    try:
+        launcher = psutil.Process(launcher_pid)
+    except psutil.Error as e:
+        logger.warning(f"Could not attach to launcher PID {launcher_pid}: {e}")
+        return
+
+    procs = launcher.children(recursive=True)
+    procs.append(launcher)
+
+    logger.warning(
+        f"Stopping compute launcher PID {launcher_pid} while keeping observe alive."
+    )
+    for proc in reversed(procs):
+        try:
+            proc.terminate()
+        except psutil.Error:
+            pass
+
+    _, alive = psutil.wait_procs(procs, timeout=timeout)
+    for proc in alive:
+        try:
+            proc.kill()
+        except psutil.Error:
+            pass
+
+    if alive:
+        psutil.wait_procs(alive, timeout=5)
 
 
 def assemble_error_list(config):
@@ -244,21 +289,20 @@ def check_for_errors(config):
                                     )
                                     logger.stdout_sink.flush_to_stdout()
                                     database_actions.database_entry_crashed(config)
+                                    recovery.record_failure(config)
                                     os.system(
                                         f"scancel {config['general']['jobid']}"
                                     )
                                     sys.exit(42)
                                 logger.error(
-                                    "Cancelling the compute job; a fresh "
+                                    "Stopping the compute launcher; a fresh "
                                     "prepcompute will be submitted with the "
                                     "configured fix applied."
                                 )
                                 logger.stdout_sink.flush_to_stdout()
                                 database_actions.database_entry_crashed(config)
-                                os.system(
-                                    f"scancel {config['general']['jobid']}"
-                                )
                                 config["general"]["recovery_pending"] = True
+                                stop_launcher_process(config)
                                 return config
             next_check += frequency
         if warned == 0:

--- a/src/esm_runscripts/recovery.py
+++ b/src/esm_runscripts/recovery.py
@@ -26,6 +26,14 @@ def _state_path(config):
     )
 
 
+def _k_gm_max_status_path(config):
+    return (
+        f"{config['general']['experiment_scripts_dir']}"
+        f"/{config['general']['expid']}_{config['general']['setup_name']}"
+        f".recovery_k_gm_max_status.dat"
+    )
+
+
 def load_state(config):
     path = _state_path(config)
     if not os.path.isfile(path):
@@ -50,6 +58,157 @@ def clear_state(config):
     if os.path.isfile(path):
         os.remove(path)
         logger.info(f"Cleared recovery state at {path}")
+
+
+def _format_numeric(value):
+    return f"{float(value):.15g}"
+
+
+def _tracking_year(config, state=None):
+    if state and state.get("run_date"):
+        try:
+            return int(str(state["run_date"])[:4])
+        except (TypeError, ValueError):
+            pass
+
+    current_date = config["general"].get("current_date")
+    if current_date is not None:
+        try:
+            return int(current_date.year)
+        except AttributeError:
+            try:
+                return int(str(current_date)[:4])
+            except (TypeError, ValueError):
+                pass
+
+    return None
+
+
+def _load_k_gm_max_status_entries(config):
+    path = _k_gm_max_status_path(config)
+    entries = {}
+    if not os.path.isfile(path):
+        return entries
+
+    with open(path) as fh:
+        for lineno, line in enumerate(fh, start=1):
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parts = stripped.split()
+            if len(parts) != 3:
+                logger.warning(
+                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
+                    "expected 3 columns."
+                )
+                continue
+            try:
+                year = int(parts[0])
+                value = float(parts[1])
+                status = int(parts[2])
+            except ValueError:
+                logger.warning(
+                    f"Malformed recovery k_gm_max status line {lineno} in {path}; "
+                    "could not parse numeric fields."
+                )
+                continue
+            entries[year] = (value, status)
+    return entries
+
+
+def _write_k_gm_max_status_entries(config, entries):
+    path = _k_gm_max_status_path(config)
+    with open(path, "w") as fh:
+        for year in sorted(entries):
+            value, status = entries[year]
+            fh.write(f"{year} {_format_numeric(value)} {int(status)}\n")
+    logger.info(f"Recovery k_gm_max status written to {path}")
+
+
+def has_k_gm_max_status_entry(config, year=None):
+    if year is None:
+        year = _tracking_year(config)
+    if year is None:
+        return False
+    return year in _load_k_gm_max_status_entries(config)
+
+
+def _read_k_gm_max_from_namelist(path):
+    if not path or not os.path.isfile(path):
+        return None
+    try:
+        nml = f90nml.read(path)
+        return nml["oce_dyn"]["k_gm_max"]
+    except (OSError, KeyError, TypeError, ValueError) as e:
+        logger.warning(f"Could not read k_gm_max from {path}: {e}")
+        return None
+
+
+def _current_k_gm_max(config):
+    work_dir = config["general"].get("thisrun_work_dir")
+    if work_dir:
+        value = _read_k_gm_max_from_namelist(os.path.join(work_dir, "namelist.oce"))
+        if value is not None:
+            return value
+
+    fesom_cfg = config.get("fesom", {})
+    cfg_dir = fesom_cfg.get("thisrun_config_dir")
+    if cfg_dir:
+        value = _read_k_gm_max_from_namelist(os.path.join(cfg_dir, "namelist.oce"))
+        if value is not None:
+            return value
+
+    return None
+
+
+def _pending_k_gm_max(target_changes):
+    return (
+        target_changes.get("namelist.oce", {})
+        .get("oce_dyn", {})
+        .get("k_gm_max")
+    )
+
+
+def update_k_gm_max_status(config, status, value=None, year=None):
+    if year is None:
+        year = _tracking_year(config)
+    if year is None:
+        logger.warning("Could not determine year for recovery k_gm_max status.")
+        return
+
+    entries = _load_k_gm_max_status_entries(config)
+    if value is None and year in entries:
+        value = entries[year][0]
+    if value is None:
+        value = _current_k_gm_max(config)
+    if value is None:
+        logger.warning(
+            f"Could not determine k_gm_max for year {year}; skipping status update."
+        )
+        return
+
+    entries[year] = (float(value), int(status))
+    _write_k_gm_max_status_entries(config, entries)
+
+
+def record_pending_k_gm_max(config, state, target_changes):
+    value = _pending_k_gm_max(target_changes)
+    if value is None:
+        return
+    update_k_gm_max_status(
+        config,
+        status=0,
+        value=value,
+        year=_tracking_year(config, state),
+    )
+
+
+def record_success(config):
+    update_k_gm_max_status(config, status=1)
+
+
+def record_failure(config):
+    update_k_gm_max_status(config, status=0)
 
 
 def record_trigger(config, component, trigger, trigger_cfg):
@@ -110,6 +269,32 @@ def _merge_namelist_changes(target, addition):
             target[nml_name][group].update(entries or {})
 
 
+def _get_recovery_namelist_path(config, component, nml_name):
+    """
+    Return the best namelist path to use as the baseline for additive recovery
+    deltas.
+
+    For retries of the SAME run, ``copy_files_to_thisrun`` refreshes the
+    ``thisrun_config_dir`` from the original inputs before ``apply_recovery_fix``
+    runs. To make additive perturbations accumulate across retries, prefer the
+    namelist from the existing ``work`` directory when present, and fall back to
+    ``thisrun_config_dir`` otherwise.
+    """
+    work_dir = config["general"].get("thisrun_work_dir")
+    if work_dir:
+        work_path = os.path.join(work_dir, nml_name)
+        if os.path.isfile(work_path):
+            return work_path
+
+    cfg_dir = config[component].get("thisrun_config_dir")
+    if cfg_dir:
+        cfg_path = os.path.join(cfg_dir, nml_name)
+        if os.path.isfile(cfg_path):
+            return cfg_path
+
+    return None
+
+
 def _resolve_deltas(config, component, deltas):
     """
     Turn a nested delta spec into absolute namelist_changes by reading the
@@ -118,18 +303,23 @@ def _resolve_deltas(config, component, deltas):
     """
     resolved = {}
     cfg_dir = config[component].get("thisrun_config_dir")
-    if not cfg_dir or not os.path.isdir(cfg_dir):
+    work_dir = config["general"].get("thisrun_work_dir")
+    if (
+        (not cfg_dir or not os.path.isdir(cfg_dir))
+        and (not work_dir or not os.path.isdir(work_dir))
+    ):
         logger.warning(
             f"Cannot apply namelist_deltas for '{component}': "
-            f"thisrun_config_dir unavailable."
+            f"neither thisrun_config_dir nor thisrun_work_dir is available."
         )
         return resolved
 
     for nml_name, groups in (deltas or {}).items():
-        nml_path = os.path.join(cfg_dir, nml_name)
-        if not os.path.isfile(nml_path):
+        nml_path = _get_recovery_namelist_path(config, component, nml_name)
+        if not nml_path:
             logger.warning(
-                f"Recovery delta targets missing namelist: {nml_path}; skipping."
+                f"Recovery delta targets missing namelist '{nml_name}' in "
+                f"thisrun_work_dir/thisrun_config_dir; skipping."
             )
             continue
         nml = f90nml.read(nml_path)
@@ -151,7 +341,7 @@ def _resolve_deltas(config, component, deltas):
                 )
                 logger.info(
                     f"Recovery perturbation: {nml_name}:{group}:{key} "
-                    f"{current} -> {new_value} (delta {delta:+})"
+                    f"{current} -> {new_value} (delta {delta:+}; source {nml_path})"
                 )
     return resolved
 
@@ -202,6 +392,7 @@ def apply_fix_to_config(config):
     target = config[component].setdefault("namelist_changes", {})
     _merge_namelist_changes(target, absolute)
     _merge_namelist_changes(target, resolved_deltas)
+    record_pending_k_gm_max(config, state, target)
 
     return config
 


### PR DESCRIPTION
  Summary
  - keep observe alive during recover by terminating only the compute launcher instead of cancelling the whole batch job
  - add apply_recovery_fix to the AWIESM prepcompute recipe
  - use the current run namelist as the baseline for recovery deltas so repeated same-year retries accumulate k_gm_max changes
  - persist a per-year recovery_k_gm_max_status file with year, final k_gm_max and success flag

  Validation
  - python -m py_compile src/esm_runscripts/observe.py src/esm_runscripts/recovery.py
  - verified repeated same-year recover retries now resubmit correctly