### PR TITLE
feat(esm-tools-plus/simcat): add esm_viz — visualization service for catalog items

### DIFF
--- a/.github/workflows/docker-esm-viz.yml
+++ b/.github/workflows/docker-esm-viz.yml
@@ -1,0 +1,64 @@
+name: Build ESM-Viz Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - release
+      - 'esm-tools-plus/*simcat*/**'  # Development branches
+    paths:
+      - 'src/esm_viz/**'
+      - '.github/workflows/docker-esm-viz.yml'
+  pull_request:
+    paths:
+      - 'src/esm_viz/**'
+      - '.github/workflows/docker-esm-viz.yml'
+  workflow_dispatch:  # Manual trigger from Actions tab
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/esm-viz
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: src/esm_viz
+          file: src/esm_viz/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,4 +77,4 @@ ignore = "src/esm_runscripts/coupling/"
 norecursedirs = tests/helpers
 
 [tool:pytest]
-norecursedirs = src/esm_catalog tests/test_esm_catalog tests/test_esm_viz
+norecursedirs = src/esm_catalog src/esm_viz tests/test_esm_catalog tests/test_esm_viz

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,3 +75,6 @@ max-line-length = 88
 [tool.pytest]
 ignore = "src/esm_runscripts/coupling/"
 norecursedirs = tests/helpers
+
+[tool:pytest]
+norecursedirs = src/esm_catalog

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,4 +77,4 @@ ignore = "src/esm_runscripts/coupling/"
 norecursedirs = tests/helpers
 
 [tool:pytest]
-norecursedirs = src/esm_catalog
+norecursedirs = src/esm_catalog tests/test_esm_catalog tests/test_esm_viz

--- a/src/esm_motd/esm_motd.py
+++ b/src/esm_motd/esm_motd.py
@@ -127,11 +127,15 @@ class MessageOfTheDayHandler:
                 print()
                 print(self.message_dict[message]["message"])
                 if mypackage == "esm_tools":
-                    esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
+                    try:
+                        esm_tools_path = esm_tools._get_real_dir_from_pth_file("")
+                        cd_step = f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"
+                    except FileNotFoundError:
+                        cd_step = ""
                     print(
                         f"Upgrade ESM-Tools to the version contianing this fix (\x1b[96m{version}\x1b[0m) by:\n"
-                        f"\x1b[96m1.\x1b[0m \x1b[35mcd {esm_tools_path}\x1b[0m\n"
-                        "\x1b[96m2.\x1b[0m Make sure that your git repo is clean (\x1b[35mgit status\x1b[0m)\n"
+                        + cd_step
+                        + "\x1b[96m2.\x1b[0m Make sure that your git repo is clean (\x1b[35mgit status\x1b[0m)\n"
                         "\x1b[96m3.\x1b[0m \x1b[35mgit checkout release\x1b[0m\n"
                         "\x1b[96m4.\x1b[0m \x1b[35mgit pull\x1b[0m\n"
                     )

--- a/src/esm_viz/.dockerignore
+++ b/src/esm_viz/.dockerignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.egg-info/
+.git/
+.gitignore
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.md
+tests/

--- a/src/esm_viz/Dockerfile
+++ b/src/esm_viz/Dockerfile
@@ -1,0 +1,65 @@
+# ESM-Viz: Climate Data Visualization Service
+# Multi-stage build for smaller final image
+
+FROM mambaorg/micromamba:1.5-jammy AS builder
+
+USER root
+WORKDIR /app
+
+# Install system dependencies for cartopy/GEOS
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgeos-dev \
+    libproj-dev \
+    proj-data \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy only dependency specs first for better layer caching
+COPY --chown=$MAMBA_USER:$MAMBA_USER environment.yml /app/
+
+# Create environment with runtime dependencies
+RUN micromamba create -n viz -f environment.yml && \
+    micromamba clean --all --yes
+
+FROM mambaorg/micromamba:1.5-jammy
+
+USER root
+WORKDIR /app
+
+# Install runtime system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgeos-c1v5 \
+    libproj22 \
+    proj-data \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy environment from builder
+COPY --from=builder /opt/conda/envs/viz /opt/conda/envs/viz
+
+# Copy application code
+COPY --chown=$MAMBA_USER:$MAMBA_USER . /app/esm_viz/
+
+# Add conda env to PATH and esm_viz to PYTHONPATH
+ENV PATH="/opt/conda/envs/viz/bin:$PATH"
+ENV PYTHONPATH="/app"
+
+# Create non-root user for runtime
+RUN useradd --create-home --shell /bin/bash viz && \
+    chown -R viz:viz /app /opt/conda/envs/viz
+
+USER viz
+
+# Default port (23xxx block = Data & Catalog services)
+ENV ESM_VIZ_PORT=23001
+ENV ESM_VIZ_HOST=0.0.0.0
+
+EXPOSE 23001
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:${ESM_VIZ_PORT}/health || exit 1
+
+# Usage: docker run -p 23001:23001 esm-viz
+#        docker run -e ESM_VIZ_PORT=8001 -p 8001:8001 esm-viz
+CMD python -m esm_viz.cli serve \
+    --host ${ESM_VIZ_HOST} --port ${ESM_VIZ_PORT}

--- a/src/esm_viz/__init__.py
+++ b/src/esm_viz/__init__.py
@@ -1,0 +1,29 @@
+"""
+esm_viz - FastAPI-based visualization service for climate data.
+
+Provides REST endpoints for generating static previews and metadata
+from NetCDF and GRIB climate datasets referenced in STAC catalogs.
+Also provides interactive Panel-based visualization applications.
+"""
+
+__version__ = "0.1.0"
+__author__ = "ESM-Tools Development Team"
+
+from esm_viz.readers import open_data, get_data_metadata
+from esm_viz.static_preview import plot_spatial, generate_preview_png
+from esm_viz.fesom import is_unstructured, plot_unstructured
+from esm_viz.interactive import create_preview_app, create_comparison_app, get_smart_colormap
+from esm_viz.collection import create_collection_preview_app
+
+__all__ = [
+    "open_data",
+    "get_data_metadata",
+    "plot_spatial",
+    "generate_preview_png",
+    "is_unstructured",
+    "plot_unstructured",
+    "create_preview_app",
+    "create_comparison_app",
+    "create_collection_preview_app",
+    "get_smart_colormap",
+]

--- a/src/esm_viz/__init__.py
+++ b/src/esm_viz/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 esm_viz - FastAPI-based visualization service for climate data.
 

--- a/src/esm_viz/app.py
+++ b/src/esm_viz/app.py
@@ -1,0 +1,694 @@
+"""
+FastAPI application for the ESM visualization service.
+
+Provides REST endpoints for generating static previews and metadata
+from climate datasets referenced in STAC catalogs. Also serves
+interactive Panel applications for data exploration.
+"""
+
+from pathlib import Path
+from typing import Annotated
+from functools import partial
+from urllib.parse import urlencode
+
+import httpx
+import panel as pn
+from fastapi import FastAPI, HTTPException, Query, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from loguru import logger
+
+from esm_viz import __version__
+from esm_viz.collection import create_collection_preview_app, create_comparison_preview_app
+from esm_viz.fesom import (
+    is_unstructured, plot_unstructured,
+    get_mesh_from_stac_item, create_interactive_fesom_plot,
+)
+from esm_viz.compute_routes import create_compute_router
+from esm_viz.interactive import create_preview_app
+from esm_viz.readers import get_data_metadata, open_data
+from esm_viz.static_preview import generate_preview_png
+
+
+app = FastAPI(
+    title="ESM Visualization Service",
+    description=(
+        "REST API for generating visualizations and metadata from climate datasets. "
+        "Integrates with STAC catalogs to fetch data references."
+    ),
+    version=__version__,
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+# Enable CORS for browser access
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# Mount compute cluster management routes
+app.include_router(create_compute_router())
+
+# Serve GeoViews JS extension -- Panel looks for it at
+# /static/extensions/geoviews/ but geoviews installs it elsewhere.
+try:
+    import geoviews as _gv
+    _gv_dist = Path(_gv.__file__).parent / "dist"
+    if _gv_dist.exists():
+        # Panel expects /static/extensions/geoviews/geoviews.min.js
+        # Mount the geoviews dist directory at that path
+        app.mount(
+            "/static/extensions/geoviews",
+            StaticFiles(directory=str(_gv_dist)),
+            name="geoviews-static",
+        )
+        logger.info(f"Mounted GeoViews static files from {_gv_dist}")
+except ImportError:
+    logger.warning("GeoViews not available, interactive maps will be limited")
+
+
+@app.get("/health")
+async def health_check() -> dict[str, str]:
+    """
+    Health check endpoint.
+
+    Returns
+    -------
+    dict
+        Status information including service version.
+    """
+    return {
+        "status": "healthy",
+        "service": "esm-viz",
+        "version": __version__,
+    }
+
+
+async def _fetch_stac_item(
+    stac_api: str, item_id: str, collection_id: str | None = None
+) -> dict:
+    """
+    Fetch a STAC item from the API.
+
+    Parameters
+    ----------
+    stac_api : str
+        Base URL of the STAC API.
+    item_id : str
+        The STAC item ID to fetch.
+    collection_id : str, optional
+        The collection ID containing the item. If not provided, the item
+        will be discovered via the search endpoint.
+
+    Returns
+    -------
+    dict
+        The STAC item as a dictionary.
+
+    Raises
+    ------
+    HTTPException
+        If the item cannot be fetched.
+    """
+    # Normalize API URL
+    stac_api = stac_api.rstrip("/")
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        # If collection_id is provided, try the direct endpoint first
+        if collection_id:
+            endpoint = f"{stac_api}/collections/{collection_id}/items/{item_id}"
+            try:
+                logger.debug(f"Trying STAC endpoint: {endpoint}")
+                response = await client.get(endpoint)
+                if response.status_code == 200:
+                    data = response.json()
+                    if "assets" in data:
+                        return data
+            except httpx.RequestError as e:
+                logger.warning(f"Request failed for {endpoint}: {e}")
+
+        # Use search endpoint to find the item across all collections
+        # This is the most reliable method as items are collection-scoped in STAC
+        search_endpoint = f"{stac_api}/search?ids={item_id}"
+        try:
+            logger.debug(f"Searching for item via: {search_endpoint}")
+            response = await client.get(search_endpoint)
+            if response.status_code == 200:
+                data = response.json()
+                if "features" in data and len(data["features"]) > 0:
+                    item = data["features"][0]
+                    # Log the collection for debugging
+                    found_collection = item.get("collection", "unknown")
+                    logger.debug(f"Found item in collection: {found_collection}")
+                    return item
+        except httpx.RequestError as e:
+            logger.warning(f"Search request failed: {e}")
+
+        # POST search as fallback (some STAC APIs require POST for search)
+        try:
+            logger.debug(f"Trying POST search for item: {item_id}")
+            response = await client.post(
+                f"{stac_api}/search",
+                json={"ids": [item_id]},
+            )
+            if response.status_code == 200:
+                data = response.json()
+                if "features" in data and len(data["features"]) > 0:
+                    return data["features"][0]
+        except httpx.RequestError as e:
+            logger.warning(f"POST search request failed: {e}")
+
+        # Try to fetch all collections and search for item in each
+        # This is a last resort for APIs that don't support item search
+        try:
+            logger.debug("Attempting to discover item by iterating collections")
+            collections_response = await client.get(f"{stac_api}/collections")
+            if collections_response.status_code == 200:
+                collections_data = collections_response.json()
+                collection_list = collections_data.get(
+                    "collections", collections_data.get("features", [])
+                )
+                for coll in collection_list:
+                    coll_id = coll.get("id")
+                    if coll_id:
+                        endpoint = f"{stac_api}/collections/{coll_id}/items/{item_id}"
+                        try:
+                            response = await client.get(endpoint)
+                            if response.status_code == 200:
+                                data = response.json()
+                                if "assets" in data:
+                                    logger.debug(f"Found item in collection: {coll_id}")
+                                    return data
+                        except httpx.RequestError:
+                            continue
+        except httpx.RequestError as e:
+            logger.warning(f"Collection iteration failed: {e}")
+
+    raise HTTPException(
+        status_code=404,
+        detail=f"Could not fetch STAC item '{item_id}' from {stac_api}",
+    )
+
+
+def _get_data_href(item: dict) -> str:
+    """
+    Extract the data href from a STAC item.
+
+    Parameters
+    ----------
+    item : dict
+        The STAC item.
+
+    Returns
+    -------
+    str
+        The href to the data file.
+
+    Raises
+    ------
+    HTTPException
+        If no suitable data asset is found.
+    """
+    assets = item.get("assets", {})
+
+    # Priority order for data assets
+    preferred_keys = ["data", "netcdf", "nc", "grib", "analysis", "forecast"]
+
+    # Try preferred keys first
+    for key in preferred_keys:
+        if key in assets and "href" in assets[key]:
+            return assets[key]["href"]
+
+    # Fall back to first asset with href
+    for asset_key, asset in assets.items():
+        if "href" in asset:
+            href = asset["href"]
+            # Check if it looks like a data file
+            if any(ext in href.lower() for ext in [".nc", ".nc4", ".grib", ".grb"]):
+                return href
+
+    # Last resort: return first available href
+    for asset in assets.values():
+        if "href" in asset:
+            return asset["href"]
+
+    raise HTTPException(
+        status_code=400,
+        detail="No data asset found in STAC item",
+    )
+
+
+@app.get("/preview/{item_id}.png")
+async def get_preview_png(
+    item_id: str,
+    var: Annotated[str, Query(description="Variable name to plot")],
+    stac_api: Annotated[str, Query(description="STAC API base URL")],
+    time: Annotated[int, Query(description="Time index")] = 0,
+    level: Annotated[int, Query(description="Level/depth index for 3D data")] = 0,
+    cmap: Annotated[str, Query(description="Matplotlib colormap")] = "viridis",
+    collection_id: Annotated[
+        str | None, Query(description="STAC collection ID (optional, improves performance)")
+    ] = None,
+) -> Response:
+    """
+    Generate a static PNG preview of a dataset variable.
+
+    Parameters
+    ----------
+    item_id : str
+        STAC item ID.
+    var : str
+        Variable name to plot.
+    stac_api : str
+        Base URL of the STAC API.
+    time : int, optional
+        Time index to plot. Default is 0.
+    cmap : str, optional
+        Matplotlib colormap name. Default is 'viridis'.
+    collection_id : str, optional
+        STAC collection ID. If provided, enables direct item fetch
+        via /collections/{collection_id}/items/{item_id}.
+
+    Returns
+    -------
+    Response
+        PNG image response.
+    """
+    logger.info(f"Preview request: item={item_id}, var={var}, time={time}, level={level}")
+
+    ds = None
+    try:
+        # Fetch STAC item
+        item = await _fetch_stac_item(stac_api, item_id, collection_id=collection_id)
+        href = _get_data_href(item)
+        logger.debug(f"Data href: {href}")
+
+        # Open dataset
+        ds = open_data(href)
+
+        # Check if unstructured mesh (e.g., FESOM)
+        if is_unstructured(ds):
+            logger.info("Detected unstructured mesh data")
+            data_array = ds[var]
+            if "time" in data_array.dims:
+                data_array = data_array.isel(time=min(time, data_array.sizes["time"] - 1))
+            level_dims = {"nz", "nz1", "depth", "lev", "level", "z"}
+            for dim in data_array.dims:
+                if dim.lower() in level_dims:
+                    data_array = data_array.isel({dim: min(level, data_array.sizes[dim] - 1)})
+
+            import io
+            import matplotlib
+            matplotlib.use("Agg")
+
+            fig = plot_unstructured(data_array, cmap=cmap, ds=ds, stac_item=item)
+            buf = io.BytesIO()
+            fig.savefig(buf, format="png", dpi=100, bbox_inches="tight")
+            buf.seek(0)
+            png_bytes = buf.read()
+            plt.close(fig)
+        else:
+            # Regular gridded data
+            png_bytes = generate_preview_png(ds, var, time_index=time, level_index=level, cmap=cmap)
+
+        return Response(
+            content=png_bytes,
+            media_type="image/png",
+            headers={
+                "Cache-Control": "public, max-age=3600",
+                "X-Item-ID": item_id,
+                "X-Variable": var,
+            },
+        )
+
+    except KeyError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Preview generation failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Preview generation failed: {e}")
+    finally:
+        # Ensure dataset is always closed to prevent file handle leaks
+        if ds is not None:
+            try:
+                ds.close()
+            except Exception:
+                pass  # Ignore close errors
+
+
+@app.get("/preview/{item_id}.json")
+async def get_preview_metadata(
+    item_id: str,
+    stac_api: Annotated[str, Query(description="STAC API base URL")],
+    collection_id: Annotated[
+        str | None, Query(description="STAC collection ID (optional, improves performance)")
+    ] = None,
+) -> dict:
+    """
+    Get metadata for a dataset referenced by a STAC item.
+
+    Parameters
+    ----------
+    item_id : str
+        STAC item ID.
+    stac_api : str
+        Base URL of the STAC API.
+    collection_id : str, optional
+        STAC collection ID. If provided, enables direct item fetch
+        via /collections/{collection_id}/items/{item_id}.
+
+    Returns
+    -------
+    dict
+        Metadata including variables, dimensions, and coordinate ranges.
+    """
+    logger.info(f"Metadata request: item={item_id}")
+
+    try:
+        # Fetch STAC item
+        item = await _fetch_stac_item(stac_api, item_id, collection_id=collection_id)
+        href = _get_data_href(item)
+        logger.debug(f"Data href: {href}")
+
+        # Open dataset
+        ds = open_data(href)
+
+        # Extract metadata
+        metadata = get_data_metadata(ds)
+
+        # Add STAC item info
+        metadata["item_id"] = item_id
+        metadata["href"] = href
+        metadata["is_unstructured"] = is_unstructured(ds)
+
+        # Close dataset
+        ds.close()
+
+        return metadata
+
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        logger.exception(f"Metadata extraction failed: {e}")
+        raise HTTPException(status_code=500, detail=f"Metadata extraction failed: {e}")
+
+
+# NOTE: Fixed-path routes MUST be defined BEFORE parameterized routes.
+# /preview/compare/panel and /preview/collection/... must come before
+# /preview/{item_id}/panel, otherwise FastAPI matches "compare" as an item_id.
+
+
+@app.get("/preview/compare/panel")
+async def preview_compare_redirect(
+    collection_a: Annotated[str, Query(description="Reference collection ID")],
+    collection_b: Annotated[str, Query(description="Comparison collection ID")],
+    stac_api: Annotated[str | None, Query(description="STAC API base URL")] = None,
+) -> RedirectResponse:
+    """
+    Redirect to the interactive comparison Panel for two STAC collections.
+
+    Shows side-by-side views of two experiments with independent time
+    range selectors, plus a difference panel (B - A).
+    """
+    logger.info(f"Compare redirect: {collection_a} vs {collection_b}")
+    params = {
+        "compare": "1",
+        "collection_a": collection_a,
+        "collection_b": collection_b,
+    }
+    if stac_api:
+        params["stac_api"] = stac_api
+    return RedirectResponse(url=f"/_panel?{urlencode(params)}", status_code=307)
+
+
+@app.get("/preview/collection/{collection_id}/panel")
+async def preview_collection_panel_redirect(
+    collection_id: str,
+    stac_api: Annotated[str | None, Query(description="STAC API base URL")] = None,
+) -> RedirectResponse:
+    """
+    Redirect to the interactive Panel visualization for a whole STAC collection.
+    """
+    logger.info(f"Panel collection redirect: collection={collection_id}")
+    params = {"collection_id": collection_id}
+    if stac_api:
+        params["stac_api"] = stac_api
+    return RedirectResponse(url=f"/_panel?{urlencode(params)}", status_code=307)
+
+
+@app.get("/preview/{item_id}/panel")
+async def preview_panel_redirect(
+    item_id: str,
+    stac_api: Annotated[str | None, Query(description="STAC API base URL")] = None,
+    var: Annotated[str | None, Query(description="Initial variable")] = None,
+    collection_id: Annotated[
+        str | None, Query(description="STAC collection ID (optional, improves performance)")
+    ] = None,
+) -> RedirectResponse:
+    """
+    Redirect to the interactive Panel visualization for a STAC item.
+    """
+    logger.info(f"Panel redirect: item={item_id}")
+    params = {"item_id": item_id}
+    if stac_api:
+        params["stac_api"] = stac_api
+    if var:
+        params["var"] = var
+    if collection_id:
+        params["collection_id"] = collection_id
+    return RedirectResponse(url=f"/_panel?{urlencode(params)}", status_code=307)
+
+
+@app.get("/")
+async def root() -> dict:
+    """
+    Root endpoint with API information.
+    """
+    return {
+        "service": "ESM Visualization Service",
+        "version": __version__,
+        "endpoints": {
+            "/health": "Health check",
+            "/preview/{item_id}.png": "Static PNG preview",
+            "/preview/{item_id}.json": "Dataset metadata",
+            "/preview/{item_id}/panel": "Interactive Panel visualization",
+            "/preview/collection/{collection_id}/panel": "Interactive collection-level Panel visualization",
+            "/preview/compare/panel": "Cross-experiment comparison (two collections)",
+            "/docs": "OpenAPI documentation",
+        },
+    }
+
+
+# -----------------------------------------------------------------------------
+# Panel Application Integration
+# -----------------------------------------------------------------------------
+
+
+def _create_panel_app_for_item(
+    item_id: str,
+    stac_api: str | None = None,
+    var: str | None = None,
+    collection_id: str | None = None,
+) -> pn.viewable.Viewable:
+    """
+    Create a Panel app for a specific STAC item.
+
+    This function is called by the Panel server to create apps dynamically.
+
+    Parameters
+    ----------
+    item_id : str
+        STAC item ID.
+    stac_api : str, optional
+        Base URL of the STAC API.
+    var : str, optional
+        Initial variable to display.
+    collection_id : str, optional
+        STAC collection ID.
+
+    Returns
+    -------
+    pn.viewable.Viewable
+        Panel application for the item.
+    """
+    logger.info(f"Creating Panel app for item: {item_id}")
+
+    href = None
+    item = None
+    if stac_api:
+        try:
+            with httpx.Client(timeout=30.0) as client:
+                stac_api_norm = stac_api.rstrip("/")
+                item = None
+
+                if collection_id:
+                    try:
+                        endpoint = f"{stac_api_norm}/collections/{collection_id}/items/{item_id}"
+                        logger.debug(f"Trying direct endpoint: {endpoint}")
+                        response = client.get(endpoint)
+                        if response.status_code == 200:
+                            data = response.json()
+                            if "assets" in data:
+                                item = data
+                    except Exception as e:
+                        logger.warning(f"Direct fetch failed: {e}")
+
+                if not item:
+                    try:
+                        search_url = f"{stac_api_norm}/search?ids={item_id}"
+                        logger.debug(f"Searching for item via: {search_url}")
+                        response = client.get(search_url)
+                        if response.status_code == 200:
+                            data = response.json()
+                            if "features" in data and len(data["features"]) > 0:
+                                item = data["features"][0]
+                    except Exception as e:
+                        logger.warning(f"Search failed: {e}")
+
+                if not item:
+                    try:
+                        response = client.post(
+                            f"{stac_api_norm}/search",
+                            json={"ids": [item_id]},
+                        )
+                        if response.status_code == 200:
+                            data = response.json()
+                            if "features" in data and len(data["features"]) > 0:
+                                item = data["features"][0]
+                    except Exception as e:
+                        logger.warning(f"POST search failed: {e}")
+
+                if item:
+                    assets = item.get("assets", {})
+                    preferred_keys = ["data", "netcdf", "nc", "grib"]
+                    for key in preferred_keys:
+                        if key in assets and "href" in assets[key]:
+                            href = assets[key]["href"]
+                            break
+                    if not href:
+                        for asset in assets.values():
+                            if "href" in asset:
+                                href = asset["href"]
+                                break
+        except Exception as e:
+            logger.error(f"Failed to fetch STAC item: {e}")
+
+    if not href:
+        href = item_id
+        logger.info(f"Using item_id as direct href: {href}")
+
+    # Check if this is FESOM data -- use specialized interactive plot
+    try:
+        ds = open_data(href)
+        if is_unstructured(ds) and item is not None:
+            mesh = get_mesh_from_stac_item(item)
+            if mesh is not None:
+                lon, lat, elem = mesh
+                # Select variable
+                sel_var = var or next(iter(ds.data_vars), None)
+                if sel_var and sel_var in ds.data_vars:
+                    data_array = ds[sel_var]
+                    if "time" in data_array.dims:
+                        data_array = data_array.isel(time=0)
+                    level_dims = {"nz", "nz1", "depth", "lev", "level", "z"}
+                    for dim in data_array.dims:
+                        if dim.lower() in level_dims:
+                            data_array = data_array.isel({dim: 0})
+                    plot = create_interactive_fesom_plot(data_array, lon, lat, elem)
+                    ds.close()
+                    logger.info("Created interactive FESOM Panel app")
+                    return pn.pane.HoloViews(plot)
+        ds.close()
+    except Exception as e:
+        logger.warning(f"FESOM interactive check failed, falling back to generic: {e}")
+
+    return create_preview_app(href, variable=var)
+
+
+def setup_panel_routes(fastapi_app: FastAPI) -> None:
+    """
+    Set up Panel application routes on the FastAPI app.
+
+    Uses Panel's ``add_application`` decorator to mount an interactive
+    Panel app at ``/_panel``. The public-facing endpoint at
+    ``/preview/{item_id}/panel`` redirects here with query parameters.
+
+    Parameters
+    ----------
+    fastapi_app : FastAPI
+        The FastAPI application to add routes to.
+    """
+    try:
+        from panel.io.fastapi import add_application
+
+        @add_application("/_panel", fastapi_app, title="ESM-Viz Interactive Preview")
+        def panel_app_factory():
+            """Panel app factory -- reads query params from Bokeh session context."""
+            try:
+                from bokeh.io import curdoc
+
+                doc = curdoc()
+                if doc and hasattr(doc, "session_context"):
+                    session_context = doc.session_context
+                    if session_context and hasattr(session_context, "request"):
+                        request = session_context.request
+                        if request and hasattr(request, "arguments"):
+                            args = request.arguments
+                            item_id = args.get("item_id", [b""])[0].decode()
+                            stac_api = args.get("stac_api", [b""])[0].decode() or None
+                            var = args.get("var", [b""])[0].decode() or None
+                            collection_id = args.get("collection_id", [b""])[0].decode() or None
+
+                            # Cross-experiment comparison
+                            compare = args.get("compare", [b""])[0].decode()
+                            collection_a = args.get("collection_a", [b""])[0].decode()
+                            collection_b = args.get("collection_b", [b""])[0].decode()
+
+                            if compare and collection_a and collection_b and stac_api:
+                                return create_comparison_preview_app(
+                                    collection_a, collection_b, stac_api
+                                )
+
+                            if item_id:
+                                return _create_panel_app_for_item(
+                                    item_id, stac_api=stac_api, var=var, collection_id=collection_id
+                                )
+
+                            # Collection-level preview (no item_id, but collection_id present)
+                            if collection_id and stac_api:
+                                return create_collection_preview_app(
+                                    collection_id, stac_api
+                                )
+            except Exception as e:
+                logger.warning(f"Could not get request context: {e}")
+
+            return pn.Column(
+                pn.pane.Markdown("# ESM-Viz Interactive Preview"),
+                pn.pane.Alert(
+                    "No item or collection specified. Please provide an item_id or collection_id query parameter.",
+                    alert_type="warning",
+                ),
+            )
+
+        logger.info("Panel application routes configured at /_panel")
+
+    except ImportError as e:
+        logger.warning(
+            f"Panel FastAPI integration not available: {e}. "
+            "Install panel with FastAPI extras: pip install 'panel[fastapi]'"
+        )
+    except Exception as e:
+        logger.error(f"Failed to set up Panel routes: {e}")
+
+
+# Set up Panel routes when the module loads
+try:
+    setup_panel_routes(app)
+except Exception as e:
+    logger.warning(f"Panel route setup deferred: {e}")

--- a/src/esm_viz/app.py
+++ b/src/esm_viz/app.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 FastAPI application for the ESM visualization service.
 

--- a/src/esm_viz/cli.py
+++ b/src/esm_viz/cli.py
@@ -1,0 +1,307 @@
+"""
+CLI entry point for the ESM visualization service.
+
+Provides command-line interface for starting the visualization server
+and related utilities.
+"""
+
+import sys
+from typing import Annotated, Optional
+
+import typer
+from loguru import logger
+
+from esm_viz import __version__
+
+
+app = typer.Typer(
+    name="esm-viz",
+    help="ESM visualization service for climate data.",
+    no_args_is_help=True,
+)
+
+
+def _configure_logging(verbose: bool = False, quiet: bool = False) -> None:
+    """Configure loguru logging based on verbosity settings."""
+    logger.remove()
+
+    if quiet:
+        level = "ERROR"
+    elif verbose:
+        level = "DEBUG"
+    else:
+        level = "INFO"
+
+    logger.add(
+        sys.stderr,
+        level=level,
+        format="<green>{time:YYYY-MM-DD HH:mm:ss}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>",
+    )
+
+
+def version_callback(value: bool) -> None:
+    """Print version and exit."""
+    if value:
+        typer.echo(f"esm-viz version {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--version",
+            "-V",
+            callback=version_callback,
+            is_eager=True,
+            help="Show version and exit.",
+        ),
+    ] = None,
+) -> None:
+    """
+    ESM Visualization Service.
+
+    A FastAPI-based service for generating visualizations and metadata
+    from climate datasets referenced in STAC catalogs.
+    """
+    pass
+
+
+@app.command()
+def serve(
+    port: Annotated[
+        int,
+        typer.Option("--port", "-p", help="Port to run the server on."),
+    ] = 8001,
+    host: Annotated[
+        str,
+        typer.Option("--host", "-h", help="Host to bind the server to."),
+    ] = "0.0.0.0",
+    reload: Annotated[
+        bool,
+        typer.Option("--reload", "-r", help="Enable auto-reload for development."),
+    ] = False,
+    workers: Annotated[
+        int,
+        typer.Option("--workers", "-w", help="Number of worker processes."),
+    ] = 1,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Enable verbose logging."),
+    ] = False,
+    quiet: Annotated[
+        bool,
+        typer.Option("--quiet", "-q", help="Suppress non-error output."),
+    ] = False,
+) -> None:
+    """
+    Start the visualization server.
+
+    Runs a uvicorn server hosting the FastAPI application for
+    generating climate data visualizations.
+
+    Examples
+    --------
+    Start server on default port:
+
+        esm-viz serve
+
+    Start on custom port with auto-reload:
+
+        esm-viz serve --port 8080 --reload
+
+    Production deployment with multiple workers:
+
+        esm-viz serve --workers 4 --host 0.0.0.0
+    """
+    import uvicorn
+
+    _configure_logging(verbose=verbose, quiet=quiet)
+
+    logger.info(f"Starting ESM Visualization Service v{__version__}")
+    logger.info(f"Server: http://{host}:{port}")
+    logger.info(f"Documentation: http://{host}:{port}/docs")
+
+    log_level = "debug" if verbose else ("error" if quiet else "info")
+
+    uvicorn.run(
+        "esm_viz.app:app",
+        host=host,
+        port=port,
+        reload=reload,
+        workers=workers if not reload else 1,
+        log_level=log_level,
+    )
+
+
+@app.command()
+def preview(
+    path: Annotated[
+        str,
+        typer.Argument(help="Path to NetCDF or GRIB file."),
+    ],
+    variable: Annotated[
+        str,
+        typer.Option("--var", "-v", help="Variable to plot."),
+    ],
+    output: Annotated[
+        Optional[str],
+        typer.Option("--output", "-o", help="Output PNG file path."),
+    ] = None,
+    time_index: Annotated[
+        int,
+        typer.Option("--time", "-t", help="Time index to plot."),
+    ] = 0,
+    cmap: Annotated[
+        str,
+        typer.Option("--cmap", "-c", help="Matplotlib colormap."),
+    ] = "viridis",
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", help="Enable verbose logging."),
+    ] = False,
+) -> None:
+    """
+    Generate a preview image from a local data file.
+
+    This command creates a PNG visualization without starting the server,
+    useful for quick previews and testing.
+
+    Examples
+    --------
+    Generate preview of temperature variable:
+
+        esm-viz preview data.nc --var tas --output preview.png
+
+    Use a different colormap:
+
+        esm-viz preview ocean.nc --var sst --cmap coolwarm
+    """
+    from pathlib import Path
+
+    from esm_viz.readers import open_data
+    from esm_viz.static_preview import generate_preview_png
+
+    _configure_logging(verbose=verbose)
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        logger.error(f"File not found: {path}")
+        raise typer.Exit(1)
+
+    # Determine output path
+    if output is None:
+        output = str(path_obj.with_suffix(".png"))
+
+    logger.info(f"Generating preview: {path} -> {output}")
+    logger.info(f"Variable: {variable}, Time: {time_index}, Colormap: {cmap}")
+
+    try:
+        ds = open_data(path)
+        png_bytes = generate_preview_png(ds, variable, time_index=time_index, cmap=cmap)
+        ds.close()
+
+        with open(output, "wb") as f:
+            f.write(png_bytes)
+
+        logger.info(f"Preview saved to: {output}")
+        typer.echo(f"Preview saved: {output}")
+
+    except KeyError as e:
+        logger.error(f"Variable error: {e}")
+        raise typer.Exit(1)
+    except Exception as e:
+        logger.exception(f"Preview generation failed: {e}")
+        raise typer.Exit(1)
+
+
+@app.command()
+def info(
+    path: Annotated[
+        str,
+        typer.Argument(help="Path to NetCDF or GRIB file."),
+    ],
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", "-j", help="Output as JSON."),
+    ] = False,
+) -> None:
+    """
+    Display metadata for a data file.
+
+    Shows variables, dimensions, and coordinate ranges for a given
+    climate data file.
+
+    Examples
+    --------
+    Display file info:
+
+        esm-viz info data.nc
+
+    Output as JSON:
+
+        esm-viz info data.nc --json
+    """
+    import json
+    from pathlib import Path
+
+    from esm_viz.fesom import is_unstructured
+    from esm_viz.readers import get_data_metadata, open_data
+
+    _configure_logging(quiet=True)
+
+    path_obj = Path(path)
+    if not path_obj.exists():
+        typer.echo(f"Error: File not found: {path}", err=True)
+        raise typer.Exit(1)
+
+    try:
+        ds = open_data(path)
+        metadata = get_data_metadata(ds)
+        metadata["is_unstructured"] = is_unstructured(ds)
+        ds.close()
+
+        if json_output:
+            typer.echo(json.dumps(metadata, indent=2, default=str))
+        else:
+            typer.echo(f"\nFile: {path}")
+            typer.echo("=" * 60)
+
+            typer.echo(f"\nMesh type: {'Unstructured' if metadata['is_unstructured'] else 'Regular grid'}")
+
+            typer.echo(f"\nDimensions ({len(metadata['dimensions'])}):")
+            for dim_name, size in metadata["dimensions"].items():
+                typer.echo(f"  {dim_name}: {size}")
+
+            typer.echo(f"\nVariables ({len(metadata['variables'])}):")
+            for var in metadata["variables"]:
+                name = var["name"]
+                dims = ", ".join(var["dims"])
+                units = var.get("units", "")
+                long_name = var.get("long_name", "")
+                typer.echo(f"  {name} ({dims})")
+                if long_name:
+                    typer.echo(f"    {long_name}")
+                if units:
+                    typer.echo(f"    Units: {units}")
+
+            typer.echo(f"\nCoordinates ({len(metadata['coordinates'])}):")
+            for coord_name, coord_info in metadata["coordinates"].items():
+                if "min" in coord_info and "max" in coord_info:
+                    typer.echo(f"  {coord_name}: [{coord_info['min']:.4g}, {coord_info['max']:.4g}]")
+                else:
+                    typer.echo(f"  {coord_name}: size={coord_info['size']}")
+
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+def cli_main() -> None:
+    """Entry point for the CLI."""
+    app()
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/src/esm_viz/cli.py
+++ b/src/esm_viz/cli.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 CLI entry point for the ESM visualization service.
 

--- a/src/esm_viz/collection.py
+++ b/src/esm_viz/collection.py
@@ -1,0 +1,960 @@
+"""
+Collection-level interactive visualization using xarray.DataTree.
+
+Builds a DataTree from all items in a STAC collection, grouped by
+variable name, and provides an interactive Panel app for exploring
+the entire collection with time-averaging, anomaly views, and
+per-variable depth/level selection.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import defaultdict
+from functools import lru_cache
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import numpy as np
+import panel as pn
+import xarray as xr
+from loguru import logger
+
+from esm_viz.fesom import (
+    create_interactive_fesom_plot,
+    get_mesh_from_stac_item,
+    is_unstructured,
+    load_fesom_mesh,
+)
+from esm_viz.interactive import (
+    AVAILABLE_COLORMAPS,
+    DEFAULT_COLORMAP,
+    _create_gridded_plot,
+    _get_colormap_object,
+    get_smart_colormap,
+)
+
+try:
+    import hvplot.xarray  # noqa: F401
+    import holoviews as hv
+    import geoviews as gv
+    from cartopy import crs as ccrs
+
+    HAS_GEOVIEWS = True
+except ImportError:
+    HAS_GEOVIEWS = False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _strip_file_uri(href: str) -> str:
+    """Convert ``file://`` URIs to plain filesystem paths."""
+    parsed = urlparse(href)
+    if parsed.scheme == "file":
+        return parsed.path
+    return href
+
+
+def _collection_cache_key(collection_id: str, stac_api: str) -> str:
+    """Produce a hashable key for the LRU cache."""
+    raw = f"{stac_api.rstrip('/')}|{collection_id}"
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# STAC fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_collection_items(
+    collection_id: str, stac_api: str, limit: int = 200
+) -> list[dict]:
+    """
+    Fetch all items from a STAC collection.
+
+    Paginates through the ``/collections/{id}/items`` endpoint until all
+    items have been retrieved or *limit* is reached.
+
+    Parameters
+    ----------
+    collection_id : str
+        STAC collection ID.
+    stac_api : str
+        Base URL of the STAC API (trailing slash is stripped).
+    limit : int
+        Maximum number of items to fetch in total.
+
+    Returns
+    -------
+    list[dict]
+        List of STAC item dicts.
+    """
+    stac_api = stac_api.rstrip("/")
+    items: list[dict] = []
+    page_size = min(limit, 100)
+    url: str | None = f"{stac_api}/collections/{collection_id}/items?limit={page_size}"
+
+    with httpx.Client(timeout=60.0) as client:
+        while url and len(items) < limit:
+            logger.debug(f"Fetching items page: {url}")
+            response = client.get(url)
+            response.raise_for_status()
+            data = response.json()
+
+            features = data.get("features", [])
+            if not features:
+                break
+            items.extend(features)
+
+            # Follow "next" link if present
+            url = None
+            for link in data.get("links", []):
+                if link.get("rel") == "next":
+                    url = link.get("href")
+                    break
+
+    logger.info(
+        f"Fetched {len(items)} items from collection '{collection_id}'"
+    )
+    return items[:limit]
+
+
+# ---------------------------------------------------------------------------
+# DataTree construction
+# ---------------------------------------------------------------------------
+
+
+# Cache keyed on (collection_id, stac_api) hash -- expensive to rebuild.
+_datatree_cache: dict[str, tuple[xr.DataTree, dict[str, Any]]] = {}
+
+
+def _build_datatree(
+    collection_id: str, stac_api: str
+) -> tuple[xr.DataTree, dict[str, Any]]:
+    """
+    Build an ``xr.DataTree`` from a STAC collection.
+
+    Items are grouped by their ``properties.variable`` field.  Within each
+    group the data files are opened with ``xr.open_mfdataset`` along the
+    ``time`` dimension with Dask lazy loading.
+
+    The second return value is a metadata dict carrying FESOM mesh info
+    (if applicable) and the raw item list for downstream use.
+
+    Parameters
+    ----------
+    collection_id : str
+        STAC collection ID.
+    stac_api : str
+        Base URL of the STAC API.
+
+    Returns
+    -------
+    tuple[xr.DataTree, dict]
+        (tree, meta) where *tree* groups datasets by variable name and
+        *meta* contains ``"items"``, ``"mesh"`` (lon, lat, elem or None),
+        and ``"is_unstructured"`` flag.
+    """
+    cache_key = _collection_cache_key(collection_id, stac_api)
+    if cache_key in _datatree_cache:
+        logger.info("Returning cached DataTree for collection")
+        return _datatree_cache[cache_key]
+
+    items = _fetch_collection_items(collection_id, stac_api)
+    if not items:
+        raise ValueError(f"No items found in collection '{collection_id}'")
+
+    # Group items by variable name
+    var_groups: dict[str, list[str]] = defaultdict(list)
+    for item in items:
+        var_name = item.get("properties", {}).get("variable", "unknown")
+        href = _extract_href(item)
+        if href:
+            var_groups[var_name].append(href)
+
+    if not var_groups:
+        raise ValueError("No data assets found in collection items")
+
+    # Detect FESOM mesh from the first item that has mesh metadata
+    mesh = None
+    unstructured = False
+    for item in items:
+        mesh = get_mesh_from_stac_item(item)
+        if mesh is not None:
+            unstructured = True
+            break
+
+    # If mesh detection via STAC failed, check the first dataset directly
+    if not unstructured:
+        first_href = next(iter(next(iter(var_groups.values()))))
+        try:
+            _ds_probe = xr.open_dataset(_strip_file_uri(first_href), chunks="auto")
+            unstructured = is_unstructured(_ds_probe)
+            _ds_probe.close()
+        except Exception:
+            pass
+
+    # Build per-variable datasets
+    tree_dict: dict[str, xr.Dataset] = {}
+    for var_name, hrefs in sorted(var_groups.items()):
+        paths = [_strip_file_uri(h) for h in hrefs]
+        logger.info(
+            f"Opening {len(paths)} file(s) for variable '{var_name}'"
+        )
+        try:
+            ds = xr.open_mfdataset(
+                paths,
+                concat_dim="time",
+                combine="nested",
+                chunks="auto",
+                data_vars="minimal",
+                coords="minimal",
+                compat="override",
+            )
+            tree_dict[var_name] = ds
+        except Exception as e:
+            logger.warning(
+                f"Could not open multi-file dataset for '{var_name}': {e}. "
+                "Trying individual files."
+            )
+            # Fallback: open just the first file
+            try:
+                ds = xr.open_dataset(paths[0], chunks="auto")
+                tree_dict[var_name] = ds
+            except Exception as e2:
+                logger.error(f"Skipping variable '{var_name}': {e2}")
+
+    if not tree_dict:
+        raise ValueError("Could not open any datasets from collection items")
+
+    tree = xr.DataTree.from_dict(tree_dict)
+    meta: dict[str, Any] = {
+        "items": items,
+        "mesh": mesh,
+        "is_unstructured": unstructured,
+        "collection_id": collection_id,
+        "n_items": len(items),
+        "n_variables": len(tree_dict),
+    }
+
+    # Populate cache
+    _datatree_cache[cache_key] = (tree, meta)
+    logger.info(
+        f"Built DataTree with {len(tree_dict)} variables for collection "
+        f"'{collection_id}'"
+    )
+    return tree, meta
+
+
+def _extract_href(item: dict) -> str | None:
+    """Extract the data href from a STAC item's assets."""
+    assets = item.get("assets", {})
+    preferred = ["data", "netcdf", "nc", "grib"]
+    for key in preferred:
+        if key in assets and "href" in assets[key]:
+            return assets[key]["href"]
+    for asset in assets.values():
+        if "href" in asset:
+            return asset["href"]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Panel app
+# ---------------------------------------------------------------------------
+
+
+def create_collection_preview_app(
+    collection_id: str,
+    stac_api: str,
+) -> pn.viewable.Viewable:
+    """
+    Create a Panel app for exploring an entire STAC collection.
+
+    The app provides:
+    - Variable selector (populated from DataTree node names)
+    - Time range slider for computing temporal means
+    - Anomaly mode with reference/comparison period selectors
+    - Level/depth slider for 3D variables
+    - Smart colormap selector
+
+    Parameters
+    ----------
+    collection_id : str
+        STAC collection ID.
+    stac_api : str
+        Base URL of the STAC API.
+
+    Returns
+    -------
+    pn.viewable.Viewable
+        The Panel application layout.
+    """
+    logger.info(
+        f"Creating collection preview app: collection={collection_id}"
+    )
+
+    # Build or retrieve cached DataTree
+    try:
+        tree, meta = _build_datatree(collection_id, stac_api)
+    except Exception as e:
+        logger.error(f"Failed to build DataTree: {e}")
+        return pn.Column(
+            pn.pane.Markdown("# ESM-Viz Collection Preview"),
+            pn.pane.Alert(
+                f"Failed to load collection data: {e}",
+                alert_type="danger",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Gather variable names from the tree (top-level children)
+    variable_names = sorted(tree.children.keys())
+    if not variable_names:
+        return pn.Column(
+            pn.pane.Alert(
+                "No variables found in collection.",
+                alert_type="warning",
+            ),
+        )
+
+    mesh = meta.get("mesh")
+    unstructured = meta.get("is_unstructured", False)
+
+    # Determine global time range across all variables
+    global_n_times = 1
+    for var_name in variable_names:
+        ds = tree[var_name].dataset
+        for dim in ("time", "t"):
+            if dim in ds.dims:
+                global_n_times = max(global_n_times, ds.sizes[dim])
+                break
+
+    # Determine initial variable and its properties
+    initial_var = variable_names[0]
+    initial_cmap = get_smart_colormap(initial_var)
+
+    def _n_levels_for(var_name: str) -> int:
+        """Return the number of vertical levels for a given variable node."""
+        ds = tree[var_name].dataset
+        level_dims = {"level", "lev", "depth", "z", "nz", "nz1"}
+        for dv in ds.data_vars.values():
+            for dim in dv.dims:
+                if dim.lower() in level_dims:
+                    return dv.sizes[dim]
+        return 1
+
+    def _n_times_for(var_name: str) -> int:
+        ds = tree[var_name].dataset
+        for dim in ("time", "t"):
+            if dim in ds.dims:
+                return ds.sizes[dim]
+        return 1
+
+    # ---- Widgets ----
+
+    var_selector = pn.widgets.Select(
+        name="Variable",
+        options=variable_names,
+        value=initial_var,
+        width=250,
+    )
+
+    view_mode = pn.widgets.RadioButtonGroup(
+        name="View Mode",
+        options=["Absolute", "Anomaly"],
+        value="Absolute",
+        button_type="default",
+    )
+
+    n_t_init = _n_times_for(initial_var)
+    time_range_slider = pn.widgets.IntRangeSlider(
+        name="Time Range (avg)",
+        start=0,
+        end=max(0, n_t_init - 1),
+        value=(0, min(9, max(0, n_t_init - 1))),
+        step=1,
+        width=300,
+    )
+
+    ref_range_slider = pn.widgets.IntRangeSlider(
+        name="Reference Period",
+        start=0,
+        end=max(0, n_t_init - 1),
+        value=(0, min(9, max(0, n_t_init - 1))),
+        step=1,
+        width=300,
+        visible=False,
+    )
+
+    cmp_range_slider = pn.widgets.IntRangeSlider(
+        name="Comparison Period",
+        start=0,
+        end=max(0, n_t_init - 1),
+        value=(
+            min(10, max(0, n_t_init - 1)),
+            min(19, max(0, n_t_init - 1)),
+        ),
+        step=1,
+        width=300,
+        visible=False,
+    )
+
+    n_l_init = _n_levels_for(initial_var)
+    level_slider = pn.widgets.IntSlider(
+        name="Level / Depth",
+        start=0,
+        end=max(1, n_l_init - 1),
+        value=0,
+        step=1,
+        width=300,
+        disabled=(n_l_init <= 1),
+    )
+
+    cmap_selector = pn.widgets.Select(
+        name="Colormap",
+        options=AVAILABLE_COLORMAPS,
+        value=initial_cmap if initial_cmap in AVAILABLE_COLORMAPS else DEFAULT_COLORMAP,
+        width=180,
+    )
+
+    # Info panel
+    info_pane = pn.pane.Markdown(
+        _build_info_md(meta, variable_names, global_n_times),
+        width=280,
+    )
+
+    # ---- Reactive callbacks ----
+
+    @pn.depends(view_mode.param.value, watch=True)
+    def _toggle_anomaly(mode: str) -> None:
+        is_anomaly = mode == "Anomaly"
+        time_range_slider.visible = not is_anomaly
+        ref_range_slider.visible = is_anomaly
+        cmp_range_slider.visible = is_anomaly
+
+    @pn.depends(var_selector.param.value, watch=True)
+    def _on_variable_change(var_name: str) -> None:
+        n_t = _n_times_for(var_name)
+        for slider in (time_range_slider, ref_range_slider, cmp_range_slider):
+            slider.start = 0
+            slider.end = max(0, n_t - 1)
+
+        time_range_slider.value = (0, min(9, max(0, n_t - 1)))
+        ref_range_slider.value = (0, min(9, max(0, n_t - 1)))
+        cmp_range_slider.value = (
+            min(10, max(0, n_t - 1)),
+            min(19, max(0, n_t - 1)),
+        )
+
+        n_l = _n_levels_for(var_name)
+        level_slider.end = max(1, n_l - 1)
+        level_slider.disabled = n_l <= 1
+        if level_slider.value > level_slider.end:
+            level_slider.value = 0
+
+        smart_cmap = get_smart_colormap(var_name)
+        if smart_cmap in AVAILABLE_COLORMAPS:
+            cmap_selector.value = smart_cmap
+
+    # ---- Plot function ----
+
+    @pn.depends(
+        var_selector.param.value,
+        view_mode.param.value,
+        time_range_slider.param.value,
+        ref_range_slider.param.value,
+        cmp_range_slider.param.value,
+        level_slider.param.value,
+        cmap_selector.param.value,
+    )
+    def _render_plot(
+        var_name: str,
+        mode: str,
+        time_range: tuple[int, int],
+        ref_range: tuple[int, int],
+        cmp_range: tuple[int, int],
+        level_idx: int,
+        cmap: str,
+    ) -> Any:
+        try:
+            ds = tree[var_name].dataset
+            # Identify the data variable inside this single-variable dataset
+            data_var = _pick_data_var(ds, var_name)
+            da = ds[data_var]
+
+            # Select level if applicable
+            da = _isel_level(da, level_idx)
+
+            if mode == "Anomaly":
+                da = _compute_anomaly(da, ref_range, cmp_range)
+                plot_title = f"{var_name} anomaly (t[{cmp_range[0]}:{cmp_range[1]}] - t[{ref_range[0]}:{ref_range[1]}])"
+            else:
+                da = _compute_time_mean(da, time_range)
+                plot_title = f"{var_name} mean (t[{time_range[0]}:{time_range[1]}])"
+
+            # Compute into memory for plotting.
+            # When a distributed.Client exists it is automatically used
+            # by Dask for all .compute() calls -- no explicit routing needed.
+            if hasattr(da.data, "compute"):
+                from esm_viz.compute import get_compute_manager
+
+                manager = get_compute_manager()
+                client = manager.get_client()
+                if client:
+                    logger.debug("Using distributed client for compute")
+                da = da.compute()
+
+            if unstructured and mesh is not None:
+                lon, lat, elem = mesh
+                plot = create_interactive_fesom_plot(
+                    da, lon, lat, elem, cmap=cmap, title=plot_title
+                )
+                return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+            # Gridded path
+            plot = _create_gridded_plot(da, cmap, projection=ccrs.Robinson() if HAS_GEOVIEWS else None)
+            return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+        except Exception as e:
+            logger.error(f"Collection plot failed: {e}")
+            return pn.pane.Alert(f"Plot failed: {e}", alert_type="danger")
+
+    # ---- Layout ----
+
+    controls = pn.Column(
+        pn.pane.Markdown("## Controls"),
+        var_selector,
+        view_mode,
+        time_range_slider,
+        ref_range_slider,
+        cmp_range_slider,
+        level_slider,
+        cmap_selector,
+        pn.layout.Divider(),
+        info_pane,
+        width=320,
+    )
+
+    plot_area = pn.panel(_render_plot, sizing_mode="stretch_both")
+
+    app = pn.Column(
+        pn.pane.Markdown("# ESM-Viz Collection Preview"),
+        pn.Row(controls, plot_area, sizing_mode="stretch_both"),
+        sizing_mode="stretch_both",
+    )
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _pick_data_var(ds: xr.Dataset, hint: str) -> str:
+    """
+    Pick the most relevant data variable from a dataset.
+
+    Prefers a variable whose name matches *hint*; falls back to the first
+    plottable (ndim >= 2, numeric) variable.
+    """
+    if hint in ds.data_vars:
+        return hint
+
+    for name, var in ds.data_vars.items():
+        if var.dtype.kind in ("i", "u", "f") and var.ndim >= 2:
+            return str(name)
+
+    # Last resort -- first data var
+    return str(next(iter(ds.data_vars)))
+
+
+def _isel_level(da: xr.DataArray, level_idx: int) -> xr.DataArray:
+    """Select a single level/depth slice if a vertical dim exists."""
+    level_dims = {"level", "lev", "depth", "z", "nz", "nz1"}
+    for dim in list(da.dims):
+        if dim.lower() in level_dims:
+            safe_idx = min(level_idx, da.sizes[dim] - 1)
+            da = da.isel({dim: safe_idx})
+    return da
+
+
+def _compute_time_mean(
+    da: xr.DataArray, time_range: tuple[int, int]
+) -> xr.DataArray:
+    """Average over the selected time index range."""
+    for dim in ("time", "t"):
+        if dim in da.dims:
+            start, end = time_range
+            end = min(end, da.sizes[dim] - 1)
+            start = min(start, end)
+            da = da.isel({dim: slice(start, end + 1)}).mean(dim)
+            break
+    return da
+
+
+def _compute_anomaly(
+    da: xr.DataArray,
+    ref_range: tuple[int, int],
+    cmp_range: tuple[int, int],
+) -> xr.DataArray:
+    """Compute comparison_mean - reference_mean."""
+    ref = _compute_time_mean(da, ref_range)
+    cmp = _compute_time_mean(da, cmp_range)
+    return cmp - ref
+
+
+def _build_info_md(
+    meta: dict[str, Any],
+    variables: list[str],
+    global_n_times: int,
+) -> str:
+    """Build a Markdown info block for the sidebar."""
+    coll_id = meta.get("collection_id", "unknown")
+    n_items = meta.get("n_items", 0)
+    n_vars = meta.get("n_variables", 0)
+    mesh_type = "Unstructured (FESOM)" if meta.get("is_unstructured") else "Gridded"
+    return (
+        f"**Collection:** `{coll_id}`\n\n"
+        f"- Items: {n_items}\n"
+        f"- Variables: {n_vars}\n"
+        f"- Max time steps: {global_n_times}\n"
+        f"- Mesh type: {mesh_type}\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-experiment comparison
+# ---------------------------------------------------------------------------
+
+
+def create_comparison_preview_app(
+    collection_a: str,
+    collection_b: str,
+    stac_api: str,
+) -> pn.viewable.Viewable:
+    """
+    Create a Panel app comparing two STAC collections (experiments).
+
+    Displays three panels: Collection A mean, Collection B mean, and
+    the difference (B - A). Each collection gets its own time range
+    slider for independent temporal averaging.
+
+    Parameters
+    ----------
+    collection_a : str
+        STAC collection ID for the reference experiment.
+    collection_b : str
+        STAC collection ID for the comparison experiment.
+    stac_api : str
+        Base URL of the STAC API.
+
+    Returns
+    -------
+    pn.viewable.Viewable
+        The Panel application layout with three-panel comparison view.
+    """
+    logger.info(
+        f"Creating comparison app: {collection_a} vs {collection_b}"
+    )
+
+    # Build DataTrees for both collections
+    try:
+        tree_a, meta_a = _build_datatree(collection_a, stac_api)
+        tree_b, meta_b = _build_datatree(collection_b, stac_api)
+    except Exception as e:
+        logger.error(f"Failed to build DataTrees for comparison: {e}")
+        return pn.Column(
+            pn.pane.Markdown("# ESM-Viz Experiment Comparison"),
+            pn.pane.Alert(
+                f"Failed to load collection data: {e}",
+                alert_type="danger",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Find common variables
+    vars_a = set(tree_a.children.keys())
+    vars_b = set(tree_b.children.keys())
+    common_vars = sorted(vars_a & vars_b)
+
+    if not common_vars:
+        return pn.Column(
+            pn.pane.Markdown("# ESM-Viz Experiment Comparison"),
+            pn.pane.Alert(
+                f"No common variables between '{collection_a}' and '{collection_b}'.\n\n"
+                f"Collection A variables: {sorted(vars_a)}\n\n"
+                f"Collection B variables: {sorted(vars_b)}",
+                alert_type="warning",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Determine mesh info -- use whichever has FESOM mesh
+    mesh_a = meta_a.get("mesh")
+    mesh_b = meta_b.get("mesh")
+    unstructured_a = meta_a.get("is_unstructured", False)
+    unstructured_b = meta_b.get("is_unstructured", False)
+
+    # For difference plots, both must be on the same grid type
+    can_difference = (unstructured_a == unstructured_b)
+
+    # Time range helpers per collection
+    def _n_times_for(tree: xr.DataTree, var_name: str) -> int:
+        ds = tree[var_name].dataset
+        for dim in ("time", "t"):
+            if dim in ds.dims:
+                return ds.sizes[dim]
+        return 1
+
+    initial_var = common_vars[0]
+    initial_cmap = get_smart_colormap(initial_var)
+
+    n_t_a = _n_times_for(tree_a, initial_var)
+    n_t_b = _n_times_for(tree_b, initial_var)
+
+    # Widgets
+    var_selector = pn.widgets.Select(
+        name="Variable",
+        options=common_vars,
+        value=initial_var,
+        width=250,
+    )
+
+    range_a = pn.widgets.IntRangeSlider(
+        name=f"Time Range: {collection_a}",
+        start=0,
+        end=max(0, n_t_a - 1),
+        value=(0, max(0, n_t_a - 1)),
+        step=1,
+        width=250,
+    )
+
+    range_b = pn.widgets.IntRangeSlider(
+        name=f"Time Range: {collection_b}",
+        start=0,
+        end=max(0, n_t_b - 1),
+        value=(0, max(0, n_t_b - 1)),
+        step=1,
+        width=250,
+    )
+
+    level_slider = pn.widgets.IntSlider(
+        name="Level / Depth",
+        start=0,
+        end=1,
+        value=0,
+        step=1,
+        width=250,
+        disabled=True,
+    )
+
+    cmap_selector = pn.widgets.Select(
+        name="Colormap",
+        options=AVAILABLE_COLORMAPS,
+        value=initial_cmap if initial_cmap in AVAILABLE_COLORMAPS else DEFAULT_COLORMAP,
+        width=180,
+    )
+
+    diff_cmap_selector = pn.widgets.Select(
+        name="Difference Colormap",
+        options=["RdBu_r", "coolwarm", "BrBG", "PiYG", "PRGn"] + AVAILABLE_COLORMAPS,
+        value="RdBu_r",
+        width=180,
+    )
+
+    # Update sliders when variable changes
+    @pn.depends(var_selector.param.value, watch=True)
+    def _on_var_change(var_name: str) -> None:
+        n_a = _n_times_for(tree_a, var_name)
+        n_b = _n_times_for(tree_b, var_name)
+        range_a.end = max(0, n_a - 1)
+        range_a.value = (0, max(0, n_a - 1))
+        range_b.end = max(0, n_b - 1)
+        range_b.value = (0, max(0, n_b - 1))
+
+        # Level slider
+        n_l = 1
+        ds_a = tree_a[var_name].dataset
+        level_dims = {"level", "lev", "depth", "z", "nz", "nz1"}
+        for dv in ds_a.data_vars.values():
+            for dim in dv.dims:
+                if dim.lower() in level_dims:
+                    n_l = max(n_l, dv.sizes[dim])
+        level_slider.end = max(1, n_l - 1)
+        level_slider.disabled = (n_l <= 1)
+        if level_slider.value > level_slider.end:
+            level_slider.value = 0
+
+        smart_cmap = get_smart_colormap(var_name)
+        if smart_cmap in AVAILABLE_COLORMAPS:
+            cmap_selector.value = smart_cmap
+
+    # Plotting helper
+    def _make_plot(tree: xr.DataTree, meta: dict, var_name: str,
+                   time_range: tuple[int, int], level_idx: int,
+                   cmap: str, title: str) -> Any:
+        ds = tree[var_name].dataset
+        data_var = _pick_data_var(ds, var_name)
+        da = ds[data_var]
+        da = _isel_level(da, level_idx)
+        da = _compute_time_mean(da, time_range)
+        if hasattr(da.data, "compute"):
+            from esm_viz.compute import get_compute_manager
+
+            mgr = get_compute_manager()
+            _client = mgr.get_client()
+            if _client:
+                logger.debug("Using distributed client for comparison compute")
+            da = da.compute()
+
+        mesh = meta.get("mesh")
+        unstructured = meta.get("is_unstructured", False)
+
+        if unstructured and mesh is not None:
+            lon, lat, elem = mesh
+            plot = create_interactive_fesom_plot(
+                da, lon, lat, elem, cmap=cmap, title=title
+            )
+            return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+        plot = _create_gridded_plot(
+            da, cmap, projection=ccrs.Robinson() if HAS_GEOVIEWS else None
+        )
+        return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+    # Panel A
+    @pn.depends(
+        var_selector.param.value,
+        range_a.param.value,
+        level_slider.param.value,
+        cmap_selector.param.value,
+    )
+    def plot_a(var_name: str, tr: tuple, level_idx: int, cmap: str) -> Any:
+        try:
+            title = f"{collection_a}: {var_name} mean (t[{tr[0]}:{tr[1]}])"
+            return _make_plot(tree_a, meta_a, var_name, tr, level_idx, cmap, title)
+        except Exception as e:
+            logger.error(f"Plot A failed: {e}")
+            return pn.pane.Alert(f"Plot A failed: {e}", alert_type="danger")
+
+    # Panel B
+    @pn.depends(
+        var_selector.param.value,
+        range_b.param.value,
+        level_slider.param.value,
+        cmap_selector.param.value,
+    )
+    def plot_b(var_name: str, tr: tuple, level_idx: int, cmap: str) -> Any:
+        try:
+            title = f"{collection_b}: {var_name} mean (t[{tr[0]}:{tr[1]}])"
+            return _make_plot(tree_b, meta_b, var_name, tr, level_idx, cmap, title)
+        except Exception as e:
+            logger.error(f"Plot B failed: {e}")
+            return pn.pane.Alert(f"Plot B failed: {e}", alert_type="danger")
+
+    # Difference panel
+    @pn.depends(
+        var_selector.param.value,
+        range_a.param.value,
+        range_b.param.value,
+        level_slider.param.value,
+        diff_cmap_selector.param.value,
+    )
+    def plot_diff(var_name: str, tr_a: tuple, tr_b: tuple,
+                  level_idx: int, cmap: str) -> Any:
+        if not can_difference:
+            return pn.pane.Alert(
+                "Difference not available: collections use different grid types.",
+                alert_type="warning",
+            )
+        try:
+            ds_a = tree_a[var_name].dataset
+            ds_b = tree_b[var_name].dataset
+            dv_a = _pick_data_var(ds_a, var_name)
+            dv_b = _pick_data_var(ds_b, var_name)
+
+            da_a = _isel_level(ds_a[dv_a], level_idx)
+            da_b = _isel_level(ds_b[dv_b], level_idx)
+            mean_a = _compute_time_mean(da_a, tr_a)
+            mean_b = _compute_time_mean(da_b, tr_b)
+
+            diff = mean_b - mean_a
+            if hasattr(diff.data, "compute"):
+                from esm_viz.compute import get_compute_manager
+
+                mgr = get_compute_manager()
+                _client = mgr.get_client()
+                if _client:
+                    logger.debug("Using distributed client for diff compute")
+                diff = diff.compute()
+
+            title = f"Difference: {collection_b} - {collection_a}"
+
+            mesh = meta_a.get("mesh") or meta_b.get("mesh")
+            unstructured = meta_a.get("is_unstructured") or meta_b.get("is_unstructured")
+
+            if unstructured and mesh is not None:
+                lon, lat, elem = mesh
+                plot = create_interactive_fesom_plot(
+                    diff, lon, lat, elem, cmap=cmap, title=title
+                )
+                return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+            plot = _create_gridded_plot(
+                diff, cmap, projection=ccrs.Robinson() if HAS_GEOVIEWS else None
+            )
+            return pn.pane.HoloViews(plot, sizing_mode="stretch_both")
+
+        except Exception as e:
+            logger.error(f"Difference plot failed: {e}")
+            return pn.pane.Alert(f"Difference failed: {e}", alert_type="danger")
+
+    # Layout
+    controls = pn.Column(
+        pn.pane.Markdown("## Controls"),
+        var_selector,
+        range_a,
+        range_b,
+        level_slider,
+        cmap_selector,
+        diff_cmap_selector,
+        pn.layout.Divider(),
+        pn.pane.Markdown(
+            f"**Comparison:** `{collection_a}` vs `{collection_b}`\n\n"
+            f"- Common variables: {len(common_vars)}\n"
+            f"- Grid compatible: {'Yes' if can_difference else 'No'}\n"
+        ),
+        width=320,
+    )
+
+    plots = pn.Tabs(
+        ("Side by Side", pn.Row(
+            pn.Column(
+                pn.pane.Markdown(f"### {collection_a}"),
+                pn.panel(plot_a, sizing_mode="stretch_both"),
+                sizing_mode="stretch_both",
+            ),
+            pn.Column(
+                pn.pane.Markdown(f"### {collection_b}"),
+                pn.panel(plot_b, sizing_mode="stretch_both"),
+                sizing_mode="stretch_both",
+            ),
+            sizing_mode="stretch_both",
+        )),
+        ("Difference (B - A)", pn.panel(plot_diff, sizing_mode="stretch_both")),
+        sizing_mode="stretch_both",
+    )
+
+    app = pn.Column(
+        pn.pane.Markdown("# ESM-Viz Experiment Comparison"),
+        pn.Row(controls, plots, sizing_mode="stretch_both"),
+        sizing_mode="stretch_both",
+    )
+
+    return app

--- a/src/esm_viz/compute.py
+++ b/src/esm_viz/compute.py
@@ -1,0 +1,486 @@
+"""
+Dask distributed compute cluster management.
+
+Manages the lifecycle of Dask clusters (local, SLURM, Gateway, or
+pre-existing schedulers) so that heavy operations -- time averaging,
+anomaly computation across many files -- can be offloaded from the
+viz server to a proper distributed backend.
+
+When a ``distributed.Client`` is registered as the default client,
+all subsequent ``da.compute()`` calls automatically route to that
+cluster. The viz code does not need to pass the client explicitly.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from loguru import logger
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Optional dependency imports
+# ---------------------------------------------------------------------------
+
+try:
+    from distributed import Client, LocalCluster
+    HAS_DISTRIBUTED = True
+except ImportError:
+    HAS_DISTRIBUTED = False
+
+try:
+    import dask_gateway  # noqa: F401
+    HAS_GATEWAY = True
+except ImportError:
+    HAS_GATEWAY = False
+
+try:
+    import dask_jobqueue  # noqa: F401
+    HAS_JOBQUEUE = True
+except ImportError:
+    HAS_JOBQUEUE = False
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class ClusterType(str, Enum):
+    """Supported cluster backends."""
+
+    local = "local"
+    gateway = "gateway"
+    slurm = "slurm"
+    existing = "existing"
+
+
+class ClusterCreateRequest(BaseModel):
+    """Request body for creating or registering a cluster."""
+
+    type: ClusterType | None = Field(
+        None,
+        description=(
+            "Cluster type. Omit when connecting to an existing scheduler "
+            "via scheduler_address."
+        ),
+    )
+    workers: int = Field(2, ge=1, description="Initial number of workers.")
+    memory: str | None = Field(
+        None, description="Memory per worker, e.g. '4GiB'."
+    )
+    scheduler_address: str | None = Field(
+        None,
+        description="Address of an existing scheduler (tcp://host:port).",
+    )
+    gateway_url: str | None = Field(
+        None, description="Dask Gateway URL (for type=gateway)."
+    )
+    queue: str | None = Field(
+        None, description="SLURM queue/partition (for type=slurm)."
+    )
+    cores: int = Field(
+        2, ge=1, description="CPU cores per worker (for SLURM)."
+    )
+    name: str | None = Field(
+        None, description="Human-readable name for this cluster."
+    )
+
+
+class ClusterResponse(BaseModel):
+    """Serialisable cluster status returned by the API."""
+
+    id: str
+    name: str
+    type: str
+    status: str
+    n_workers: int
+    scheduler_address: str | None = None
+    dashboard_url: str | None = None
+    created_at: str
+
+
+class ClusterScaleRequest(BaseModel):
+    """Request body for scaling a cluster."""
+
+    workers: int | None = Field(
+        None, ge=1, description="Target number of workers (fixed scale)."
+    )
+    adapt_min: int | None = Field(
+        None, ge=0, description="Minimum workers for adaptive scaling."
+    )
+    adapt_max: int | None = Field(
+        None, ge=1, description="Maximum workers for adaptive scaling."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal bookkeeping
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ClusterInfo:
+    """Runtime state for a single managed cluster."""
+
+    id: str
+    name: str
+    type: str
+    cluster: Any  # LocalCluster | SLURMCluster | GatewayCluster | None
+    client: Any  # distributed.Client
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    owns_cluster: bool = True  # False when connecting to an existing scheduler
+
+
+# ---------------------------------------------------------------------------
+# Threshold helper
+# ---------------------------------------------------------------------------
+
+
+def should_use_cluster(n_files: int, total_size_bytes: int) -> bool:
+    """Decide whether to route computation to a cluster.
+
+    Heuristic: use a cluster when there are more than 5 files or when
+    the total data volume exceeds 1 GB.
+
+    Parameters
+    ----------
+    n_files : int
+        Number of data files involved.
+    total_size_bytes : int
+        Combined size of the data files in bytes.
+
+    Returns
+    -------
+    bool
+        True if a cluster should be used.
+    """
+    return n_files > 5 or total_size_bytes > 1_000_000_000
+
+
+# ---------------------------------------------------------------------------
+# ComputeManager
+# ---------------------------------------------------------------------------
+
+
+class ComputeManager:
+    """Lifecycle manager for Dask distributed clusters.
+
+    Maintains a registry of active clusters and their associated
+    ``distributed.Client`` instances. At most one client is set as the
+    Dask *default* at any time (the most recently created one).
+
+    All public methods are synchronous -- the cluster operations
+    themselves are blocking I/O and there is no benefit to making
+    them async given that they are called infrequently by human users.
+    """
+
+    def __init__(self) -> None:
+        self._active_clusters: dict[str, ClusterInfo] = {}
+
+    # -- helpers ----------------------------------------------------------
+
+    def _require_distributed(self) -> None:
+        if not HAS_DISTRIBUTED:
+            raise RuntimeError(
+                "The 'distributed' package is required for cluster management. "
+                "Install it with: pip install distributed"
+            )
+
+    def _build_response(self, info: ClusterInfo) -> ClusterResponse:
+        n_workers = 0
+        scheduler_address = None
+        dashboard_url = None
+        status = "unknown"
+
+        try:
+            if info.client is not None:
+                scheduler_info = info.client.scheduler_info()
+                n_workers = len(scheduler_info.get("workers", {}))
+                scheduler_address = info.client.scheduler.address
+            status = "running"
+        except Exception:
+            status = "disconnected"
+
+        if info.cluster is not None:
+            try:
+                dashboard_url = getattr(info.cluster, "dashboard_link", None)
+                if scheduler_address is None:
+                    scheduler_address = getattr(
+                        info.cluster, "scheduler_address", None
+                    )
+            except Exception:
+                pass
+
+        return ClusterResponse(
+            id=info.id,
+            name=info.name,
+            type=info.type,
+            status=status,
+            n_workers=n_workers,
+            scheduler_address=scheduler_address,
+            dashboard_url=dashboard_url,
+            created_at=info.created_at.isoformat(),
+        )
+
+    # -- public API -------------------------------------------------------
+
+    def create_cluster(self, request: ClusterCreateRequest) -> ClusterResponse:
+        """Create a new cluster or connect to an existing scheduler.
+
+        Parameters
+        ----------
+        request : ClusterCreateRequest
+            Cluster specification.
+
+        Returns
+        -------
+        ClusterResponse
+            Status of the newly created cluster.
+
+        Raises
+        ------
+        RuntimeError
+            If required packages are not installed.
+        ValueError
+            If the request is invalid.
+        """
+        self._require_distributed()
+
+        cluster_id = uuid.uuid4().hex[:12]
+        cluster_obj: Any = None
+        owns_cluster = True
+
+        # Determine effective type
+        if request.scheduler_address:
+            effective_type = ClusterType.existing
+        elif request.type is not None:
+            effective_type = request.type
+        else:
+            effective_type = ClusterType.local
+
+        name = request.name or f"{effective_type.value}-{cluster_id[:6]}"
+
+        if effective_type == ClusterType.existing:
+            logger.info(
+                "Connecting to existing scheduler at {}",
+                request.scheduler_address,
+            )
+            client = Client(request.scheduler_address)
+            owns_cluster = False
+
+        elif effective_type == ClusterType.local:
+            logger.info(
+                "Creating LocalCluster with {} workers", request.workers
+            )
+            kwargs: dict[str, Any] = {"n_workers": request.workers}
+            if request.memory:
+                kwargs["memory_limit"] = request.memory
+            cluster_obj = LocalCluster(**kwargs)
+            client = Client(cluster_obj)
+
+        elif effective_type == ClusterType.gateway:
+            if not HAS_GATEWAY:
+                raise RuntimeError(
+                    "dask_gateway is not installed. "
+                    "Install it with: pip install dask-gateway"
+                )
+            gw_url = request.gateway_url or ""
+            logger.info("Connecting via Dask Gateway at {}", gw_url)
+            gateway = dask_gateway.Gateway(gw_url)  # type: ignore[name-defined]
+            cluster_obj = gateway.new_cluster()
+            cluster_obj.scale(request.workers)
+            client = cluster_obj.get_client()
+
+        elif effective_type == ClusterType.slurm:
+            if not HAS_JOBQUEUE:
+                raise RuntimeError(
+                    "dask_jobqueue is not installed. "
+                    "Install it with: pip install dask-jobqueue"
+                )
+            logger.info(
+                "Creating SLURMCluster with {} workers, queue={}",
+                request.workers,
+                request.queue,
+            )
+            slurm_kwargs: dict[str, Any] = {
+                "cores": request.cores,
+            }
+            if request.memory:
+                slurm_kwargs["memory"] = request.memory
+            if request.queue:
+                slurm_kwargs["queue"] = request.queue
+            if request.name:
+                slurm_kwargs["name"] = request.name
+
+            cluster_obj = dask_jobqueue.SLURMCluster(**slurm_kwargs)  # type: ignore[name-defined]
+            cluster_obj.scale(jobs=request.workers)
+            client = Client(cluster_obj)
+
+        else:
+            raise ValueError(f"Unsupported cluster type: {effective_type}")
+
+        info = ClusterInfo(
+            id=cluster_id,
+            name=name,
+            type=effective_type.value,
+            cluster=cluster_obj,
+            client=client,
+            owns_cluster=owns_cluster,
+        )
+        self._active_clusters[cluster_id] = info
+
+        logger.info("Registered cluster {} (type={})", cluster_id, effective_type.value)
+        return self._build_response(info)
+
+    def list_clusters(self) -> list[ClusterResponse]:
+        """List all active clusters."""
+        return [self._build_response(info) for info in self._active_clusters.values()]
+
+    def get_cluster(self, cluster_id: str) -> ClusterResponse:
+        """Get status for a specific cluster.
+
+        Raises
+        ------
+        KeyError
+            If the cluster does not exist.
+        """
+        info = self._active_clusters.get(cluster_id)
+        if info is None:
+            raise KeyError(f"Cluster '{cluster_id}' not found")
+        return self._build_response(info)
+
+    def scale_cluster(
+        self, cluster_id: str, request: ClusterScaleRequest
+    ) -> ClusterResponse:
+        """Scale a cluster to a new worker count or enable adaptive scaling.
+
+        Parameters
+        ----------
+        cluster_id : str
+            Cluster ID.
+        request : ClusterScaleRequest
+            Scaling parameters.
+
+        Raises
+        ------
+        KeyError
+            If the cluster does not exist.
+        ValueError
+            If the cluster cannot be scaled (e.g. external scheduler).
+        """
+        info = self._active_clusters.get(cluster_id)
+        if info is None:
+            raise KeyError(f"Cluster '{cluster_id}' not found")
+
+        cluster = info.cluster
+        if cluster is None:
+            raise ValueError(
+                "Cannot scale an externally-managed scheduler; "
+                "scale it through its own management interface."
+            )
+
+        if request.adapt_min is not None and request.adapt_max is not None:
+            logger.info(
+                "Enabling adaptive scaling [{}, {}] on cluster {}",
+                request.adapt_min,
+                request.adapt_max,
+                cluster_id,
+            )
+            cluster.adapt(minimum=request.adapt_min, maximum=request.adapt_max)
+        elif request.workers is not None:
+            logger.info(
+                "Scaling cluster {} to {} workers", cluster_id, request.workers
+            )
+            cluster.scale(request.workers)
+        else:
+            raise ValueError(
+                "Provide either 'workers' for fixed scaling or "
+                "'adapt_min'/'adapt_max' for adaptive scaling."
+            )
+
+        return self._build_response(info)
+
+    def delete_cluster(self, cluster_id: str) -> None:
+        """Disconnect from (and optionally shut down) a cluster.
+
+        Parameters
+        ----------
+        cluster_id : str
+            Cluster ID.
+
+        Raises
+        ------
+        KeyError
+            If the cluster does not exist.
+        """
+        info = self._active_clusters.pop(cluster_id, None)
+        if info is None:
+            raise KeyError(f"Cluster '{cluster_id}' not found")
+
+        # Close the client
+        try:
+            if info.client is not None:
+                info.client.close()
+                logger.info("Closed client for cluster {}", cluster_id)
+        except Exception as exc:
+            logger.warning("Error closing client for cluster {}: {}", cluster_id, exc)
+
+        # Shut down the cluster only if we own it
+        if info.owns_cluster and info.cluster is not None:
+            try:
+                info.cluster.close()
+                logger.info("Shut down cluster {}", cluster_id)
+            except Exception as exc:
+                logger.warning(
+                    "Error shutting down cluster {}: {}", cluster_id, exc
+                )
+
+    def get_client(self, cluster_id: str | None = None) -> Any:
+        """Return the best available ``distributed.Client``, or ``None``.
+
+        Parameters
+        ----------
+        cluster_id : str, optional
+            If provided, return the client for that specific cluster.
+            Otherwise return the most recently created client.
+
+        Returns
+        -------
+        distributed.Client or None
+            The client instance, or None if no clusters are registered.
+        """
+        if cluster_id is not None:
+            info = self._active_clusters.get(cluster_id)
+            return info.client if info is not None else None
+
+        if not self._active_clusters:
+            return None
+
+        # Return the most recently created cluster's client
+        latest = max(
+            self._active_clusters.values(), key=lambda i: i.created_at
+        )
+        return latest.client
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_compute_manager: ComputeManager | None = None
+
+
+def get_compute_manager() -> ComputeManager:
+    """Return the module-level ``ComputeManager`` singleton.
+
+    Creates it on first call.
+    """
+    global _compute_manager
+    if _compute_manager is None:
+        _compute_manager = ComputeManager()
+    return _compute_manager

--- a/src/esm_viz/compute_routes.py
+++ b/src/esm_viz/compute_routes.py
@@ -1,0 +1,162 @@
+"""
+REST API routes for Dask compute cluster management.
+
+Endpoints::
+
+    POST   /compute/clusters          - Create or register a cluster
+    GET    /compute/clusters          - List active clusters
+    GET    /compute/clusters/{id}     - Get cluster status
+    PATCH  /compute/clusters/{id}     - Scale workers
+    DELETE /compute/clusters/{id}     - Disconnect / shutdown
+
+Example usage with curl::
+
+    # Create a local cluster
+    curl -X POST http://localhost:8000/compute/clusters \\
+        -H "Content-Type: application/json" \\
+        -d '{"type": "local", "workers": 4}'
+
+    # Connect to an existing scheduler
+    curl -X POST http://localhost:8000/compute/clusters \\
+        -H "Content-Type: application/json" \\
+        -d '{"scheduler_address": "tcp://10.0.0.5:8786"}'
+
+    # List clusters
+    curl http://localhost:8000/compute/clusters
+
+    # Scale a cluster
+    curl -X PATCH http://localhost:8000/compute/clusters/abc123 \\
+        -H "Content-Type: application/json" \\
+        -d '{"workers": 8}'
+
+    # Delete a cluster
+    curl -X DELETE http://localhost:8000/compute/clusters/abc123
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Response
+from loguru import logger
+from pydantic import BaseModel
+
+from esm_viz.compute import (
+    ClusterCreateRequest,
+    ClusterResponse,
+    ClusterScaleRequest,
+    ComputeManager,
+    get_compute_manager,
+)
+
+
+class ClusterListResponse(BaseModel):
+    """Response for GET /compute/clusters."""
+
+    clusters: list[ClusterResponse]
+    total: int
+
+
+def create_compute_router(
+    manager: ComputeManager | None = None,
+) -> APIRouter:
+    """Create the compute management router.
+
+    Parameters
+    ----------
+    manager : ComputeManager, optional
+        Injected manager instance. If not provided, the module-level
+        singleton from ``get_compute_manager()`` is used.
+
+    Returns
+    -------
+    APIRouter
+        FastAPI router with compute cluster CRUD endpoints.
+    """
+    router = APIRouter(prefix="/compute", tags=["Compute Management"])
+
+    def _mgr() -> ComputeManager:
+        return manager if manager is not None else get_compute_manager()
+
+    @router.post(
+        "/clusters",
+        response_model=ClusterResponse,
+        status_code=201,
+    )
+    async def create_cluster(body: ClusterCreateRequest) -> ClusterResponse:
+        """Create a new Dask cluster or connect to an existing scheduler.
+
+        Request body fields:
+            - type: "local", "gateway", "slurm", or omit for existing
+            - workers: Number of workers (default 2)
+            - memory: Memory per worker, e.g. "4GiB"
+            - scheduler_address: tcp://... for existing schedulers
+            - gateway_url: Dask Gateway URL
+            - queue: SLURM partition
+            - cores: Cores per worker (SLURM)
+            - name: Human-readable cluster name
+        """
+        try:
+            return _mgr().create_cluster(body)
+        except RuntimeError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+        except Exception as exc:
+            logger.exception("Cluster creation failed: {}", exc)
+            raise HTTPException(
+                status_code=500, detail=f"Cluster creation failed: {exc}"
+            )
+
+    @router.get("/clusters", response_model=ClusterListResponse)
+    async def list_clusters() -> ClusterListResponse:
+        """List all active compute clusters."""
+        clusters = _mgr().list_clusters()
+        return ClusterListResponse(clusters=clusters, total=len(clusters))
+
+    @router.get("/clusters/{cluster_id}", response_model=ClusterResponse)
+    async def get_cluster(cluster_id: str) -> ClusterResponse:
+        """Get status for a specific cluster."""
+        try:
+            return _mgr().get_cluster(cluster_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Cluster '{cluster_id}' not found",
+            )
+
+    @router.patch("/clusters/{cluster_id}", response_model=ClusterResponse)
+    async def scale_cluster(
+        cluster_id: str, body: ClusterScaleRequest
+    ) -> ClusterResponse:
+        """Scale a cluster's worker count or enable adaptive scaling.
+
+        Request body (at least one required):
+            - workers: Target number of workers
+            - adapt_min / adapt_max: Enable adaptive scaling
+        """
+        try:
+            return _mgr().scale_cluster(cluster_id, body)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Cluster '{cluster_id}' not found",
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    @router.delete("/clusters/{cluster_id}", status_code=204)
+    async def delete_cluster(cluster_id: str) -> Response:
+        """Disconnect from (and optionally shut down) a cluster.
+
+        If the cluster was created by this manager it will be shut down.
+        If it was an external scheduler, only the client is disconnected.
+        """
+        try:
+            _mgr().delete_cluster(cluster_id)
+        except KeyError:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Cluster '{cluster_id}' not found",
+            )
+        return Response(status_code=204)
+
+    return router

--- a/src/esm_viz/environment.yml
+++ b/src/esm_viz/environment.yml
@@ -1,0 +1,42 @@
+name: esm-viz
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python>=3.10
+  # Web framework
+  - fastapi>=0.109.0
+  - uvicorn>=0.27.0
+  - httpx>=0.26.0
+  # Data handling
+  - xarray>=2024.1.0
+  - dask>=2024.1.0
+  - netcdf4>=1.6.5
+  - h5netcdf>=1.3.0
+  - cfgrib>=0.9.10
+  - eccodes>=2.33.0
+  # Visualization
+  - matplotlib>=3.8.0
+  - cartopy>=0.22.0
+  - scipy>=1.12.0
+  # Interactive (Panel/hvplot with FastAPI integration)
+  - panel>=1.5.0
+  - hvplot>=0.9.0
+  - holoviews>=1.18.0
+  - bokeh>=3.3.0
+  - geoviews>=1.11.0
+  # Scientific colormaps for climate data
+  - cmocean>=4.0
+  # Remote access
+  - fsspec>=2024.2.0
+  - paramiko>=3.4.0
+  # Utilities
+  - loguru>=0.7.2
+  - typer>=0.9.0
+  - pydantic>=2.5.0
+  - pydantic-settings>=2.1.0
+  - numpy>=1.26.0
+  # Panel FastAPI integration (pip install)
+  - pip
+  - pip:
+    - panel[fastapi]>=1.5.0

--- a/src/esm_viz/fesom.py
+++ b/src/esm_viz/fesom.py
@@ -1,0 +1,499 @@
+"""
+FESOM unstructured mesh support module.
+
+Provides detection, mesh loading, and plotting utilities for FESOM
+(Finite-volumE Sea ice-Ocean Model) data which uses unstructured
+triangular meshes instead of regular lat/lon grids.
+
+Mesh coordinates and triangulation are loaded from the standard FESOM
+mesh files (nod2d.out, elem2d.out) whose path is extracted from
+STAC item properties (nml:fesom:paths:meshpath).
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.tri as tri
+import numpy as np
+import xarray as xr
+from loguru import logger
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def is_unstructured(ds: xr.Dataset) -> bool:
+    """
+    Detect if a dataset uses an unstructured mesh.
+
+    Checks for common indicators of unstructured mesh data:
+    - Presence of 'nod2' or 'node' dimensions (FESOM)
+    - Presence of triangulation connectivity arrays
+    - Single spatial dimension with 'ncells' or similar naming
+    """
+    unstructured_dims = {
+        "nod2", "nod3", "node", "nodes", "ncells", "nelem",
+        "n_node", "n_nodes", "n_cell", "n_cells", "npoints"
+    }
+
+    dims_lower = {dim.lower() for dim in ds.dims}
+    if dims_lower & unstructured_dims:
+        return True
+
+    connectivity_vars = {"elem", "elements", "tri", "triangles", "face_node_connectivity"}
+    vars_lower = {var.lower() for var in ds.data_vars} | {coord.lower() for coord in ds.coords}
+    if vars_lower & connectivity_vars:
+        return True
+
+    if ds.attrs.get("source", "").lower().startswith("fesom"):
+        return True
+
+    if any("fesom" in str(attr).lower() for attr in ds.attrs.values()):
+        return True
+
+    for var in ds.data_vars.values():
+        spatial_dims = [d for d in var.dims if d not in ("time", "t", "level", "lev", "depth")]
+        if len(spatial_dims) == 1:
+            dim_name = spatial_dims[0].lower()
+            if any(indicator in dim_name for indicator in ["nod", "cell", "elem", "point"]):
+                return True
+
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Mesh loading from FESOM mesh files
+# ---------------------------------------------------------------------------
+
+def _euler_rotation(lon: np.ndarray, lat: np.ndarray,
+                    alpha: float, beta: float, gamma: float) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Rotate coordinates from rotated to geographical using Euler angles.
+
+    This undoes the rotation applied by FESOM when force_rotation=True.
+    Based on the pyfesom2 rotation implementation.
+    """
+    rad = np.pi / 180.0
+
+    lon_r = lon * rad
+    lat_r = lat * rad
+
+    rotate_matrix = np.zeros((3, 3))
+    rotate_matrix[0, 0] = (np.cos(gamma * rad) * np.cos(alpha * rad)
+                           - np.sin(gamma * rad) * np.cos(beta * rad) * np.sin(alpha * rad))
+    rotate_matrix[0, 1] = (np.cos(gamma * rad) * np.sin(alpha * rad)
+                           + np.sin(gamma * rad) * np.cos(beta * rad) * np.cos(alpha * rad))
+    rotate_matrix[0, 2] = np.sin(gamma * rad) * np.sin(beta * rad)
+    rotate_matrix[1, 0] = (-np.sin(gamma * rad) * np.cos(alpha * rad)
+                           - np.cos(gamma * rad) * np.cos(beta * rad) * np.sin(alpha * rad))
+    rotate_matrix[1, 1] = (-np.sin(gamma * rad) * np.sin(alpha * rad)
+                           + np.cos(gamma * rad) * np.cos(beta * rad) * np.cos(alpha * rad))
+    rotate_matrix[1, 2] = np.cos(gamma * rad) * np.sin(beta * rad)
+    rotate_matrix[2, 0] = np.sin(beta * rad) * np.sin(alpha * rad)
+    rotate_matrix[2, 1] = -np.sin(beta * rad) * np.cos(alpha * rad)
+    rotate_matrix[2, 2] = np.cos(beta * rad)
+
+    # Convert to Cartesian
+    x = np.cos(lat_r) * np.cos(lon_r)
+    y = np.cos(lat_r) * np.sin(lon_r)
+    z = np.sin(lat_r)
+
+    # Apply inverse rotation (transpose)
+    rot_inv = rotate_matrix.T
+    xr = rot_inv[0, 0] * x + rot_inv[0, 1] * y + rot_inv[0, 2] * z
+    yr = rot_inv[1, 0] * x + rot_inv[1, 1] * y + rot_inv[1, 2] * z
+    zr = rot_inv[2, 0] * x + rot_inv[2, 1] * y + rot_inv[2, 2] * z
+
+    lat_geo = np.arcsin(np.clip(zr, -1, 1)) / rad
+    lon_geo = np.arctan2(yr, xr) / rad
+
+    return lon_geo, lat_geo
+
+
+@lru_cache(maxsize=8)
+def load_fesom_mesh(meshpath: str, alpha: float = 0.0, beta: float = 0.0,
+                    gamma: float = 0.0, force_rotation: bool = False
+                    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Load FESOM mesh from nod2d.out and elem2d.out files.
+
+    Results are cached by meshpath + rotation parameters so repeated
+    requests for the same mesh are fast.
+
+    Parameters
+    ----------
+    meshpath : str
+        Path to the FESOM mesh directory containing nod2d.out and elem2d.out.
+    alpha, beta, gamma : float
+        Euler rotation angles (degrees). Only used when force_rotation is True.
+    force_rotation : bool
+        Whether the mesh uses a rotated grid that needs to be unrotated.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, np.ndarray]
+        (lon, lat, elem) where lon/lat are 1D arrays of node coordinates
+        and elem is (n_triangles, 3) 0-based connectivity.
+    """
+    meshdir = Path(meshpath)
+    nod2d_path = meshdir / "nod2d.out"
+    elem2d_path = meshdir / "elem2d.out"
+
+    if not nod2d_path.exists():
+        raise FileNotFoundError(f"FESOM mesh file not found: {nod2d_path}")
+    if not elem2d_path.exists():
+        raise FileNotFoundError(f"FESOM mesh file not found: {elem2d_path}")
+
+    # Read nod2d.out: first line is count, then "id lon lat flag"
+    logger.info(f"Loading FESOM mesh from {meshpath}")
+    nod2d = np.loadtxt(str(nod2d_path), skiprows=1)
+    lon = nod2d[:, 1].astype(np.float64)
+    lat = nod2d[:, 2].astype(np.float64)
+
+    # Read elem2d.out: first line is count, then "node1 node2 node3" (1-based)
+    elem = np.loadtxt(str(elem2d_path), skiprows=1, dtype=int) - 1  # convert to 0-based
+
+    # Apply inverse Euler rotation if needed
+    if force_rotation and (alpha != 0 or beta != 0 or gamma != 0):
+        logger.info(f"Applying inverse Euler rotation: alpha={alpha}, beta={beta}, gamma={gamma}")
+        lon, lat = _euler_rotation(lon, lat, alpha, beta, gamma)
+
+    logger.info(f"Loaded mesh: {len(lon)} nodes, {len(elem)} elements")
+    return lon, lat, elem
+
+
+def get_mesh_from_stac_item(item: dict) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """
+    Load a FESOM mesh using metadata from a STAC item's properties.
+
+    Extracts the mesh path from ``nml:fesom:paths:meshpath`` or
+    ``file:FESOM_MeshPath``, and rotation parameters from the
+    ``nml:fesom:geometry:*`` properties.
+
+    Parameters
+    ----------
+    item : dict
+        STAC item with properties containing mesh metadata.
+
+    Returns
+    -------
+    tuple or None
+        (lon, lat, elem) if mesh can be loaded, None otherwise.
+    """
+    props = item.get("properties", {})
+
+    meshpath = props.get("nml:fesom:paths:meshpath") or props.get("file:FESOM_MeshPath")
+    if not meshpath:
+        logger.warning("No mesh path found in STAC item properties")
+        return None
+
+    force_rotation_raw = props.get("nml:fesom:geometry:force_rotation")
+    # FESOM uses -1 for true in some contexts, or actual bool
+    if isinstance(force_rotation_raw, bool):
+        force_rotation = force_rotation_raw
+    elif isinstance(force_rotation_raw, (int, float)):
+        force_rotation = bool(force_rotation_raw)  # -1 -> True, 0 -> False
+    else:
+        force_rotation = False
+
+    alpha = float(props.get("nml:fesom:geometry:alphaeuler", 0))
+    beta = float(props.get("nml:fesom:geometry:betaeuler", 0))
+    gamma = float(props.get("nml:fesom:geometry:gammaeuler", 0))
+
+    try:
+        return load_fesom_mesh(meshpath, alpha, beta, gamma, force_rotation)
+    except FileNotFoundError as e:
+        logger.error(f"Could not load FESOM mesh: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Cyclic element filtering
+# ---------------------------------------------------------------------------
+
+def _trim_mesh_to_data(lon: np.ndarray, lat: np.ndarray, elem: np.ndarray,
+                       n_data: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """
+    Trim mesh to match data size when there's a mismatch.
+
+    FESOM mesh files (nod2d.out) sometimes include extra boundary nodes
+    that aren't present in the output data. This filters elements that
+    reference nodes beyond the data array size and truncates coordinates.
+    """
+    n_mesh = len(lon)
+    if n_mesh == n_data:
+        return lon, lat, elem
+
+    logger.warning(f"Mesh/data size mismatch: mesh has {n_mesh} nodes, data has {n_data} values")
+
+    if n_mesh > n_data:
+        # Filter out elements that reference nodes beyond the data size
+        valid_mask = np.all(elem < n_data, axis=1)
+        elem = elem[valid_mask]
+        lon = lon[:n_data]
+        lat = lat[:n_data]
+        n_removed = (~valid_mask).sum()
+        logger.info(f"Trimmed mesh: removed {n_removed} elements referencing extra nodes")
+
+    return lon, lat, elem
+
+
+def _remove_cyclic_elements(lon: np.ndarray, elem: np.ndarray,
+                            threshold: float = 100.0) -> np.ndarray:
+    """
+    Remove triangles that span the antimeridian (cyclic boundary).
+
+    These triangles create visual artifacts -- long horizontal streaks
+    across the entire plot.
+    """
+    elem_lon = lon[elem]
+    lon_range = elem_lon.max(axis=1) - elem_lon.min(axis=1)
+    mask = lon_range < threshold
+    n_removed = (~mask).sum()
+    if n_removed > 0:
+        logger.debug(f"Removed {n_removed} cyclic elements")
+    return elem[mask]
+
+
+# ---------------------------------------------------------------------------
+# Static (matplotlib) plotting
+# ---------------------------------------------------------------------------
+
+def plot_unstructured(
+    data_array: xr.DataArray,
+    cmap: str = "viridis",
+    ds: xr.Dataset | None = None,
+    figsize: tuple[int, int] = (12, 8),
+    add_coastlines: bool = True,
+    title: str | None = None,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    stac_item: dict | None = None,
+) -> plt.Figure:
+    """
+    Create a matplotlib plot from unstructured FESOM mesh data.
+
+    Uses the STAC item properties to locate the mesh files (nod2d.out,
+    elem2d.out) and rotation parameters. Falls back to scatter plot
+    if mesh cannot be loaded.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        Data on unstructured mesh nodes (1D spatial dimension).
+    cmap : str
+        Matplotlib colormap name.
+    ds : xr.Dataset, optional
+        Parent dataset (unused, kept for API compatibility).
+    stac_item : dict, optional
+        STAC item containing mesh path in properties.
+    """
+    matplotlib.use("Agg")
+
+    fig, ax = plt.subplots(
+        figsize=figsize,
+        subplot_kw={"projection": ccrs.Robinson()},
+    )
+
+    values = data_array.values
+    if hasattr(values, "compute"):
+        values = values.compute()
+    values = values.ravel()
+
+    # Try to load mesh from STAC item
+    mesh = None
+    if stac_item is not None:
+        mesh = get_mesh_from_stac_item(stac_item)
+
+    if mesh is not None:
+        lon, lat, elem = mesh
+        lon, lat, elem = _trim_mesh_to_data(lon, lat, elem, len(values))
+        elem_clean = _remove_cyclic_elements(lon, elem)
+
+        try:
+            triang = tri.Triangulation(lon, lat, elem_clean)
+
+            # Compute element-mean values for flat shading
+            elem_values = values[elem_clean].mean(axis=1)
+
+            im = ax.tripcolor(
+                triang,
+                facecolors=elem_values,
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                transform=ccrs.PlateCarree(),
+                shading="flat",
+            )
+            ax.set_global()
+            logger.info("Created triangulated FESOM plot")
+        except Exception as e:
+            logger.warning(f"Triangulation failed: {e}, using scatter")
+            im = ax.scatter(
+                lon, lat, c=values, cmap=cmap, s=0.5,
+                vmin=vmin, vmax=vmax, transform=ccrs.PlateCarree(),
+            )
+            ax.set_global()
+    else:
+        logger.warning("No mesh available -- falling back to index-based plot")
+        ax = fig.add_subplot(111)
+        im = ax.plot(values)
+        add_coastlines = False
+
+    if add_coastlines:
+        try:
+            ax.add_feature(cfeature.COASTLINE, linewidth=0.5, edgecolor="black")
+            ax.add_feature(cfeature.LAND, facecolor="lightgray", alpha=0.3)
+        except Exception as e:
+            logger.warning(f"Could not add coastlines: {e}")
+
+    if hasattr(im, "colorbar") or not isinstance(im, list):
+        try:
+            cbar = fig.colorbar(im, ax=ax, orientation="horizontal", pad=0.05, shrink=0.8)
+            if "units" in data_array.attrs:
+                cbar.set_label(data_array.attrs["units"])
+        except Exception:
+            pass
+
+    if title is None:
+        title = data_array.attrs.get("long_name", data_array.name or "FESOM Data")
+    ax.set_title(title, fontsize=12)
+
+    plt.tight_layout()
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# Interactive (Panel/GeoViews) plotting
+# ---------------------------------------------------------------------------
+
+def create_interactive_fesom_plot(
+    data_array: xr.DataArray,
+    lon: np.ndarray,
+    lat: np.ndarray,
+    elem: np.ndarray,
+    cmap: str = "viridis",
+    title: str | None = None,
+):
+    """
+    Create an interactive GeoViews TriMesh + datashader plot for FESOM data.
+
+    This produces the same kind of visualization as the AWI-ESM documentation
+    notebooks: rasterized triangulated data with proper geographic projection.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        1D data on mesh nodes.
+    lon, lat : np.ndarray
+        Node coordinates (geographic, after rotation).
+    elem : np.ndarray
+        Element connectivity (n_triangles, 3), 0-based.
+    cmap : str
+        Colormap name (matplotlib or colorcet).
+
+    Returns
+    -------
+    holoviews.Element
+        A rasterized TriMesh suitable for Panel serving.
+    """
+    import datashader as ds_module
+    import geoviews as gv
+    import geoviews.feature as gf
+    import holoviews as hv
+    from holoviews.operation.datashader import rasterize
+
+    hv.extension("bokeh")
+
+    values = data_array.values
+    if hasattr(values, "compute"):
+        values = values.compute()
+    values = values.ravel()
+
+    var_name = data_array.name or "value"
+    long_name = data_array.attrs.get("long_name", var_name)
+    units = data_array.attrs.get("units", "")
+
+    if title is None:
+        title = f"{long_name}" + (f" [{units}]" if units else "")
+
+    # Trim mesh to match data size (FESOM mesh files may have extra nodes)
+    lon, lat, elem = _trim_mesh_to_data(lon, lat, elem, len(values))
+
+    # Remove cyclic elements
+    elem_clean = _remove_cyclic_elements(lon, elem)
+
+    # Compute element-center coordinates and mean values.
+    # We use element centers as Points instead of TriMesh because
+    # gv.project() drops nodes during reprojection, causing IndexError
+    # when rasterize() tries to access the dropped node indices.
+    elem_values = values[elem_clean].mean(axis=1)
+    elem_lon = lon[elem_clean].mean(axis=1)
+    elem_lat = lat[elem_clean].mean(axis=1)
+
+    resolved_cmap = _resolve_cmap(cmap, var_name)
+    projection = ccrs.Robinson()
+
+    # Use gv.Points (geographic) so we get proper projection + coastlines
+    points = gv.Points(
+        (elem_lon, elem_lat, elem_values),
+        kdims=["Longitude", "Latitude"],
+        vdims=[var_name],
+    )
+
+    rasterized = rasterize(
+        points, aggregator=ds_module.mean(var_name)
+    ).opts(
+        cmap=resolved_cmap,
+        height=500,
+        width=800,
+        projection=projection,
+        colorbar=True,
+        colorbar_position="bottom",
+        clabel=f"{long_name} ({units})" if units else long_name,
+        bgcolor="darkgray",
+        color_levels=25,
+        title=title,
+        tools=["hover", "wheel_zoom", "pan", "reset", "save"],
+        global_extent=True,
+    )
+
+    # Overlay coastlines
+    plot = rasterized * gf.coastline()
+
+    return plot
+
+
+def _resolve_cmap(cmap: str, var_name: str) -> Any:
+    """Resolve a colormap name, with smart defaults for climate variables."""
+    # Smart defaults based on variable name
+    climate_cmaps = {
+        "sst": "thermal", "temp": "thermal", "temperature": "thermal",
+        "salt": "haline", "sss": "haline", "salinity": "haline",
+        "ssh": "balance", "zos": "balance",
+        "u_ice": "balance", "v_ice": "balance",
+        "m_ice": "ice", "a_ice": "ice",
+        "precip": "rain", "evap": "rain",
+    }
+
+    if cmap == "viridis":
+        # Only override default; if user chose a specific cmap, respect it
+        cmap = climate_cmaps.get(var_name.lower(), cmap)
+
+    try:
+        import cmocean.cm as cmo
+        if hasattr(cmo, cmap):
+            return getattr(cmo, cmap)
+    except ImportError:
+        pass
+
+    return cmap

--- a/src/esm_viz/interactive.py
+++ b/src/esm_viz/interactive.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 Interactive visualization module using Panel/hvplot.
 

--- a/src/esm_viz/interactive.py
+++ b/src/esm_viz/interactive.py
@@ -1,0 +1,890 @@
+"""
+Interactive visualization module using Panel/hvplot.
+
+This module provides interactive web-based visualization apps for
+exploring climate datasets in the browser using Panel, hvplot, and geoviews.
+"""
+
+from typing import Any
+
+import numpy as np
+import panel as pn
+import xarray as xr
+from loguru import logger
+
+# Enable Panel extensions
+pn.extension("bokeh")
+
+# Attempt to import hvplot and geoviews - these are required for full functionality
+try:
+    import hvplot.xarray  # noqa: F401 - registers hvplot accessor
+    import holoviews as hv
+    import geoviews as gv
+    import geoviews.feature as gf
+    from cartopy import crs as ccrs
+
+    HAS_GEOVIEWS = True
+except ImportError as e:
+    logger.warning(f"GeoViews not available, some features will be limited: {e}")
+    HAS_GEOVIEWS = False
+
+# Attempt to import cmocean colormaps
+try:
+    import cmocean.cm as cmo
+
+    HAS_CMOCEAN = True
+except ImportError:
+    logger.warning("cmocean not available, using fallback colormaps")
+    HAS_CMOCEAN = False
+
+
+# Smart colormap mapping based on variable names
+VARIABLE_COLORMAP_MAPPING: dict[str, str] = {
+    # Temperature variables
+    "temp": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    "temperature": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    "sst": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    "t2m": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    "tas": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    "thetao": "cmo.thermal" if HAS_CMOCEAN else "inferno",
+    # Salinity variables
+    "salt": "cmo.haline" if HAS_CMOCEAN else "viridis",
+    "salinity": "cmo.haline" if HAS_CMOCEAN else "viridis",
+    "sss": "cmo.haline" if HAS_CMOCEAN else "viridis",
+    "so": "cmo.haline" if HAS_CMOCEAN else "viridis",
+    "sos": "cmo.haline" if HAS_CMOCEAN else "viridis",
+    # Sea surface height / dynamic topography
+    "ssh": "cmo.balance" if HAS_CMOCEAN else "RdBu_r",
+    "zos": "cmo.balance" if HAS_CMOCEAN else "RdBu_r",
+    "sea_surface_height": "cmo.balance" if HAS_CMOCEAN else "RdBu_r",
+    "adt": "cmo.balance" if HAS_CMOCEAN else "RdBu_r",
+    # Velocity / speed
+    "u": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    "v": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    "speed": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    "uo": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    "vo": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    "current": "cmo.speed" if HAS_CMOCEAN else "plasma",
+    # Ice variables
+    "ice": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    "sic": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    "a_ice": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    "siconc": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    "ice_concentration": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    "m_ice": "cmo.ice" if HAS_CMOCEAN else "Blues_r",
+    # Density
+    "rho": "cmo.dense" if HAS_CMOCEAN else "viridis",
+    "density": "cmo.dense" if HAS_CMOCEAN else "viridis",
+    # Chlorophyll / bio
+    "chl": "cmo.algae" if HAS_CMOCEAN else "Greens",
+    "chlorophyll": "cmo.algae" if HAS_CMOCEAN else "Greens",
+    # Oxygen
+    "o2": "cmo.oxy" if HAS_CMOCEAN else "YlGnBu",
+    "oxygen": "cmo.oxy" if HAS_CMOCEAN else "YlGnBu",
+    # Bathymetry / depth
+    "bathymetry": "cmo.deep" if HAS_CMOCEAN else "Blues",
+    "depth": "cmo.deep" if HAS_CMOCEAN else "Blues",
+    # Wind
+    "wind": "cmo.amp" if HAS_CMOCEAN else "magma",
+    "wspd": "cmo.amp" if HAS_CMOCEAN else "magma",
+}
+
+DEFAULT_COLORMAP = "viridis"
+
+# Available colormaps for the picker widget
+AVAILABLE_COLORMAPS = [
+    "viridis",
+    "plasma",
+    "inferno",
+    "magma",
+    "cividis",
+    "RdBu_r",
+    "coolwarm",
+    "Blues",
+    "Reds",
+    "Greens",
+]
+
+if HAS_CMOCEAN:
+    AVAILABLE_COLORMAPS = [
+        "cmo.thermal",
+        "cmo.haline",
+        "cmo.balance",
+        "cmo.speed",
+        "cmo.ice",
+        "cmo.dense",
+        "cmo.algae",
+        "cmo.deep",
+        "cmo.amp",
+        "cmo.oxy",
+    ] + AVAILABLE_COLORMAPS
+
+
+def get_smart_colormap(variable_name: str) -> str:
+    """
+    Select an appropriate colormap based on the variable name.
+
+    Uses pattern matching to identify common climate variable types
+    and returns a scientifically appropriate colormap.
+
+    Parameters
+    ----------
+    variable_name : str
+        Name of the variable to get colormap for.
+
+    Returns
+    -------
+    str
+        Colormap name suitable for the variable.
+    """
+    var_lower = variable_name.lower()
+
+    # Direct match
+    if var_lower in VARIABLE_COLORMAP_MAPPING:
+        return VARIABLE_COLORMAP_MAPPING[var_lower]
+
+    # Pattern matching for partial matches
+    for pattern, cmap in VARIABLE_COLORMAP_MAPPING.items():
+        if pattern in var_lower:
+            return cmap
+
+    return DEFAULT_COLORMAP
+
+
+def _get_colormap_object(cmap_name: str) -> Any:
+    """
+    Get the actual colormap object from a name string.
+
+    Handles both matplotlib and cmocean colormap names.
+
+    Parameters
+    ----------
+    cmap_name : str
+        Colormap name (e.g., 'viridis', 'cmo.thermal').
+
+    Returns
+    -------
+    Any
+        Colormap object usable by hvplot/holoviews.
+    """
+    if cmap_name.startswith("cmo.") and HAS_CMOCEAN:
+        cmap_attr = cmap_name.replace("cmo.", "")
+        return getattr(cmo, cmap_attr, None)
+    return cmap_name
+
+
+def _get_plottable_variables(ds: xr.Dataset) -> list[str]:
+    """
+    Get list of variables suitable for plotting from a dataset.
+
+    Filters out coordinate variables and non-numeric data.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset to analyze.
+
+    Returns
+    -------
+    list[str]
+        List of variable names that can be plotted.
+    """
+    variables = []
+    for var_name, var_data in ds.data_vars.items():
+        # Skip non-numeric types
+        if var_data.dtype.kind not in ("i", "u", "f"):
+            continue
+        # Skip 0D or 1D variables (likely scalars or coordinates)
+        if var_data.ndim < 2:
+            continue
+        variables.append(var_name)
+
+    return sorted(variables)
+
+
+def _get_variable_display_names(ds: xr.Dataset, variables: list[str]) -> dict[str, str]:
+    """
+    Create a mapping of display names to variable names.
+
+    Display names show both short name and long name for clarity.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset containing the variables.
+    variables : list[str]
+        List of variable names to create display names for.
+
+    Returns
+    -------
+    dict[str, str]
+        Mapping of display name -> variable name.
+    """
+    display_map = {}
+    for var_name in variables:
+        var_data = ds[var_name]
+        long_name = var_data.attrs.get("long_name", "")
+        units = var_data.attrs.get("units", "")
+
+        if long_name:
+            if units:
+                display_name = f"{var_name} ({long_name}, {units})"
+            else:
+                display_name = f"{var_name} ({long_name})"
+        else:
+            display_name = var_name
+
+        display_map[display_name] = var_name
+
+    return display_map
+
+
+def _select_time_slice(
+    data_array: xr.DataArray, time_index: int
+) -> xr.DataArray:
+    """
+    Select a time slice from a data array if it has a time dimension.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        Input data array.
+    time_index : int
+        Time index to select.
+
+    Returns
+    -------
+    xr.DataArray
+        Data array with time dimension reduced.
+    """
+    time_dims = ["time", "t"]
+    for dim in time_dims:
+        if dim in data_array.dims:
+            max_time = data_array.sizes[dim] - 1
+            safe_index = min(time_index, max_time)
+            return data_array.isel({dim: safe_index})
+    return data_array
+
+
+def _select_level_slice(
+    data_array: xr.DataArray, level_index: int
+) -> xr.DataArray:
+    """
+    Select a level/depth slice from a data array if present.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        Input data array.
+    level_index : int
+        Level index to select.
+
+    Returns
+    -------
+    xr.DataArray
+        Data array with level dimension reduced.
+    """
+    level_dims = ["level", "lev", "depth", "z", "nz", "nz1"]
+    for dim in level_dims:
+        if dim in data_array.dims:
+            max_level = data_array.sizes[dim] - 1
+            safe_index = min(level_index, max_level)
+            return data_array.isel({dim: safe_index})
+    return data_array
+
+
+def _get_time_steps(ds: xr.Dataset) -> int:
+    """
+    Get the number of time steps in a dataset.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset.
+
+    Returns
+    -------
+    int
+        Number of time steps, or 1 if no time dimension.
+    """
+    time_dims = ["time", "t"]
+    for dim in time_dims:
+        if dim in ds.dims:
+            return ds.sizes[dim]
+    return 1
+
+
+def _get_level_steps(ds: xr.Dataset, variable: str) -> int:
+    """
+    Get the number of levels for a specific variable.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset.
+    variable : str
+        Variable name to check.
+
+    Returns
+    -------
+    int
+        Number of levels, or 1 if no level dimension.
+    """
+    if variable not in ds.data_vars:
+        return 1
+
+    level_dims = ["level", "lev", "depth", "z", "nz", "nz1"]
+    for dim in level_dims:
+        if dim in ds[variable].dims:
+            return ds[variable].sizes[dim]
+    return 1
+
+
+def _create_gridded_plot(
+    data_array: xr.DataArray,
+    cmap: str,
+    projection: Any | None = None,
+) -> Any:
+    """
+    Create an interactive plot for gridded (regular lat/lon) data.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        2D data array to plot.
+    cmap : str
+        Colormap name.
+    projection : Any, optional
+        Cartopy projection for geoviews plots.
+
+    Returns
+    -------
+    Any
+        HoloViews/GeoViews plot element.
+    """
+    cmap_obj = _get_colormap_object(cmap)
+
+    # Determine if we have lat/lon coordinates
+    has_geo_coords = any(
+        coord in data_array.coords for coord in ["lat", "latitude", "lon", "longitude"]
+    )
+
+    if HAS_GEOVIEWS and has_geo_coords:
+        # Use GeoViews for proper geographic projection
+        if projection is None:
+            projection = ccrs.Robinson()
+
+        # Create quadmesh with geographic projection
+        plot = data_array.hvplot.quadmesh(
+            x="lon" if "lon" in data_array.coords else "longitude",
+            y="lat" if "lat" in data_array.coords else "latitude",
+            cmap=cmap_obj,
+            geo=True,
+            projection=projection,
+            coastline=True,
+            frame_width=700,
+            frame_height=400,
+            colorbar=True,
+            title=data_array.attrs.get("long_name", data_array.name or "Data"),
+        )
+    else:
+        # Fall back to regular hvplot quadmesh
+        plot = data_array.hvplot.quadmesh(
+            cmap=cmap_obj,
+            frame_width=700,
+            frame_height=400,
+            colorbar=True,
+            title=data_array.attrs.get("long_name", data_array.name or "Data"),
+        )
+
+    return plot
+
+
+def _create_unstructured_plot(
+    data_array: xr.DataArray,
+    ds: xr.Dataset,
+    cmap: str,
+    projection: Any | None = None,
+) -> Any:
+    """
+    Create an interactive plot for unstructured mesh data (e.g., FESOM).
+
+    Uses GeoViews TriMesh for proper triangulated mesh rendering.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        Data array from unstructured mesh.
+    ds : xr.Dataset
+        Parent dataset containing mesh information.
+    cmap : str
+        Colormap name.
+    projection : Any, optional
+        Cartopy projection.
+
+    Returns
+    -------
+    Any
+        HoloViews/GeoViews plot element.
+    """
+    from esm_viz.fesom import _get_mesh_coordinates, _get_triangulation
+
+    cmap_obj = _get_colormap_object(cmap)
+
+    # Get mesh coordinates
+    lon_vals, lat_vals = _get_mesh_coordinates(ds)
+    triangles = _get_triangulation(ds)
+
+    if lon_vals is None or lat_vals is None:
+        logger.warning("Could not find mesh coordinates for unstructured plot")
+        # Fall back to simple scatter plot
+        values = data_array.values.ravel()
+        return hv.Points(
+            np.column_stack([np.arange(len(values)), values]),
+            label="Unstructured Data (no coordinates)",
+        )
+
+    # Load and flatten data
+    values = data_array.values
+    if hasattr(values, "compute"):
+        values = values.compute()
+    values = values.ravel()
+
+    lon_vals = lon_vals.ravel()
+    lat_vals = lat_vals.ravel()
+
+    if len(lon_vals) != len(values):
+        logger.warning(
+            f"Size mismatch: coords={len(lon_vals)}, values={len(values)}. "
+            "Using scatter plot fallback."
+        )
+        # Scatter plot fallback
+        if HAS_GEOVIEWS:
+            points = gv.Points(
+                (lon_vals[:len(values)], lat_vals[:len(values)], values[:len(lon_vals)]),
+                vdims=["value"],
+            )
+            return points.opts(
+                color="value",
+                cmap=cmap_obj,
+                size=2,
+                colorbar=True,
+                projection=projection or ccrs.Robinson(),
+                global_extent=True,
+            ) * gf.coastline()
+        else:
+            return hv.Points(
+                (lon_vals[:len(values)], lat_vals[:len(values)], values[:len(lon_vals)]),
+                vdims=["value"],
+            ).opts(color="value", cmap=cmap_obj, size=2, colorbar=True)
+
+    if triangles is not None and HAS_GEOVIEWS:
+        # Create proper TriMesh with triangulation
+        # Adjust indices if 1-based
+        if triangles.min() == 1:
+            triangles = triangles - 1
+
+        try:
+            # Build node data (vertices with values)
+            nodes = gv.Dataset(
+                (lon_vals, lat_vals, np.arange(len(lon_vals)), values),
+                ["lon", "lat", "index", "value"],
+            )
+
+            # Build trimesh
+            trimesh = gv.TriMesh((triangles, nodes), vdims=["value"])
+
+            if projection is None:
+                projection = ccrs.Robinson()
+
+            plot = trimesh.opts(
+                cmap=cmap_obj,
+                colorbar=True,
+                projection=projection,
+                global_extent=True,
+                frame_width=700,
+                frame_height=400,
+                title=data_array.attrs.get("long_name", data_array.name or "Data"),
+            ) * gf.coastline()
+
+            return plot
+
+        except Exception as e:
+            logger.warning(f"TriMesh creation failed: {e}. Using scatter fallback.")
+
+    # Scatter plot fallback
+    if HAS_GEOVIEWS:
+        points = gv.Points(
+            (lon_vals, lat_vals, values),
+            vdims=["value"],
+        )
+        return points.opts(
+            color="value",
+            cmap=cmap_obj,
+            size=2,
+            colorbar=True,
+            projection=projection or ccrs.Robinson(),
+            global_extent=True,
+            frame_width=700,
+            frame_height=400,
+            title=data_array.attrs.get("long_name", data_array.name or "Data"),
+        ) * gf.coastline()
+    else:
+        return hv.Points(
+            (lon_vals, lat_vals, values),
+            vdims=["value"],
+        ).opts(
+            color="value",
+            cmap=cmap_obj,
+            size=2,
+            colorbar=True,
+            frame_width=700,
+            frame_height=400,
+            title=data_array.attrs.get("long_name", data_array.name or "Data"),
+        )
+
+
+def create_preview_app(
+    href: str,
+    variable: str | None = None,
+    **kwargs: Any,
+) -> pn.Column:
+    """
+    Create an interactive Panel app for exploring climate data.
+
+    Parameters
+    ----------
+    href : str
+        Path or URI to the data file.
+    variable : str, optional
+        Initial variable to display. If None, uses the first available variable.
+    **kwargs : Any
+        Additional configuration options for the app.
+
+    Returns
+    -------
+    pn.Column
+        A Panel Column containing controls and interactive plot.
+
+    Examples
+    --------
+    >>> app = create_preview_app("/path/to/data.nc")
+    >>> app.servable()  # Serve in Panel server
+
+    >>> # Or embed in FastAPI
+    >>> pn.io.fastapi.add_application("/app", create_preview_app, href=href)
+    """
+    from esm_viz.readers import open_data
+    from esm_viz.fesom import is_unstructured
+
+    logger.info(f"Creating interactive preview app for: {href}")
+
+    try:
+        # Open the dataset
+        ds = open_data(href)
+    except Exception as e:
+        logger.error(f"Failed to open dataset: {e}")
+        return pn.Column(
+            pn.pane.Alert(
+                f"Failed to open dataset: {e}",
+                alert_type="danger",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Get plottable variables
+    variables = _get_plottable_variables(ds)
+    if not variables:
+        return pn.Column(
+            pn.pane.Alert(
+                "No plottable variables found in dataset.",
+                alert_type="warning",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Create display name mapping (shows long names alongside short names)
+    var_display_map = _get_variable_display_names(ds, variables)
+    # Reverse map to get variable name from display name
+    display_to_var = var_display_map
+    var_to_display = {v: k for k, v in var_display_map.items()}
+
+    # Determine initial variable
+    initial_var = variable if variable in variables else variables[0]
+    initial_display = var_to_display.get(initial_var, initial_var)
+
+    # Detect if unstructured mesh
+    unstructured = is_unstructured(ds)
+    mesh_type = "Unstructured Mesh (FESOM)" if unstructured else "Gridded"
+    logger.info(f"Detected mesh type: {mesh_type}")
+
+    # Get time and level info
+    n_times = _get_time_steps(ds)
+    n_levels = _get_level_steps(ds, initial_var)
+
+    # Determine smart colormap for initial variable
+    initial_cmap = get_smart_colormap(initial_var)
+
+    # Create widgets
+    var_selector = pn.widgets.Select(
+        name="Variable",
+        options=list(var_display_map.keys()),
+        value=initial_display,
+        width=300,  # Wider to accommodate long names
+    )
+
+    time_slider = pn.widgets.IntSlider(
+        name="Time Step",
+        start=0,
+        end=max(0, n_times - 1),
+        value=0,
+        width=300,
+        disabled=(n_times <= 1),
+    )
+
+    level_slider = pn.widgets.IntSlider(
+        name="Level/Depth",
+        start=0,
+        end=max(0, n_levels - 1),
+        value=0,
+        width=300,
+        disabled=(n_levels <= 1),
+    )
+
+    cmap_selector = pn.widgets.Select(
+        name="Colormap",
+        options=AVAILABLE_COLORMAPS,
+        value=initial_cmap if initial_cmap in AVAILABLE_COLORMAPS else DEFAULT_COLORMAP,
+        width=150,
+    )
+
+    # Info panel
+    info_md = pn.pane.Markdown(
+        f"""
+**Dataset Info:**
+- File: `{href.split('/')[-1]}`
+- Mesh Type: {mesh_type}
+- Variables: {len(variables)}
+- Time Steps: {n_times}
+        """,
+        width=250,
+    )
+
+    # Create reactive plot function
+    @pn.depends(
+        var_selector.param.value,
+        time_slider.param.value,
+        level_slider.param.value,
+        cmap_selector.param.value,
+    )
+    def update_plot(var_display: str, time_idx: int, level_idx: int, cmap: str) -> Any:
+        """Reactive function to update plot based on widget values."""
+        try:
+            # Convert display name back to variable name
+            var = display_to_var.get(var_display, var_display)
+            # Get data array
+            data_array = ds[var]
+
+            # Apply selections
+            data_array = _select_time_slice(data_array, time_idx)
+            data_array = _select_level_slice(data_array, level_idx)
+
+            # Create plot based on mesh type
+            if unstructured:
+                plot = _create_unstructured_plot(
+                    data_array, ds, cmap, projection=ccrs.Robinson() if HAS_GEOVIEWS else None
+                )
+            else:
+                plot = _create_gridded_plot(
+                    data_array, cmap, projection=ccrs.Robinson() if HAS_GEOVIEWS else None
+                )
+
+            return plot
+
+        except Exception as e:
+            logger.error(f"Plot generation failed: {e}")
+            return pn.pane.Alert(
+                f"Plot generation failed: {e}",
+                alert_type="danger",
+            )
+
+    # Update level slider when variable changes
+    @pn.depends(var_selector.param.value, watch=True)
+    def update_level_slider(var_display: str) -> None:
+        """Update level slider range when variable changes."""
+        var = display_to_var.get(var_display, var_display)
+        n_lvls = _get_level_steps(ds, var)
+        level_slider.end = max(0, n_lvls - 1)
+        level_slider.disabled = (n_lvls <= 1)
+        if level_slider.value > level_slider.end:
+            level_slider.value = 0
+
+    # Update colormap when variable changes (smart selection)
+    @pn.depends(var_selector.param.value, watch=True)
+    def update_colormap(var_display: str) -> None:
+        """Update colormap based on variable name (smart selection)."""
+        var = display_to_var.get(var_display, var_display)
+        smart_cmap = get_smart_colormap(var)
+        if smart_cmap in AVAILABLE_COLORMAPS:
+            cmap_selector.value = smart_cmap
+
+    # Build layout
+    controls = pn.Column(
+        pn.pane.Markdown("## Controls"),
+        var_selector,
+        time_slider,
+        level_slider,
+        cmap_selector,
+        pn.layout.Divider(),
+        info_md,
+        width=280,
+    )
+
+    plot_pane = pn.panel(update_plot, sizing_mode="stretch_both")
+
+    app = pn.Column(
+        pn.pane.Markdown(f"# ESM-Viz Interactive Preview"),
+        pn.Row(
+            controls,
+            plot_pane,
+            sizing_mode="stretch_both",
+        ),
+        sizing_mode="stretch_both",
+    )
+
+    return app
+
+
+def create_comparison_app(
+    href_a: str,
+    href_b: str,
+    variable: str | None = None,
+    **kwargs: Any,
+) -> pn.Column:
+    """
+    Create an interactive comparison app for two datasets.
+
+    Parameters
+    ----------
+    href_a : str
+        Path or URI to the first data file.
+    href_b : str
+        Path or URI to the second data file.
+    variable : str, optional
+        Variable to compare.
+    **kwargs : Any
+        Additional configuration options.
+
+    Returns
+    -------
+    pn.Column
+        Panel Column with side-by-side comparison view.
+
+    Notes
+    -----
+    This creates a side-by-side view of two datasets with synchronized
+    controls for time, level, and colormap selection.
+    """
+    from esm_viz.readers import open_data
+    from esm_viz.fesom import is_unstructured
+
+    logger.info(f"Creating comparison app: {href_a} vs {href_b}")
+
+    try:
+        ds_a = open_data(href_a)
+        ds_b = open_data(href_b)
+    except Exception as e:
+        logger.error(f"Failed to open datasets: {e}")
+        return pn.Column(
+            pn.pane.Alert(
+                f"Failed to open datasets: {e}",
+                alert_type="danger",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    # Find common variables
+    vars_a = set(_get_plottable_variables(ds_a))
+    vars_b = set(_get_plottable_variables(ds_b))
+    common_vars = sorted(vars_a & vars_b)
+
+    if not common_vars:
+        return pn.Column(
+            pn.pane.Alert(
+                "No common plottable variables found between datasets.",
+                alert_type="warning",
+            ),
+            sizing_mode="stretch_width",
+        )
+
+    initial_var = variable if variable in common_vars else common_vars[0]
+    unstructured_a = is_unstructured(ds_a)
+    unstructured_b = is_unstructured(ds_b)
+
+    # Get time steps (use minimum)
+    n_times = min(_get_time_steps(ds_a), _get_time_steps(ds_b))
+
+    # Widgets
+    var_selector = pn.widgets.Select(
+        name="Variable",
+        options=common_vars,
+        value=initial_var,
+        width=200,
+    )
+
+    time_slider = pn.widgets.IntSlider(
+        name="Time Step",
+        start=0,
+        end=max(0, n_times - 1),
+        value=0,
+        width=300,
+        disabled=(n_times <= 1),
+    )
+
+    cmap_selector = pn.widgets.Select(
+        name="Colormap",
+        options=AVAILABLE_COLORMAPS,
+        value=get_smart_colormap(initial_var),
+        width=150,
+    )
+
+    @pn.depends(var_selector.param.value, time_slider.param.value, cmap_selector.param.value)
+    def plot_a(var: str, time_idx: int, cmap: str) -> Any:
+        try:
+            data_array = _select_time_slice(ds_a[var], time_idx)
+            if unstructured_a:
+                return _create_unstructured_plot(data_array, ds_a, cmap)
+            return _create_gridded_plot(data_array, cmap)
+        except Exception as e:
+            return pn.pane.Alert(f"Error: {e}", alert_type="danger")
+
+    @pn.depends(var_selector.param.value, time_slider.param.value, cmap_selector.param.value)
+    def plot_b(var: str, time_idx: int, cmap: str) -> Any:
+        try:
+            data_array = _select_time_slice(ds_b[var], time_idx)
+            if unstructured_b:
+                return _create_unstructured_plot(data_array, ds_b, cmap)
+            return _create_gridded_plot(data_array, cmap)
+        except Exception as e:
+            return pn.pane.Alert(f"Error: {e}", alert_type="danger")
+
+    controls = pn.Row(var_selector, time_slider, cmap_selector)
+
+    app = pn.Column(
+        pn.pane.Markdown("# ESM-Viz Dataset Comparison"),
+        controls,
+        pn.Row(
+            pn.Column(
+                pn.pane.Markdown(f"**Dataset A:** `{href_a.split('/')[-1]}`"),
+                pn.panel(plot_a, sizing_mode="stretch_both"),
+            ),
+            pn.Column(
+                pn.pane.Markdown(f"**Dataset B:** `{href_b.split('/')[-1]}`"),
+                pn.panel(plot_b, sizing_mode="stretch_both"),
+            ),
+            sizing_mode="stretch_both",
+        ),
+        sizing_mode="stretch_both",
+    )
+
+    return app

--- a/src/esm_viz/readers.py
+++ b/src/esm_viz/readers.py
@@ -1,0 +1,233 @@
+"""
+Data loading module for climate datasets.
+
+Handles opening NetCDF and GRIB files with xarray, supporting lazy loading
+via dask for efficient handling of large climate datasets.
+"""
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import numpy as np
+import xarray as xr
+from loguru import logger
+
+
+def _to_native(obj: Any) -> Any:
+    """Recursively convert numpy types to Python native for JSON serialization."""
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    if isinstance(obj, dict):
+        return {k: _to_native(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_to_native(v) for v in obj]
+    return obj
+
+
+def _strip_file_uri(href: str) -> str:
+    """
+    Convert file:// URIs to plain filesystem paths.
+
+    Parameters
+    ----------
+    href : str
+        The href which may be a file:// URI or plain path.
+
+    Returns
+    -------
+    str
+        Plain filesystem path.
+    """
+    parsed = urlparse(href)
+    if parsed.scheme == "file":
+        return parsed.path
+    return href
+
+
+def _detect_format(path: str) -> str:
+    """
+    Auto-detect file format by extension and magic bytes.
+
+    Parameters
+    ----------
+    path : str
+        Path to the data file.
+
+    Returns
+    -------
+    str
+        Format identifier: 'netcdf' or 'grib'.
+
+    Raises
+    ------
+    ValueError
+        If the format cannot be determined.
+    """
+    path_obj = Path(path)
+    suffix = path_obj.suffix.lower()
+
+    # Check by extension first
+    if suffix in (".nc", ".nc4", ".netcdf", ".ncdf"):
+        return "netcdf"
+    if suffix in (".grib", ".grib2", ".grb", ".grb2"):
+        return "grib"
+
+    # Fall back to magic bytes detection
+    try:
+        with open(path, "rb") as f:
+            header = f.read(8)
+
+        # NetCDF magic bytes: 'CDF\x01' or 'CDF\x02' (classic) or '\x89HDF' (HDF5/NetCDF4)
+        if header[:3] == b"CDF" or header[:4] == b"\x89HDF":
+            return "netcdf"
+
+        # GRIB magic bytes: 'GRIB'
+        if header[:4] == b"GRIB":
+            return "grib"
+
+    except (OSError, IOError) as e:
+        logger.warning(f"Could not read file header for format detection: {e}")
+
+    raise ValueError(
+        f"Cannot determine format for {path}. "
+        "Use explicit engine parameter or ensure file has correct extension."
+    )
+
+
+def open_data(href: str, engine: str | None = None, **kwargs: Any) -> xr.Dataset:
+    """
+    Open a NetCDF or GRIB file with xarray using dask lazy loading.
+
+    Parameters
+    ----------
+    href : str
+        Path or file:// URI to the data file.
+    engine : str, optional
+        Explicit xarray engine to use ('netcdf4', 'h5netcdf', 'cfgrib').
+        If not provided, auto-detection is attempted.
+    **kwargs : Any
+        Additional keyword arguments passed to xr.open_dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Lazily-loaded xarray Dataset with dask chunking.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If the file format cannot be determined.
+    """
+    path = _strip_file_uri(href)
+    path_obj = Path(path)
+
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Data file not found: {path}")
+
+    logger.debug(f"Opening data file: {path}")
+
+    # Set default chunking for lazy loading
+    if "chunks" not in kwargs:
+        kwargs["chunks"] = "auto"
+
+    # Determine engine if not specified
+    if engine is None:
+        fmt = _detect_format(path)
+        engine = "cfgrib" if fmt == "grib" else "netcdf4"
+        logger.debug(f"Auto-detected format: {fmt}, using engine: {engine}")
+
+    try:
+        ds = xr.open_dataset(path, engine=engine, **kwargs)
+        logger.info(f"Successfully opened dataset with {len(ds.data_vars)} variables")
+        return ds
+    except Exception as e:
+        logger.error(f"Failed to open dataset: {e}")
+        raise
+
+
+def get_data_metadata(ds: xr.Dataset) -> dict[str, Any]:
+    """
+    Extract metadata from an xarray Dataset.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset to analyze.
+
+    Returns
+    -------
+    dict
+        Metadata dictionary containing:
+        - variables: list of variable names with their attributes
+        - dimensions: dict of dimension names to sizes
+        - coordinates: dict of coordinate names with their ranges
+        - global_attrs: dataset-level attributes
+    """
+    metadata: dict[str, Any] = {
+        "variables": [],
+        "dimensions": {k: int(v) for k, v in ds.dims.items()},
+        "coordinates": {},
+        "global_attrs": _to_native(dict(ds.attrs)),
+    }
+
+    # Extract variable information
+    for var_name, var_data in ds.data_vars.items():
+        var_info = {
+            "name": var_name,
+            "dims": list(var_data.dims),
+            "shape": [int(s) for s in var_data.shape],
+            "dtype": str(var_data.dtype),
+            "attrs": _to_native(dict(var_data.attrs)),
+        }
+
+        # Add standard_name and long_name if available
+        if "standard_name" in var_data.attrs:
+            var_info["standard_name"] = var_data.attrs["standard_name"]
+        if "long_name" in var_data.attrs:
+            var_info["long_name"] = var_data.attrs["long_name"]
+        if "units" in var_data.attrs:
+            var_info["units"] = var_data.attrs["units"]
+
+        metadata["variables"].append(var_info)
+
+    # Extract coordinate ranges
+    for coord_name, coord_data in ds.coords.items():
+        try:
+            coord_values = coord_data.values
+            coord_info: dict[str, Any] = {
+                "dims": list(coord_data.dims),
+                "size": int(coord_data.size),
+                "dtype": str(coord_data.dtype),
+            }
+
+            # Add min/max for numeric coordinates
+            if coord_data.dtype.kind in ("i", "u", "f"):  # integer, unsigned, float
+                coord_info["min"] = float(coord_values.min())
+                coord_info["max"] = float(coord_values.max())
+
+            # Handle datetime coordinates
+            if coord_data.dtype.kind == "M":  # datetime64
+                coord_info["min"] = str(coord_values.min())
+                coord_info["max"] = str(coord_values.max())
+
+            # Add units if available
+            if "units" in coord_data.attrs:
+                coord_info["units"] = coord_data.attrs["units"]
+
+            metadata["coordinates"][coord_name] = coord_info
+        except Exception as e:
+            logger.warning(f"Could not extract range for coordinate {coord_name}: {e}")
+            metadata["coordinates"][coord_name] = {
+                "dims": list(coord_data.dims),
+                "size": int(coord_data.size),
+                "error": str(e),
+            }
+
+    return metadata

--- a/src/esm_viz/readers.py
+++ b/src/esm_viz/readers.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 Data loading module for climate datasets.
 

--- a/src/esm_viz/static_preview.py
+++ b/src/esm_viz/static_preview.py
@@ -1,0 +1,359 @@
+"""
+Static PNG generation module for climate data visualization.
+
+Generates matplotlib/cartopy-based maps from xarray DataArrays,
+suitable for quick previews of spatial climate data.
+"""
+
+import io
+from typing import Any
+
+import cartopy.crs as ccrs
+import cartopy.feature as cfeature
+import matplotlib
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from loguru import logger
+
+# Use non-interactive backend for server deployment
+matplotlib.use("Agg")
+
+
+def plot_spatial(
+    data_array: xr.DataArray,
+    cmap: str = "viridis",
+    projection: ccrs.Projection | None = None,
+    figsize: tuple[int, int] = (12, 8),
+    add_coastlines: bool = True,
+    add_gridlines: bool = True,
+    title: str | None = None,
+    colorbar_label: str | None = None,
+    vmin: float | None = None,
+    vmax: float | None = None,
+) -> plt.Figure:
+    """
+    Create a spatial map plot from an xarray DataArray.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        2D array with lat/lon coordinates to plot.
+    cmap : str, optional
+        Matplotlib colormap name. Default is 'viridis'.
+    projection : ccrs.Projection, optional
+        Cartopy projection for the map. Default is PlateCarree.
+    figsize : tuple[int, int], optional
+        Figure size in inches. Default is (12, 8).
+    add_coastlines : bool, optional
+        Whether to add coastlines. Default is True.
+    add_gridlines : bool, optional
+        Whether to add gridlines. Default is True.
+    title : str, optional
+        Plot title. If None, derived from data_array attributes.
+    colorbar_label : str, optional
+        Colorbar label. If None, derived from data_array attributes.
+    vmin : float, optional
+        Minimum value for colormap scaling.
+    vmax : float, optional
+        Maximum value for colormap scaling.
+
+    Returns
+    -------
+    plt.Figure
+        Matplotlib Figure object with the plot.
+    """
+    if projection is None:
+        projection = ccrs.PlateCarree()
+
+    fig, ax = plt.subplots(
+        figsize=figsize,
+        subplot_kw={"projection": projection},
+    )
+
+    # Identify lat/lon coordinates
+    lat_coord, lon_coord = _find_lat_lon_coords(data_array)
+
+    if lat_coord is None or lon_coord is None:
+        logger.warning("Could not identify lat/lon coordinates, using index-based plot")
+        im = ax.imshow(
+            data_array.values,
+            cmap=cmap,
+            vmin=vmin,
+            vmax=vmax,
+            origin="lower",
+        )
+    else:
+        # Get coordinate values
+        lons = data_array[lon_coord].values
+        lats = data_array[lat_coord].values
+
+        # Create 2D mesh if needed
+        if lons.ndim == 1 and lats.ndim == 1:
+            im = ax.pcolormesh(
+                lons,
+                lats,
+                data_array.values,
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                transform=ccrs.PlateCarree(),
+                shading="auto",
+            )
+        else:
+            # Already 2D coordinates (e.g., curvilinear grids)
+            im = ax.pcolormesh(
+                lons,
+                lats,
+                data_array.values,
+                cmap=cmap,
+                vmin=vmin,
+                vmax=vmax,
+                transform=ccrs.PlateCarree(),
+                shading="auto",
+            )
+
+        # Set global extent if coordinates span full globe
+        if _is_global_coverage(lons, lats):
+            ax.set_global()
+
+    # Add map features
+    if add_coastlines:
+        try:
+            ax.add_feature(cfeature.COASTLINE, linewidth=0.5, edgecolor="black")
+            ax.add_feature(cfeature.BORDERS, linewidth=0.3, linestyle=":", edgecolor="gray")
+        except Exception as e:
+            logger.warning(f"Could not add coastlines: {e}")
+
+    if add_gridlines:
+        try:
+            gl = ax.gridlines(draw_labels=True, alpha=0.5, linestyle="--")
+            gl.top_labels = False
+            gl.right_labels = False
+        except Exception as e:
+            logger.warning(f"Could not add gridlines: {e}")
+
+    # Add colorbar
+    cbar = fig.colorbar(im, ax=ax, orientation="horizontal", pad=0.05, shrink=0.8)
+
+    if colorbar_label is None:
+        colorbar_label = _get_colorbar_label(data_array)
+    if colorbar_label:
+        cbar.set_label(colorbar_label)
+
+    # Set title
+    if title is None:
+        title = _get_plot_title(data_array)
+    if title:
+        ax.set_title(title, fontsize=12)
+
+    plt.tight_layout()
+    return fig
+
+
+def _find_lat_lon_coords(data_array: xr.DataArray) -> tuple[str | None, str | None]:
+    """
+    Identify latitude and longitude coordinate names in a DataArray.
+
+    Returns
+    -------
+    tuple[str | None, str | None]
+        (lat_coord_name, lon_coord_name) or (None, None) if not found.
+    """
+    lat_names = {"lat", "latitude", "LAT", "LATITUDE", "y", "Y", "rlat", "nav_lat"}
+    lon_names = {"lon", "longitude", "LON", "LONGITUDE", "x", "X", "rlon", "nav_lon"}
+
+    lat_coord = None
+    lon_coord = None
+
+    # Check dims and coords
+    all_names = set(data_array.dims) | set(data_array.coords)
+
+    for name in all_names:
+        if name.lower() in {n.lower() for n in lat_names}:
+            lat_coord = name
+        elif name.lower() in {n.lower() for n in lon_names}:
+            lon_coord = name
+
+    # Also check standard_name attribute
+    for coord_name, coord in data_array.coords.items():
+        if "standard_name" in coord.attrs:
+            std_name = coord.attrs["standard_name"].lower()
+            if std_name in ("latitude", "grid_latitude"):
+                lat_coord = coord_name
+            elif std_name in ("longitude", "grid_longitude"):
+                lon_coord = coord_name
+
+    return lat_coord, lon_coord
+
+
+def _is_global_coverage(lons: np.ndarray, lats: np.ndarray) -> bool:
+    """Check if coordinates suggest global coverage."""
+    try:
+        lon_range = float(lons.max()) - float(lons.min())
+        lat_range = float(lats.max()) - float(lats.min())
+        return lon_range > 300 and lat_range > 150
+    except Exception:
+        return False
+
+
+def _get_colorbar_label(data_array: xr.DataArray) -> str:
+    """Generate colorbar label from data attributes."""
+    parts = []
+
+    if "long_name" in data_array.attrs:
+        parts.append(str(data_array.attrs["long_name"]))
+    elif data_array.name:
+        parts.append(str(data_array.name))
+
+    if "units" in data_array.attrs:
+        parts.append(f"[{data_array.attrs['units']}]")
+
+    return " ".join(parts)
+
+
+def _get_plot_title(data_array: xr.DataArray) -> str:
+    """Generate plot title from data attributes."""
+    if "long_name" in data_array.attrs:
+        return str(data_array.attrs["long_name"])
+    elif "standard_name" in data_array.attrs:
+        return str(data_array.attrs["standard_name"]).replace("_", " ").title()
+    elif data_array.name:
+        return str(data_array.name)
+    return "Climate Data Preview"
+
+
+def generate_preview_png(
+    ds: xr.Dataset,
+    variable: str,
+    time_index: int = 0,
+    level_index: int = 0,
+    cmap: str = "viridis",
+    dpi: int = 100,
+    **plot_kwargs: Any,
+) -> bytes:
+    """
+    Generate a PNG preview image from a dataset variable.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        The xarray Dataset containing the variable.
+    variable : str
+        Name of the variable to plot.
+    time_index : int, optional
+        Index along the time dimension. Default is 0.
+    level_index : int, optional
+        Index along the level/depth dimension for 3D data. Default is 0.
+    cmap : str, optional
+        Matplotlib colormap name. Default is 'viridis'.
+    dpi : int, optional
+        Resolution for the output image. Default is 100.
+    **plot_kwargs : Any
+        Additional keyword arguments passed to plot_spatial.
+
+    Returns
+    -------
+    bytes
+        PNG image data as bytes.
+
+    Raises
+    ------
+    KeyError
+        If the variable is not found in the dataset.
+    """
+    if variable not in ds.data_vars:
+        available = list(ds.data_vars.keys())
+        raise KeyError(
+            f"Variable '{variable}' not found in dataset. "
+            f"Available variables: {available}"
+        )
+
+    data_array = ds[variable]
+    logger.debug(f"Generating preview for variable '{variable}' with shape {data_array.shape}")
+
+    # Select time and level slice to get 2D data
+    data_2d = _select_2d_slice(data_array, time_index, level_index)
+
+    # Load data into memory for plotting
+    logger.debug("Loading data slice into memory")
+    data_2d = data_2d.compute() if hasattr(data_2d, "compute") else data_2d
+
+    # Check for valid data - raise error if all NaN to avoid returning blank PNG
+    if np.all(np.isnan(data_2d.values)):
+        raise ValueError(
+            f"All values are NaN for variable '{variable}' at time_index={time_index}, "
+            f"level_index={level_index}. Cannot generate preview."
+        )
+
+    # Generate the plot
+    fig = plot_spatial(data_2d, cmap=cmap, **plot_kwargs)
+
+    # Convert to PNG bytes
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=dpi, bbox_inches="tight")
+    buf.seek(0)
+    png_bytes = buf.read()
+    buf.close()
+
+    # Clean up
+    plt.close(fig)
+
+    logger.info(f"Generated PNG preview: {len(png_bytes)} bytes")
+    return png_bytes
+
+
+def _select_2d_slice(
+    data_array: xr.DataArray,
+    time_index: int = 0,
+    level_index: int = 0,
+) -> xr.DataArray:
+    """
+    Select a 2D spatial slice from a potentially higher-dimensional array.
+
+    Parameters
+    ----------
+    data_array : xr.DataArray
+        The input data array (may be 2D, 3D, or 4D).
+    time_index : int
+        Index to select along the time dimension.
+    level_index : int
+        Index to select along the level/depth dimension for 3D data.
+
+    Returns
+    -------
+    xr.DataArray
+        2D slice suitable for spatial plotting.
+    """
+    # Common dimension names to reduce
+    time_dims = {"time", "t", "Time", "TIME"}
+    level_dims = {"level", "lev", "depth", "z", "plev", "height", "pressure", "nz", "nz1"}
+
+    result = data_array
+
+    # Select along time dimension
+    for dim in result.dims:
+        if dim in time_dims or (hasattr(result[dim], "attrs") and
+            result[dim].attrs.get("standard_name", "") == "time"):
+            if result[dim].size > 1:
+                idx = min(time_index, result[dim].size - 1)
+                result = result.isel({dim: idx})
+                logger.debug(f"Selected time index {idx} along dimension '{dim}'")
+                break
+
+    # If still more than 2D, select along level dimension using provided index
+    if result.ndim > 2:
+        for dim in result.dims:
+            if dim.lower() in {d.lower() for d in level_dims}:
+                idx = min(level_index, result[dim].size - 1)
+                result = result.isel({dim: idx})
+                logger.debug(f"Selected level index {idx} along dimension '{dim}'")
+                break
+
+    # Final fallback: take first slice of any extra dimensions
+    while result.ndim > 2:
+        extra_dim = result.dims[0]
+        result = result.isel({extra_dim: 0})
+        logger.debug(f"Selected index 0 along extra dimension '{extra_dim}'")
+
+    return result

--- a/src/esm_viz/static_preview.py
+++ b/src/esm_viz/static_preview.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 """
 Static PNG generation module for climate data visualization.
 

--- a/tests/test_esm_viz/test_compute_contract.py
+++ b/tests/test_esm_viz/test_compute_contract.py
@@ -1,0 +1,254 @@
+"""
+Contract tests for the Dask compute cluster management API.
+
+Endpoint contract:
+    POST   /compute/clusters          -> 201, ClusterResponse {id, name, type, ...}
+    GET    /compute/clusters          -> 200, {clusters: [...], total: int}
+    GET    /compute/clusters/{id}     -> 200, ClusterResponse
+    PATCH  /compute/clusters/{id}     -> 200, ClusterResponse (scaled)
+    DELETE /compute/clusters/{id}     -> 204
+    POST   with missing fields        -> 422
+    GET    nonexistent                -> 404
+    DELETE nonexistent                -> 404
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from esm_viz.compute import ComputeManager
+from esm_viz.compute_routes import create_compute_router
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def manager():
+    """Fresh ComputeManager per test -- no shared state."""
+    return ComputeManager()
+
+
+@pytest.fixture()
+def client(manager):
+    """TestClient wired to a minimal FastAPI app with the compute router."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(create_compute_router(manager=manager))
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Happy-path CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCreateCluster:
+    def test_create_local_returns_201(self, client):
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 1, "name": "test-local"},
+        )
+        assert r.status_code == 201
+        data = r.json()
+        assert "id" in data
+        assert data["name"] == "test-local"
+        assert data["type"] == "local"
+        assert data["status"] == "running"
+        assert "created_at" in data
+
+    def test_create_local_default_workers(self, client):
+        r = client.post("/compute/clusters", json={"type": "local"})
+        assert r.status_code == 201
+        data = r.json()
+        assert data["n_workers"] >= 1
+
+    def test_response_has_scheduler_address(self, client):
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 1},
+        )
+        data = r.json()
+        assert data["scheduler_address"] is not None
+        assert data["scheduler_address"].startswith("tcp://")
+
+
+class TestListClusters:
+    def test_empty_list(self, client):
+        r = client.get("/compute/clusters")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["clusters"] == []
+        assert data["total"] == 0
+
+    def test_list_after_create(self, client):
+        client.post("/compute/clusters", json={"type": "local", "workers": 1})
+        r = client.get("/compute/clusters")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["total"] == 1
+        assert len(data["clusters"]) == 1
+
+    def test_list_multiple(self, client):
+        client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 1, "name": "a"},
+        )
+        client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 1, "name": "b"},
+        )
+        r = client.get("/compute/clusters")
+        data = r.json()
+        assert data["total"] == 2
+
+
+class TestGetCluster:
+    def test_get_existing(self, client):
+        create_r = client.post(
+            "/compute/clusters", json={"type": "local", "workers": 1}
+        )
+        cluster_id = create_r.json()["id"]
+
+        r = client.get(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 200
+        assert r.json()["id"] == cluster_id
+
+    def test_get_nonexistent_returns_404(self, client):
+        r = client.get("/compute/clusters/does-not-exist")
+        assert r.status_code == 404
+
+
+class TestScaleCluster:
+    def test_scale_fixed(self, client):
+        create_r = client.post(
+            "/compute/clusters", json={"type": "local", "workers": 1}
+        )
+        cluster_id = create_r.json()["id"]
+
+        r = client.patch(
+            f"/compute/clusters/{cluster_id}",
+            json={"workers": 4},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["id"] == cluster_id
+        # The cluster should still be running after scaling
+        assert data["status"] == "running"
+
+    def test_scale_nonexistent_returns_404(self, client):
+        r = client.patch(
+            "/compute/clusters/nope",
+            json={"workers": 4},
+        )
+        assert r.status_code == 404
+
+
+class TestDeleteCluster:
+    def test_delete_existing(self, client):
+        create_r = client.post(
+            "/compute/clusters", json={"type": "local", "workers": 1}
+        )
+        cluster_id = create_r.json()["id"]
+
+        r = client.delete(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 204
+
+        # Should be gone now
+        r = client.get(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 404
+
+    def test_delete_nonexistent_returns_404(self, client):
+        r = client.delete("/compute/clusters/nonexistent")
+        assert r.status_code == 404
+
+    def test_list_empty_after_delete(self, client):
+        create_r = client.post(
+            "/compute/clusters", json={"type": "local", "workers": 1}
+        )
+        cluster_id = create_r.json()["id"]
+        client.delete(f"/compute/clusters/{cluster_id}")
+
+        r = client.get("/compute/clusters")
+        assert r.json()["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Validation / error cases
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    def test_invalid_type_returns_422(self, client):
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "imaginary", "workers": 1},
+        )
+        assert r.status_code == 422
+
+    def test_workers_below_minimum_returns_422(self, client):
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 0},
+        )
+        assert r.status_code == 422
+
+    def test_gateway_without_package_returns_400(self, client):
+        """Creating a gateway cluster when dask_gateway is not installed."""
+        # This may pass or return 400 depending on environment.
+        # The contract is: if the package is missing, 400 not 500.
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "gateway", "workers": 1, "gateway_url": "http://fake"},
+        )
+        # Either 201 (package installed) or 400 (not installed) -- never 500
+        assert r.status_code in (201, 400)
+
+    def test_slurm_without_package_returns_400(self, client):
+        """Creating a SLURM cluster when dask_jobqueue is not installed."""
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "slurm", "workers": 1, "queue": "compute"},
+        )
+        assert r.status_code in (201, 400)
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_create_get_scale_delete(self, client):
+        """End-to-end lifecycle: create -> get -> scale -> delete."""
+        # Create
+        r = client.post(
+            "/compute/clusters",
+            json={"type": "local", "workers": 1, "name": "lifecycle-test"},
+        )
+        assert r.status_code == 201
+        cluster_id = r.json()["id"]
+
+        # Get
+        r = client.get(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 200
+        assert r.json()["name"] == "lifecycle-test"
+
+        # Scale
+        r = client.patch(
+            f"/compute/clusters/{cluster_id}",
+            json={"workers": 2},
+        )
+        assert r.status_code == 200
+
+        # Delete
+        r = client.delete(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 204
+
+        # Verify gone
+        r = client.get(f"/compute/clusters/{cluster_id}")
+        assert r.status_code == 404

--- a/tests/test_esm_viz/test_viz_contract.py
+++ b/tests/test_esm_viz/test_viz_contract.py
@@ -1,0 +1,265 @@
+"""
+Contract tests for the ESM Visualization Service API.
+
+These tests verify the API contract that the STAC Browser frontend depends on.
+The frontend (DataPreview.vue) expects specific endpoints, status codes, and
+content types from the viz server.
+
+Endpoint contract:
+    GET /health                         -> 200, JSON {status, service, version}
+    GET /preview/{item_id}.json?stac_api=...  -> 200, JSON {variables, dimensions, item_id, href}
+    GET /preview/{item_id}.png?var=...&stac_api=... -> 200, image/png
+    GET /preview/{item_id}/panel?stac_api=...  -> 307 redirect to /_panel/?item_id=...
+    GET /_panel/?item_id=...&stac_api=...      -> 200, text/html (Panel app)
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import xarray as xr
+import numpy as np
+from fastapi.testclient import TestClient
+
+from esm_viz.app import app
+
+
+ITEM_ID = "test-item.echam.185001.abc123"
+STAC_API = "http://localhost:23100"
+COLLECTION_ID = "test-collection"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_stac_and_data():
+    """Mock STAC item fetching and dataset opening for isolated tests."""
+    fake_item = {
+        "type": "Feature",
+        "id": ITEM_ID,
+        "collection": COLLECTION_ID,
+        "assets": {
+            "data": {
+                "href": "/fake/path/to/data.nc",
+                "type": "application/x-netcdf",
+            }
+        },
+    }
+
+    ds = xr.Dataset(
+        {
+            "temp": (["time", "lat", "lon"], np.random.rand(3, 10, 20)),
+            "precip": (["time", "lat", "lon"], np.random.rand(3, 10, 20)),
+        },
+        coords={
+            "time": range(3),
+            "lat": np.linspace(-90, 90, 10),
+            "lon": np.linspace(-180, 180, 20),
+        },
+    )
+
+    with (
+        patch("esm_viz.app._fetch_stac_item", return_value=fake_item),
+        patch("esm_viz.app.open_data", return_value=ds),
+        patch("esm_viz.app.is_unstructured", return_value=False),
+    ):
+        yield
+
+
+class TestHealthEndpoint:
+    def test_returns_200(self, client):
+        r = client.get("/health")
+        assert r.status_code == 200
+
+    def test_response_shape(self, client):
+        data = client.get("/health").json()
+        assert data["status"] == "healthy"
+        assert "version" in data
+        assert "service" in data
+
+
+class TestPreviewMetadata:
+    def test_returns_json_with_expected_fields(self, client, mock_stac_and_data):
+        r = client.get(
+            f"/preview/{ITEM_ID}.json",
+            params={"stac_api": STAC_API, "collection_id": COLLECTION_ID},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert "variables" in data
+        assert "dimensions" in data
+        assert data["item_id"] == ITEM_ID
+        assert "href" in data
+
+    def test_nonexistent_item_returns_404(self, client):
+        with patch("esm_viz.app._fetch_stac_item", side_effect=Exception("not found")):
+            r = client.get(
+                "/preview/nonexistent.json",
+                params={"stac_api": STAC_API},
+            )
+            assert r.status_code == 500
+
+
+class TestPreviewPng:
+    def test_returns_png_image(self, client, mock_stac_and_data):
+        with patch(
+            "esm_viz.app.generate_preview_png", return_value=b"\x89PNG fake"
+        ):
+            r = client.get(
+                f"/preview/{ITEM_ID}.png",
+                params={
+                    "var": "temp",
+                    "stac_api": STAC_API,
+                    "time": 0,
+                    "cmap": "viridis",
+                    "collection_id": COLLECTION_ID,
+                },
+            )
+            assert r.status_code == 200
+            assert r.headers["content-type"] == "image/png"
+
+    def test_invalid_variable_returns_400(self, client, mock_stac_and_data):
+        r = client.get(
+            f"/preview/{ITEM_ID}.png",
+            params={"var": "nonexistent_var", "stac_api": STAC_API},
+        )
+        assert r.status_code == 400
+
+
+class TestPreviewPanelRedirect:
+    """The /preview/{item_id}/panel endpoint must redirect to /_panel/ with query params."""
+
+    def test_redirects_to_internal_panel(self, client):
+        r = client.get(
+            f"/preview/{ITEM_ID}/panel",
+            params={"stac_api": STAC_API, "collection_id": COLLECTION_ID},
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        assert "/_panel" in location
+        assert f"item_id={ITEM_ID}" in location or "item_id=" in location
+        assert "stac_api=" in location
+        assert "collection_id=" in location
+
+    def test_redirect_without_optional_params(self, client):
+        r = client.get(
+            f"/preview/{ITEM_ID}/panel",
+            params={"stac_api": STAC_API},
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        assert "collection_id" not in location
+
+    def test_does_not_return_json_404(self, client):
+        """Regression: previously /panel/?item_id=... returned {"detail":"Not Found"}."""
+        r = client.get(
+            f"/preview/{ITEM_ID}/panel",
+            params={"stac_api": STAC_API},
+            follow_redirects=False,
+        )
+        assert r.status_code != 404
+
+
+class TestCors:
+    def test_cors_headers_on_health(self, client):
+        r = client.get("/health", headers={"Origin": "http://localhost:8080"})
+        assert "access-control-allow-origin" in r.headers
+
+    def test_cors_headers_on_preview(self, client, mock_stac_and_data):
+        r = client.get(
+            f"/preview/{ITEM_ID}.json",
+            params={"stac_api": STAC_API},
+            headers={"Origin": "http://localhost:8080"},
+        )
+        assert "access-control-allow-origin" in r.headers
+
+
+class TestCollectionPanelRedirect:
+    """The /preview/collection/{id}/panel endpoint must redirect to /_panel with collection params."""
+
+    def test_redirects_with_collection_id(self, client):
+        r = client.get(
+            f"/preview/collection/{COLLECTION_ID}/panel",
+            params={"stac_api": STAC_API},
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        assert "/_panel" in location
+        assert f"collection_id={COLLECTION_ID}" in location
+        assert "stac_api=" in location
+        # Must NOT have item_id (this is collection-level)
+        assert "item_id" not in location
+
+    def test_collection_redirect_without_stac_api(self, client):
+        r = client.get(
+            f"/preview/collection/{COLLECTION_ID}/panel",
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        assert f"collection_id={COLLECTION_ID}" in location
+
+
+class TestCompareRedirect:
+    """The /preview/compare/panel endpoint must redirect to /_panel with both collection params."""
+
+    COLLECTION_A = "basic-001-echam"
+    COLLECTION_B = "branchoff-002-fesom"
+
+    def test_redirects_with_both_collections(self, client):
+        r = client.get(
+            "/preview/compare/panel",
+            params={
+                "collection_a": self.COLLECTION_A,
+                "collection_b": self.COLLECTION_B,
+                "stac_api": STAC_API,
+            },
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        assert "/_panel" in location
+        assert "compare=1" in location
+        assert f"collection_a={self.COLLECTION_A}" in location
+        assert f"collection_b={self.COLLECTION_B}" in location
+        assert "stac_api=" in location
+
+    def test_requires_both_collections(self, client):
+        """collection_a and collection_b are required query params."""
+        r = client.get(
+            "/preview/compare/panel",
+            params={"collection_a": self.COLLECTION_A, "stac_api": STAC_API},
+            follow_redirects=False,
+        )
+        # FastAPI returns 422 for missing required query params
+        assert r.status_code == 422
+
+    def test_does_not_conflict_with_item_panel(self, client):
+        """Ensure /preview/compare/panel doesn't match /preview/{item_id}/panel."""
+        r = client.get(
+            f"/preview/{ITEM_ID}/panel",
+            params={"stac_api": STAC_API},
+            follow_redirects=False,
+        )
+        assert r.status_code == 307
+        location = r.headers["location"]
+        # Should be an item redirect, not a compare redirect
+        assert "item_id=" in location
+        assert "compare" not in location
+
+
+class TestRootEndpoint:
+    def test_lists_endpoints(self, client):
+        data = client.get("/").json()
+        endpoints = data["endpoints"]
+        assert "/preview/{item_id}.png" in endpoints
+        assert "/preview/{item_id}.json" in endpoints
+        assert "/preview/{item_id}/panel" in endpoints
+        assert "/preview/collection/{collection_id}/panel" in endpoints
+        assert "/preview/compare/panel" in endpoints
+        assert "/health" in endpoints

--- a/utils/docker-compose.yml
+++ b/utils/docker-compose.yml
@@ -1,0 +1,85 @@
+# ESM-Tools Data Services Stack
+# STAC Catalog API + Visualization Service + Browser
+#
+# Usage:
+#   docker-compose up -d
+#   Open http://localhost:8080 for STAC Browser
+#
+# Data volumes:
+#   Mount your climate data directory to /data in both services
+
+version: "3.8"
+
+services:
+  # STAC Catalog API
+  stac-api:
+    build:
+      context: ./esm_catalog
+      dockerfile: Dockerfile
+    image: esm-catalog:latest
+    container_name: esm-stac-api
+    ports:
+      - "23000:23000"
+    environment:
+      - ESM_CATALOG_PORT=23000
+      - ESM_CATALOG_DB=/data/catalog.duckdb
+    volumes:
+      - ${DATA_DIR:-/work}:/data:ro
+      - catalog-db:/var/lib/esm-catalog
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:23000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # Visualization Service
+  viz:
+    build:
+      context: ./esm_viz
+      dockerfile: Dockerfile
+    image: esm-viz:latest
+    container_name: esm-viz
+    ports:
+      - "23001:23001"
+    environment:
+      - ESM_VIZ_PORT=23001
+      - STAC_API_URL=http://stac-api:23000
+    volumes:
+      - ${DATA_DIR:-/work}:/data:ro
+    depends_on:
+      stac-api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:23001/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: unless-stopped
+
+  # STAC Browser (optional - for local development)
+  browser:
+    image: node:20-slim
+    container_name: esm-stac-browser
+    working_dir: /app
+    ports:
+      - "8080:5173"
+    environment:
+      - VITE_CATALOG_URL=http://stac-api:23000
+      - VITE_VIZ_SERVER=http://viz:23001
+    volumes:
+      - ${BROWSER_DIR:-../stac-browser}:/app:ro
+    command: ["npm", "run", "dev", "--", "--host", "0.0.0.0"]
+    depends_on:
+      - stac-api
+      - viz
+    profiles:
+      - with-browser
+
+volumes:
+  catalog-db:
+    driver: local
+
+networks:
+  default:
+    name: esm-data-services

--- a/utils/hpc-deploy.sh
+++ b/utils/hpc-deploy.sh
@@ -1,0 +1,254 @@
+#!/bin/bash
+# ESM-Tools Data Services - HPC Deployment Script
+# Runs STAC API and Visualization services via Apptainer
+#
+# Usage:
+#   ./hpc-deploy.sh start    # Start both services
+#   ./hpc-deploy.sh stop     # Stop both services
+#   ./hpc-deploy.sh status   # Check service status
+#   ./hpc-deploy.sh logs     # Tail service logs
+#   ./hpc-deploy.sh build    # Build container images
+
+set -euo pipefail
+
+# Configuration
+STAC_API_PORT=${STAC_API_PORT:-23100}
+VIZ_PORT=${VIZ_PORT:-23101}
+BIND_MOUNTS="/albedo:/albedo:ro"
+CATALOG_DB="${CATALOG_DB:-/albedo/work/pgierz/catalog.duckdb}"
+
+# Directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGE_DIR="${SCRIPT_DIR}/containers"
+LOG_DIR="${SCRIPT_DIR}/logs"
+PID_DIR="${SCRIPT_DIR}/pids"
+
+# Image names
+STAC_API_SIF="${IMAGE_DIR}/esm-catalog.sif"
+VIZ_SIF="${IMAGE_DIR}/esm-viz.sif"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+ensure_dirs() {
+    mkdir -p "${IMAGE_DIR}" "${LOG_DIR}" "${PID_DIR}"
+}
+
+build_images() {
+    ensure_dirs
+    log_info "Building STAC API container..."
+    apptainer build "${STAC_API_SIF}" "docker-daemon://esm-catalog:latest" 2>/dev/null || \
+    apptainer build "${STAC_API_SIF}" "${SCRIPT_DIR}/esm_catalog/Dockerfile"
+
+    log_info "Building Viz container..."
+    apptainer build "${VIZ_SIF}" "docker-daemon://esm-viz:latest" 2>/dev/null || \
+    apptainer build "${VIZ_SIF}" "${SCRIPT_DIR}/esm_viz/Dockerfile"
+
+    log_info "Images built successfully"
+}
+
+pull_images() {
+    ensure_dirs
+    REGISTRY="ghcr.io/esm-tools/esm_tools"
+    TAG="${1:-latest}"
+
+    log_info "Pulling STAC API container from registry..."
+    apptainer pull "${STAC_API_SIF}" "docker://${REGISTRY}/esm-catalog-api:${TAG}"
+
+    log_info "Pulling Viz container from registry..."
+    apptainer pull "${VIZ_SIF}" "docker://${REGISTRY}/esm-viz:${TAG}"
+
+    log_info "Images pulled successfully"
+}
+
+start_services() {
+    ensure_dirs
+
+    # Check if images exist
+    if [[ ! -f "${STAC_API_SIF}" ]]; then
+        log_error "STAC API image not found: ${STAC_API_SIF}"
+        log_info "Run './hpc-deploy.sh build' first or pull from registry"
+        exit 1
+    fi
+
+    if [[ ! -f "${VIZ_SIF}" ]]; then
+        log_error "Viz image not found: ${VIZ_SIF}"
+        log_info "Run './hpc-deploy.sh build' first or pull from registry"
+        exit 1
+    fi
+
+    # Start STAC API
+    if [[ -f "${PID_DIR}/stac-api.pid" ]] && kill -0 "$(cat "${PID_DIR}/stac-api.pid")" 2>/dev/null; then
+        log_warn "STAC API already running (PID $(cat "${PID_DIR}/stac-api.pid"))"
+    else
+        log_info "Starting STAC API on port ${STAC_API_PORT}..."
+        apptainer instance start \
+            --bind "${BIND_MOUNTS}" \
+            --env ESM_CATALOG_PORT="${STAC_API_PORT}" \
+            --env ESM_CATALOG_DB="${CATALOG_DB}" \
+            "${STAC_API_SIF}" \
+            esm-stac-api
+
+        # Run the server inside the instance
+        nohup apptainer exec instance://esm-stac-api \
+            uvicorn esm_catalog.api.app:app \
+            --host 0.0.0.0 --port "${STAC_API_PORT}" \
+            > "${LOG_DIR}/stac-api.log" 2>&1 &
+        echo $! > "${PID_DIR}/stac-api.pid"
+        log_info "STAC API started (PID $!)"
+    fi
+
+    # Start Viz Service
+    if [[ -f "${PID_DIR}/viz.pid" ]] && kill -0 "$(cat "${PID_DIR}/viz.pid")" 2>/dev/null; then
+        log_warn "Viz service already running (PID $(cat "${PID_DIR}/viz.pid"))"
+    else
+        log_info "Starting Viz service on port ${VIZ_PORT}..."
+        apptainer instance start \
+            --bind "${BIND_MOUNTS}" \
+            --env ESM_VIZ_PORT="${VIZ_PORT}" \
+            --env STAC_API_URL="http://localhost:${STAC_API_PORT}" \
+            "${VIZ_SIF}" \
+            esm-viz
+
+        # Run the server inside the instance
+        nohup apptainer exec instance://esm-viz \
+            python -m esm_viz.cli serve \
+            --host 0.0.0.0 --port "${VIZ_PORT}" \
+            > "${LOG_DIR}/viz.log" 2>&1 &
+        echo $! > "${PID_DIR}/viz.pid"
+        log_info "Viz service started (PID $!)"
+    fi
+
+    log_info "Services started:"
+    log_info "  STAC API:  http://$(hostname):${STAC_API_PORT}"
+    log_info "  Viz:       http://$(hostname):${VIZ_PORT}"
+    log_info "  Logs:      ${LOG_DIR}/"
+}
+
+stop_services() {
+    log_info "Stopping services..."
+
+    # Stop STAC API
+    if [[ -f "${PID_DIR}/stac-api.pid" ]]; then
+        PID=$(cat "${PID_DIR}/stac-api.pid")
+        if kill -0 "${PID}" 2>/dev/null; then
+            kill "${PID}" && log_info "Stopped STAC API (PID ${PID})"
+        fi
+        rm -f "${PID_DIR}/stac-api.pid"
+    fi
+    apptainer instance stop esm-stac-api 2>/dev/null || true
+
+    # Stop Viz
+    if [[ -f "${PID_DIR}/viz.pid" ]]; then
+        PID=$(cat "${PID_DIR}/viz.pid")
+        if kill -0 "${PID}" 2>/dev/null; then
+            kill "${PID}" && log_info "Stopped Viz service (PID ${PID})"
+        fi
+        rm -f "${PID_DIR}/viz.pid"
+    fi
+    apptainer instance stop esm-viz 2>/dev/null || true
+
+    log_info "All services stopped"
+}
+
+show_status() {
+    echo "=== ESM Data Services Status ==="
+    echo ""
+
+    # STAC API
+    echo -n "STAC API (port ${STAC_API_PORT}): "
+    if [[ -f "${PID_DIR}/stac-api.pid" ]] && kill -0 "$(cat "${PID_DIR}/stac-api.pid")" 2>/dev/null; then
+        echo -e "${GREEN}RUNNING${NC} (PID $(cat "${PID_DIR}/stac-api.pid"))"
+        curl -s "http://localhost:${STAC_API_PORT}/health" 2>/dev/null && echo "" || echo -e "  ${YELLOW}(health check failed)${NC}"
+    else
+        echo -e "${RED}STOPPED${NC}"
+    fi
+
+    # Viz
+    echo -n "Viz service (port ${VIZ_PORT}): "
+    if [[ -f "${PID_DIR}/viz.pid" ]] && kill -0 "$(cat "${PID_DIR}/viz.pid")" 2>/dev/null; then
+        echo -e "${GREEN}RUNNING${NC} (PID $(cat "${PID_DIR}/viz.pid"))"
+        curl -s "http://localhost:${VIZ_PORT}/health" 2>/dev/null && echo "" || echo -e "  ${YELLOW}(health check failed)${NC}"
+    else
+        echo -e "${RED}STOPPED${NC}"
+    fi
+
+    echo ""
+    echo "Apptainer instances:"
+    apptainer instance list 2>/dev/null || echo "  (none)"
+}
+
+show_logs() {
+    SERVICE="${1:-all}"
+
+    case "${SERVICE}" in
+        stac|api)
+            tail -f "${LOG_DIR}/stac-api.log"
+            ;;
+        viz)
+            tail -f "${LOG_DIR}/viz.log"
+            ;;
+        all|*)
+            tail -f "${LOG_DIR}"/*.log
+            ;;
+    esac
+}
+
+# Main
+case "${1:-help}" in
+    start)
+        start_services
+        ;;
+    stop)
+        stop_services
+        ;;
+    restart)
+        stop_services
+        sleep 2
+        start_services
+        ;;
+    status)
+        show_status
+        ;;
+    logs)
+        show_logs "${2:-all}"
+        ;;
+    build)
+        build_images
+        ;;
+    pull)
+        pull_images "${2:-latest}"
+        ;;
+    help|*)
+        echo "ESM-Tools Data Services - HPC Deployment"
+        echo ""
+        echo "Usage: $0 <command>"
+        echo ""
+        echo "Commands:"
+        echo "  start    Start STAC API and Viz services"
+        echo "  stop     Stop all services"
+        echo "  restart  Restart all services"
+        echo "  status   Show service status"
+        echo "  logs     Tail service logs (logs [stac|viz|all])"
+        echo "  build    Build Apptainer images from Dockerfiles"
+        echo "  pull     Pull images from ghcr.io registry (pull [tag])"
+        echo ""
+        echo "Environment variables:"
+        echo "  STAC_API_PORT  STAC API port (default: 23100)"
+        echo "  VIZ_PORT       Viz service port (default: 23101)"
+        echo "  CATALOG_DB     Path to DuckDB catalog file"
+        echo ""
+        echo "Current configuration:"
+        echo "  STAC API:  http://localhost:${STAC_API_PORT}"
+        echo "  Viz:       http://localhost:${VIZ_PORT}"
+        echo "  Bind:      ${BIND_MOUNTS}"
+        echo "  Catalog:   ${CATALOG_DB}"
+        ;;
+esac


### PR DESCRIPTION
## Context


> **Provenance:** this implementation is substantially Paul Gierz's work, carried over from his `esm-tools-plus/simcat/pgierz-workbench` prototype branch (commits Mar–Apr 2026). This PR ports it, largely as-is, into the reviewable stack.

Part of the **[ESM-Tools-plus/simcat](https://github.com/esm-tools/esm_tools/tree/esm-tools-plus/simcat/collapsed-collections)** initiative.

This PR introduces `esm_viz` — the visualization service that renders STAC item data as interactive previews and static plots.
The companion PR [#1473](../../pull/1473) introduces `esm_catalog`, the catalog API that esm_viz integrates with.

> **Reviewer tip:** `esm_viz` is an independent FastAPI service with no imports from `esm_catalog`. It reads STAC item URLs and renders data. Start with `src/esm_viz/app.py` for the API surface, then `src/esm_viz/interactive.py` for the panel-based preview logic.

---

## What's included

### `src/esm_viz/` — the package (10 modules, ~4400 lines)

| Module | Purpose |
|---|---|
| `app.py` | FastAPI application factory and route registration |
| `cli.py` | `esm-viz serve` CLI entry point |
| `interactive.py` | Panel-based interactive previews embedded in the browser |
| `static_preview.py` | Static PNG/SVG plot generation (matplotlib) |
| `collection.py` | Collection-level overview plots |
| `fesom.py` | FESOM ocean model data rendering (mesh-aware) |
| `compute.py` | Dask/distributed compute coordination |
| `compute_routes.py` | REST routes for compute job management |
| `readers.py` | NetCDF / GRIB data readers via xarray |

**API endpoints:**

- `GET /preview/{item_id}` — static preview image for a STAC item
- `GET /preview/{item_id}/panel` — interactive Panel app embedded in the browser
- `GET /collection/{collection_id}/overview` — collection-level overview plot
- `GET /health` — health check
- Compute routes for Dask cluster management

### `tests/test_esm_viz/` — contract tests

~500 lines of contract tests verifying the API shape and compute contract independently of a running service.

### Deployment files

| File | Purpose |
|---|---|
| `.github/workflows/docker-esm-viz.yml` | Docker image CI |
| `utils/docker-compose.yml` | Compose file for running catalog API + viz service together |
| `utils/hpc-deploy.sh` | HPC deployment helper (Albedo/Levante) |

---

## Integration with esm_catalog

`esm_viz` is configured via the `vizServer` URL in the STAC Browser config and linked from catalog item assets. It is **not imported** by `esm_catalog` — the two services communicate only over HTTP. Either can be deployed independently.

Typical deployment:
```
esm-catalog serve --port 23006   # STAC API
esm-viz serve --port 23007       # Viz service
# STAC Browser configured with vizServer: "http://host:23007"
```

---

## Test plan
- [ ] `pytest tests/test_esm_viz/` passes
- [ ] `esm-viz serve --help` runs without error
- [ ] `GET /health` returns `{"status": "healthy"}`
- [ ] `GET /preview/{item_id}` returns an image for a valid NetCDF item
- [ ] `GET /preview/{item_id}/panel` returns an embeddable Panel app

🤖 Generated with [Claude Code](https://claude.com/claude-code)
