### PR TITLE
feat(esm_catalog): PR-A1a — STAC data-model foundation

### DIFF
--- a/.github/workflows/esm-catalog-tests.yml
+++ b/.github/workflows/esm-catalog-tests.yml
@@ -5,12 +5,16 @@ on:
     paths:
       - "src/esm_catalog/**"
       - "tests/test_esm_catalog/**"
+      - "configs/machines/**"
+      - "configs/storage/**"
       - ".github/workflows/esm-catalog-tests.yml"
       - "setup.py"
   pull_request:
     paths:
       - "src/esm_catalog/**"
       - "tests/test_esm_catalog/**"
+      - "configs/machines/**"
+      - "configs/storage/**"
       - ".github/workflows/esm-catalog-tests.yml"
       - "setup.py"
 
@@ -19,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.12"]
+        python-version: ["3.9"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -28,12 +32,10 @@ jobs:
       - name: Install
         run: |
           python -m pip install --upgrade pip
-          # Install esm_catalog in isolation. A full ".[catalog]" pulls the entire
-          # esm-tools base, which pins ruamel.yaml.clib==0.2.7 — it fails to build
-          # on Python 3.12. The catalog is a standalone component, so we install it
-          # with --no-deps and add only the deps it actually imports (plus a modern
-          # pytest; the base pins pytest==7.1.2, which predates 3.12 support).
-          pip install -e . --no-deps
-          pip install -U "pytest>=7.4" click loguru pystac shapely universal-pathlib
+          # esm_catalog now imports esm_parser (configs/machines + configs/storage
+          # yaml loading), so it needs the full esm-tools base, not just its own
+          # extras. Matrix is 3.9-only to match the rest of esm-tools: the base
+          # pins ruamel.yaml.clib==0.2.7, which doesn't build on 3.12.
+          pip install -e ".[catalog]"
       - name: Run esm_catalog tests
         run: pytest tests/test_esm_catalog -v

--- a/configs/machines/albedo.yaml
+++ b/configs/machines/albedo.yaml
@@ -198,3 +198,11 @@ computer:
 
         PATH[(1)]: "$PERL5LIB/../bin:$PATH"
         PATH[(2)]: "$PATH:$ECCODESROOT/bin"  #$HDF5ROOT/bin:$NETCDFFROOT/bin:$NETCDFROOT/bin:$ECCODESROOT/bin:$PATH
+
+storage:
+    albedo-work:
+        path_str: "/albedo/"
+        facility: "AWI"
+        system: "albedo"
+        storage_type: "lustre"
+        state: "online"

--- a/configs/machines/levante.yaml
+++ b/configs/machines/levante.yaml
@@ -544,7 +544,7 @@ computer:
 
 storage:
     levante-work:
-        path_str: "^(?!.*/levante).*/work/"
+        path_str: "^/work/[a-z]{2}[0-9]{4}/"
         facility: "DKRZ"
         system: "levante"
         storage_type: "lustre"

--- a/configs/machines/levante.yaml
+++ b/configs/machines/levante.yaml
@@ -541,3 +541,11 @@ computer:
 
     further_reading:
             - batch_system/slurm.yaml
+
+storage:
+    levante-work:
+        path_str: "^(?!.*/levante).*/work/"
+        facility: "DKRZ"
+        system: "levante"
+        storage_type: "lustre"
+        state: "online"

--- a/configs/storage/hpss.yaml
+++ b/configs/storage/hpss.yaml
@@ -1,0 +1,9 @@
+################################################################################
+# Tape/HPSS archive storage, not tied to a specific machine.
+################################################################################
+storage:
+    hpss:
+        path_str: "/arch/|/hpss/"
+        storage_type: "hpss"
+        state: "offline"
+        recall_time_estimate: 300

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -15,15 +15,14 @@ subdirectories. `esm_catalog` IS the STAC catalog layer; the extra nesting is re
 
 ```
 src/esm_catalog/
-    context.py      ← PR-A1b
+    context.py      ← PR-A1b  (+ Contact dataclass from PR-A1g)
     registry.py     ← PR-A1b
     collection.py   ← PR-A1b
-    item.py         ← PR-A1b
+    item.py         ← PR-A1b  (+ contacts injection from PR-A1g)
     hpc.py          ← PR-A1c  (extension + detect logic combined)
     datacube.py     ← PR-A1d
     namelist.py     ← PR-A1e
     paleo.py        ← PR-A1f
-    contacts.py     ← PR-A1g
 ```
 
 ## Custom STAC extension schemas
@@ -221,9 +220,13 @@ needed in `configs/stac-extensions/`.
   as `namelists_by_component`; scan layer populates, STAC layer reads.
 - Production validation: `CollectionContext(production=True)` requires at least one
   contact with name + institution.
-- `add_contacts(item, ctx)` in `contacts.py` maps contacts to STAC format.
+- No separate `contacts.py` — contacts injection is part of item construction.
+  `_contact_to_stac(contact)` is a private helper in `item.py`; `_build_properties`
+  reads `ctx.contacts` directly; `make_item` adds the extension URL to `stac_extensions`
+  when contacts are present. A dedicated module for a single small function adds
+  indirection without benefit.
 - External community schema URL (already resolves); no schema file needed.
-- 12 tests, 29 total passing.
+- 29 tests passing (Contact tests in `test_context.py`, contacts-via-item tests in `test_stac_item.py`).
 
 **Runscript config convention (new — document in user guide):**
 

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -117,7 +117,18 @@ variable, datetime/start_datetime/end_datetime, format, output_frequency, variab
 
 ---
 
-### [ ] PR-A1c — HPC storage extension
+### [x] PR-A1c — HPC storage extension
+
+**Branch:** `esm-catalog/pr-a1c-hpc-extension` (PR #1511) ✓ design decisions:
+- No path-pattern matching or filesystem probing at all — the caller resolves its
+  own machine config and passes it down as `machine_config: dict` (keys: facility,
+  system, storage_type). `CollectionContext` gained an optional `machine_config` field.
+- `hpc:storage_tier` derived from storage_type (hpss/dmf/tape → cold, gpfs → warm,
+  else hot); `hpc:storage_type` goes on the data asset's extra_fields.
+- `hpc:last_access` from `path.stat().st_atime`; graceful no-op (beyond last_access)
+  when `machine_config` is None. Fields 19/20 dropped as planned.
+- Schema authored at `configs/stac-extensions/hpc/v1.0.0/schema.json`; tests validate
+  built items against it via jsonschema.
 
 **Branch from:** `release` (after PR-A1b is merged)
 **Goal:** Add HPC storage metadata to items. Fields: 14, 15, 16, 17, 18.
@@ -162,7 +173,15 @@ needed in `configs/stac-extensions/`.
 
 ---
 
-### [ ] PR-A1e — Namelist extension
+### [x] PR-A1e — Namelist extension
+
+**Branch:** `esm-catalog/pr-a1e-namelist-extension` (PR #1512) ✓ design decisions:
+- `nml:raw` dropped, `nml:files`/`nml:groups`/`nml:parameters` kept, 10-item list cap
+  kept, `add_namelist_item_extension` kept as-is — all per plan.
+- Collection-level extension wired into `make_collection` using the collection's own
+  component's entry from `ctx.namelists_by_component`; item-level wired into `make_item`.
+- Schema authored at `configs/stac-extensions/namelist/v1.0.0/schema.json` (if/then/else
+  on type for Collection vs Item shapes); tests validate both against it.
 
 **Branch from:** `release` (after PR-A1b is merged)
 **Goal:** Add namelist parameters to items and collections. Field: 31.
@@ -183,7 +202,22 @@ needed in `configs/stac-extensions/`.
 
 ---
 
-### [ ] PR-A1f — Paleo + experiment classification
+### [x] PR-A1f — Paleo + experiment classification
+
+**Branch:** `esm-catalog/pr-a1f-paleo-extension` (PR #1513) ✓ design decisions:
+- All four planned fixes applied: dead `TYPE_CHECKING` block removed,
+  `detect_paleo_simulation` removed, `_add_experiment_type` no longer reads
+  `nml:echam:runctl:dt_start` (regression test asserts the namelist property is
+  ignored), `paleo:years_bp` only when `experiment_type == "paleo"`.
+- Exposed as `add_paleo_extension(item, paleo_config, paleo_year, reference_year)` and
+  `add_experiment_type(item)` in `paleo.py` (experiment_type logic moved out of item.py).
+- `CollectionContext` gained an optional `paleo_config` field (the `general.paleo`
+  config section as a plain dict: reference_year, epoch, period).
+- `add_experiment_type` prefers the `paleo:year` property over the item's own datetimes,
+  so deep-time runs with meaningless model calendars classify correctly.
+- Schema authored at `configs/stac-extensions/paleo/v1.0.0/schema.json`.
+- Note: #1511/#1512/#1513 all touch the same two spots in `item.py`; the last two to
+  merge each need trivial conflict resolution (keep all import/call lines).
 
 **Branch from:** `release` (after PR-A1b is merged)
 **Goal:** Add paleo fields and experiment_type. Fields: 21–27.

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -90,19 +90,21 @@ branch — the file won't exist at that path until it's on `release`.
 ### [x] PR-A1b — Core infrastructure
 
 **Branch:** `esm-catalog/pr-a1b-core-infrastructure` ✓ merged design decisions:
-- `ESMCollection(dict)` and `ESMItem(dict)` — dict subclasses with instance methods
+- Function-based API: `make_item(...)` returns `pystac.Item`; `make_collection(...)` returns `pystac.Collection`; `update_extent(collection, item)` is a standalone function
+- `CollectionContext` dataclass with `production: bool` flag and `__post_init__` validation; required production fields listed in `PRODUCTION_REQUIRED: ClassVar`; `data_license` field (avoids shadowing Python builtin `license`)
 - Flat layout: all files directly in `src/esm_catalog/`, no subdirectories
 - `test_no_scan_dependency.py` deferred — add it in the PR that introduces `esm_catalog.scan`
+- No dependency on `esm_tools` from `esm_catalog` (avoids `pkg_resources` / Python 3.12 CI breakage)
 
 **Branch from:** `release`
 **Goal:** Minimal working STAC Item + Collection with only the confirmed core fields.
 No extension calls.
 
 **Files created:**
-- `src/esm_catalog/context.py` — `CollectionContext` dataclass
+- `src/esm_catalog/context.py` — `CollectionContext` dataclass with production validation
 - `src/esm_catalog/registry.py` — `EXTENSION_URLS` dict
-- `src/esm_catalog/collection.py` — `ESMCollection(dict)` with `update_extent` method
-- `src/esm_catalog/item.py` — `ESMItem(dict)` with `_build_*` methods; core fields only (1, 3, 5, 8, 10); URI conversion inlined in `_to_href` (no separate `uri.py` — UPath 0.3.x drops the SSH host from `str(path)`, workaround uses `storage_options['host']`)
+- `src/esm_catalog/collection.py` — `make_collection(ctx)`, `update_extent(collection, item)`
+- `src/esm_catalog/item.py` — `make_item(path, metadata, ctx)` with `_build_*` helper functions; core fields only (1, 3, 5, 8, 10); URI conversion in `_to_href` (UPath 0.3.x drops SSH host from `str(path)`, workaround uses `storage_options['host']`)
 
 **Item properties in this PR:**
 ```
@@ -113,10 +115,6 @@ variable, datetime/start_datetime/end_datetime, format, output_frequency, variab
 - `tests/test_esm_catalog/test_context.py`
 - `tests/test_esm_catalog/test_stac_collection.py`
 - `tests/test_esm_catalog/test_stac_item.py`
-- `tests/test_esm_catalog/test_no_scan_dependency.py`
-
-**Source to copy from `esm-catalog/pr-a1a-stac-foundation`:** use the existing files as
-the starting point but strip everything that belongs to a later PR.
 
 ---
 

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -8,6 +8,46 @@ then tick its checkbox and update the status.
 
 ---
 
+## File layout convention
+
+All new files live **flat** inside `src/esm_catalog/` — no `stac/` or `extensions/`
+subdirectories. `esm_catalog` IS the STAC catalog layer; the extra nesting is redundant.
+
+```
+src/esm_catalog/
+    context.py      ← PR-A1b
+    uri.py          ← PR-A1b
+    registry.py     ← PR-A1b
+    collection.py   ← PR-A1b
+    item.py         ← PR-A1b
+    hpc.py          ← PR-A1c  (extension + detect logic combined)
+    datacube.py     ← PR-A1d
+    namelist.py     ← PR-A1e
+    paleo.py        ← PR-A1f
+    contacts.py     ← PR-A1g
+```
+
+## Custom STAC extension schemas
+
+The three custom ESM-Tools extensions (`hpc`, `paleo`, `namelist`) need JSON Schema
+files. These live **in this repo** under `configs/stac-extensions/`, not on an external
+site:
+
+```
+configs/stac-extensions/
+    hpc/v1.0.0/schema.json       ← PR-A1c
+    namelist/v1.0.0/schema.json  ← PR-A1e
+    paleo/v1.0.0/schema.json     ← PR-A1f
+```
+
+The URLs in `registry.py` point to `https://esm-tools.github.io/stac-extensions/...`
+as placeholders. Each extension PR must update its URL to the raw GitHub URL
+(`https://raw.githubusercontent.com/esm-tools/esm_tools/release/configs/stac-extensions/...`)
+**after** the schema file is merged to `release`. Do not update the URL on the feature
+branch — the file won't exist at that path until it's on `release`.
+
+---
+
 ## Metadata fields reference
 
 | # | Field | Status | PR |
@@ -57,11 +97,9 @@ No extension calls.
 **Files to create:**
 - `src/esm_catalog/context.py` — `CollectionContext` dataclass (fields: `experiment_id`, `component`, `collection_id`, `experiment_path`, `namelists_by_component`)
 - `src/esm_catalog/uri.py` — `parse_uri`, `to_uri`, `_has_protocol`; keep lazy UPath import but drop the verbose install-hint error message
-- `src/esm_catalog/stac/__init__.py`
-- `src/esm_catalog/stac/extensions/__init__.py`
-- `src/esm_catalog/stac/extensions/registry.py` — `EXTENSION_URLS` dict (keep all URLs; unused ones cost nothing)
-- `src/esm_catalog/stac/collection.py` — `make_collection`, `update_collection_extent`; **no** `add_namelist_extension` call
-- `src/esm_catalog/stac/item.py` — `make_item` with core fields only (1, 3, 5, 8, 10); **no** extension calls, **no** `_add_experiment_type`
+- `src/esm_catalog/registry.py` — `EXTENSION_URLS` dict (keep all URLs; unused ones cost nothing)
+- `src/esm_catalog/collection.py` — `make_collection`, `update_collection_extent`; **no** `add_namelist_extension` call
+- `src/esm_catalog/item.py` — `make_item` with core fields only (1, 3, 5, 8, 10); **no** extension calls, **no** `_add_experiment_type`
 
 **Item properties in this PR:**
 ```
@@ -87,27 +125,23 @@ the starting point but strip everything that belongs to a later PR.
 Fields 19 and 20 (HSM subprocess queries) are permanently dropped.
 
 **Files to create:**
-- `src/esm_catalog/hpc/__init__.py`
-- `src/esm_catalog/hpc/detect.py` — **rewrite required**
-- `src/esm_catalog/stac/extensions/hpc.py` — simplified (no `get_hsm_state` call)
+- `src/esm_catalog/hpc.py` — extension + detect logic combined in one file (no subdirectory).
+  Replaces both `hpc/detect.py` and `stac/extensions/hpc.py` from pr-a1a branch.
+- `configs/stac-extensions/hpc/v1.0.0/schema.json` — JSON Schema for the hpc extension.
+  After this PR is merged to `release`, update the `"hpc"` URL in `registry.py` to the
+  raw GitHub URL.
+- `tests/test_esm_catalog/test_hpc.py` — write new tests
 
 **Key problem with the existing `detect.py` — must be fixed:**
 The current code hardcodes machine names as Python path patterns (`/albedo/` → AWI, `/work/` → DKRZ).
 This is machine-specific and fragile. The right approach:
 - Machine storage info (facility, system, storage_type) belongs in ESM-Tools machine YAML configs.
-- `detect.py` should read from the parsed ESM-Tools config/machine dict, not probe the filesystem.
+- Detection should read from the parsed ESM-Tools config/machine dict, not probe the filesystem.
 - Drop the `ctypes`/`statfs(2)` approach entirely — it is Linux-only and uses raw C struct layouts.
 - Keep `hpc:last_access` from `path.stat().st_atime` (simple, no subprocess).
 
-**Files to delete (vs pr-a1a branch):**
-- `src/esm_catalog/hpc/state.py` — entire file; it only served fields 19 and 20.
-
-**Signature change for `add_hpc_extension`:**
+**Signature for `add_hpc_extension`:**
 ```python
-# Before (current branch):
-add_hpc_extension(item, path)  # detects storage by probing path
-
-# After:
 add_hpc_extension(item, path, machine_config: dict | None = None)
 # machine_config is the parsed ESM-Tools machine section;
 # if None, only hpc:last_access is populated (graceful degradation).
@@ -121,8 +155,11 @@ add_hpc_extension(item, path, machine_config: dict | None = None)
 **Goal:** Add cube:dimensions and cube:variables to items. Fields: 12, 13.
 
 **Files to create:**
-- `src/esm_catalog/stac/extensions/datacube.py` — copy from pr-a1a branch; no changes needed
+- `src/esm_catalog/datacube.py` — copy from `stac/extensions/datacube.py` in pr-a1a branch; no logic changes needed.
 - `tests/test_esm_catalog/test_stac_datacube.py` — write new tests
+
+**Note:** datacube uses an external community schema URL (already resolves); no schema file
+needed in `configs/stac-extensions/`.
 
 ---
 
@@ -132,7 +169,10 @@ add_hpc_extension(item, path, machine_config: dict | None = None)
 **Goal:** Add namelist parameters to items and collections. Field: 31.
 
 **Files to create:**
-- `src/esm_catalog/stac/extensions/namelist.py`
+- `src/esm_catalog/namelist.py` — adapted from `stac/extensions/namelist.py` in pr-a1a branch.
+- `configs/stac-extensions/namelist/v1.0.0/schema.json` — JSON Schema for the namelist extension.
+  After this PR is merged to `release`, update the `"namelist"` URL in `registry.py` to the
+  raw GitHub URL.
 - `tests/test_esm_catalog/test_stac_namelist_ext.py`
 
 **Changes from pr-a1a branch:**
@@ -150,7 +190,10 @@ add_hpc_extension(item, path, machine_config: dict | None = None)
 **Goal:** Add paleo fields and experiment_type. Fields: 21–27.
 
 **Files to create:**
-- `src/esm_catalog/stac/extensions/paleo.py`
+- `src/esm_catalog/paleo.py` — adapted from `stac/extensions/paleo.py` in pr-a1a branch.
+- `configs/stac-extensions/paleo/v1.0.0/schema.json` — JSON Schema for the paleo extension.
+  After this PR is merged to `release`, update the `"paleo"` URL in `registry.py` to the
+  raw GitHub URL.
 - `tests/test_esm_catalog/test_stac_paleo.py` — write new tests
 
 **Changes from pr-a1a branch:**
@@ -170,9 +213,11 @@ add_hpc_extension(item, path, machine_config: dict | None = None)
 **Goal:** Add PI contact information to items. Fields: 28, 29, 30.
 
 **Files to create:**
-- `src/esm_catalog/stac/extensions/contacts.py` — copy from pr-a1a; check that `pi_name`/`PI_name`
-  dual-lookup is consistent with how ESM-Tools configs actually store PI information.
+- `src/esm_catalog/contacts.py` — adapted from `stac/extensions/contacts.py` in pr-a1a branch.
 - `tests/test_esm_catalog/test_stac_contacts.py` — write new tests
+
+**Note:** contacts uses an external community schema URL (already resolves); no schema file
+needed in `configs/stac-extensions/`.
 
 **Open question before implementing:** verify that `general.pi_name` / `general.PI_name` etc. are
 actually present in any existing ESM-Tools runscript configs. If not, define the canonical key name

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -1,0 +1,195 @@
+# ESM Catalog STAC — Development Plan
+
+This file tracks the plan for breaking the `esm-catalog/pr-a1a-stac-foundation` branch
+into a series of small, reviewable PRs. Each PR branches from `release`.
+
+Future Claude sessions: read this file first, implement the next unchecked PR,
+then tick its checkbox and update the status.
+
+---
+
+## Metadata fields reference
+
+| # | Field | Status | PR |
+|---|-------|--------|----|
+| 1 | `variable` | confirmed | A1b |
+| 2 | `stream` (GRIB stream type) | **explore later** | — |
+| 3 | `datetime` / `start_datetime` / `end_datetime` | confirmed | A1b |
+| 4 | `file:size` | **explore later** | — |
+| 5 | `format` (netcdf/grib) | confirmed | A1b |
+| 6 | `keywords` | **explore later** | — |
+| 7 | `conventions` (CF conventions string) | **explore later** | — |
+| 8 | `output_frequency` | confirmed | A1b |
+| 9 | `file:{key}` all global attributes | **explore later** | — |
+| 10 | `variables` (multi-variable list) | confirmed | A1b |
+| 11 | `cf:parameter` | **explore later** | — |
+| 12 | `cube:dimensions` | confirmed | A1d |
+| 13 | `cube:variables` | confirmed | A1d |
+| 14 | `hpc:facility` | confirmed | A1c |
+| 15 | `hpc:system` | confirmed | A1c |
+| 16 | `hpc:storage_tier` | confirmed | A1c |
+| 17 | `hpc:last_access` | confirmed | A1c |
+| 18 | `hpc:storage_type` | confirmed | A1c |
+| 19 | `hpc:state` (subprocess dmattr/lfs) | **dropped** | — |
+| 20 | `hpc:recall_time_estimate` | **dropped** | — |
+| 21 | `paleo:year` | confirmed | A1f |
+| 22 | `paleo:display` | confirmed | A1f |
+| 23 | `paleo:reference_year` | confirmed | A1f |
+| 24 | `paleo:epoch` | confirmed | A1f |
+| 25 | `paleo:period` | confirmed | A1f |
+| 26 | `paleo:years_bp` | confirmed | A1f |
+| 27 | `experiment_type` | confirmed | A1f |
+| 28 | `contacts[].name` | confirmed | A1g |
+| 29 | `contacts[].identifier` (ORCID) | confirmed | A1g |
+| 30 | `contacts[].organization` | confirmed | A1g |
+| 31 | `nml:{component}:{group}:{key}` | confirmed | A1e |
+
+---
+
+## PRs
+
+### [ ] PR-A1b — Core infrastructure
+
+**Branch from:** `release`
+**Goal:** Minimal working STAC Item + Collection with only the confirmed core fields.
+No extension calls.
+
+**Files to create:**
+- `src/esm_catalog/context.py` — `CollectionContext` dataclass (fields: `experiment_id`, `component`, `collection_id`, `experiment_path`, `namelists_by_component`)
+- `src/esm_catalog/uri.py` — `parse_uri`, `to_uri`, `_has_protocol`; keep lazy UPath import but drop the verbose install-hint error message
+- `src/esm_catalog/stac/__init__.py`
+- `src/esm_catalog/stac/extensions/__init__.py`
+- `src/esm_catalog/stac/extensions/registry.py` — `EXTENSION_URLS` dict (keep all URLs; unused ones cost nothing)
+- `src/esm_catalog/stac/collection.py` — `make_collection`, `update_collection_extent`; **no** `add_namelist_extension` call
+- `src/esm_catalog/stac/item.py` — `make_item` with core fields only (1, 3, 5, 8, 10); **no** extension calls, **no** `_add_experiment_type`
+
+**Item properties in this PR:**
+```
+variable, datetime/start_datetime/end_datetime, format, output_frequency, variables (list)
+```
+
+**Tests to create:**
+- `tests/test_esm_catalog/test_context.py`
+- `tests/test_esm_catalog/test_uri.py`
+- `tests/test_esm_catalog/test_stac_collection.py`
+- `tests/test_esm_catalog/test_stac_item.py`
+- `tests/test_esm_catalog/test_no_scan_dependency.py`
+
+**Source to copy from `esm-catalog/pr-a1a-stac-foundation`:** use the existing files as
+the starting point but strip everything that belongs to a later PR.
+
+---
+
+### [ ] PR-A1c — HPC storage extension
+
+**Branch from:** `release` (after PR-A1b is merged)
+**Goal:** Add HPC storage metadata to items. Fields: 14, 15, 16, 17, 18.
+Fields 19 and 20 (HSM subprocess queries) are permanently dropped.
+
+**Files to create:**
+- `src/esm_catalog/hpc/__init__.py`
+- `src/esm_catalog/hpc/detect.py` — **rewrite required**
+- `src/esm_catalog/stac/extensions/hpc.py` — simplified (no `get_hsm_state` call)
+
+**Key problem with the existing `detect.py` — must be fixed:**
+The current code hardcodes machine names as Python path patterns (`/albedo/` → AWI, `/work/` → DKRZ).
+This is machine-specific and fragile. The right approach:
+- Machine storage info (facility, system, storage_type) belongs in ESM-Tools machine YAML configs.
+- `detect.py` should read from the parsed ESM-Tools config/machine dict, not probe the filesystem.
+- Drop the `ctypes`/`statfs(2)` approach entirely — it is Linux-only and uses raw C struct layouts.
+- Keep `hpc:last_access` from `path.stat().st_atime` (simple, no subprocess).
+
+**Files to delete (vs pr-a1a branch):**
+- `src/esm_catalog/hpc/state.py` — entire file; it only served fields 19 and 20.
+
+**Signature change for `add_hpc_extension`:**
+```python
+# Before (current branch):
+add_hpc_extension(item, path)  # detects storage by probing path
+
+# After:
+add_hpc_extension(item, path, machine_config: dict | None = None)
+# machine_config is the parsed ESM-Tools machine section;
+# if None, only hpc:last_access is populated (graceful degradation).
+```
+
+---
+
+### [ ] PR-A1d — Datacube extension
+
+**Branch from:** `release` (after PR-A1b is merged)
+**Goal:** Add cube:dimensions and cube:variables to items. Fields: 12, 13.
+
+**Files to create:**
+- `src/esm_catalog/stac/extensions/datacube.py` — copy from pr-a1a branch; no changes needed
+- `tests/test_esm_catalog/test_stac_datacube.py` — write new tests
+
+---
+
+### [ ] PR-A1e — Namelist extension
+
+**Branch from:** `release` (after PR-A1b is merged)
+**Goal:** Add namelist parameters to items and collections. Field: 31.
+
+**Files to create:**
+- `src/esm_catalog/stac/extensions/namelist.py`
+- `tests/test_esm_catalog/test_stac_namelist_ext.py`
+
+**Changes from pr-a1a branch:**
+- Drop `nml:raw` from `add_namelist_extension` — storing the full raw namelist as JSON in the
+  collection may be megabytes for complex setups; drop it unless a later session decides it is needed.
+- Keep `nml:files`, `nml:groups`, `nml:parameters`.
+- Keep `add_namelist_item_extension` as-is.
+- The 10-item list-length cap in `_flatten_for_search` is fine; keep it.
+
+---
+
+### [ ] PR-A1f — Paleo + experiment classification
+
+**Branch from:** `release` (after PR-A1b is merged)
+**Goal:** Add paleo fields and experiment_type. Fields: 21–27.
+
+**Files to create:**
+- `src/esm_catalog/stac/extensions/paleo.py`
+- `tests/test_esm_catalog/test_stac_paleo.py` — write new tests
+
+**Changes from pr-a1a branch:**
+- Remove `if TYPE_CHECKING: pass` (dead code).
+- Remove `detect_paleo_simulation` — it is not called anywhere in the STAC layer.
+- `_add_experiment_type` currently reads `nml:echam:runctl:dt_start` from item properties
+  (a namelist field set by PR-A1e). This creates an ordering dependency. **Fix:** use only
+  `start_datetime`/`datetime` from the item properties; the namelist coupling is a fragile
+  assumption that `echam` is always the component.
+- `paleo:years_bp` should only be added when `experiment_type == "paleo"`, not for every item.
+
+---
+
+### [ ] PR-A1g — Contacts extension
+
+**Branch from:** `release` (after PR-A1b is merged)
+**Goal:** Add PI contact information to items. Fields: 28, 29, 30.
+
+**Files to create:**
+- `src/esm_catalog/stac/extensions/contacts.py` — copy from pr-a1a; check that `pi_name`/`PI_name`
+  dual-lookup is consistent with how ESM-Tools configs actually store PI information.
+- `tests/test_esm_catalog/test_stac_contacts.py` — write new tests
+
+**Open question before implementing:** verify that `general.pi_name` / `general.PI_name` etc. are
+actually present in any existing ESM-Tools runscript configs. If not, define the canonical key name
+and document it. Check `configs/` and `runscripts/` in the repo.
+
+---
+
+## Deferred — explore in a future session
+
+These metadata fields were not confirmed or dropped; they need investigation before deciding
+whether and how to implement them.
+
+| # | Field | Question to answer |
+|---|-------|--------------------|
+| 2 | `stream` | Is GRIB stream type a useful search dimension? Where does it come from in the scan layer? |
+| 4 | `file:size` | Useful for data management queries? Overhead to collect? |
+| 6 | `keywords` | Is a `[collection_id]` keyword useful in STAC Browser? Better to rely on `collection` field? |
+| 7 | `conventions` | Always "CF-1.x"? Worth indexing? |
+| 9 | `file:{key}` all global attrs | Too many arbitrary keys; if needed, define an allowlist of specific attributes |
+| 11 | `cf:parameter` | Requires CF convention parsing; is this available from the scan layer? |

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -207,21 +207,31 @@ needed in `configs/stac-extensions/`.
 
 ---
 
-### [ ] PR-A1g — Contacts extension
+### [x] PR-A1g — Contacts extension
 
-**Branch from:** `release` (after PR-A1b is merged)
+**Branch:** `esm-catalog/pr-a1g-contacts-extension` (branched from pr-a1b) ✓
+
 **Goal:** Add PI contact information to items. Fields: 28, 29, 30.
 
-**Files to create:**
-- `src/esm_catalog/contacts.py` — adapted from `stac/extensions/contacts.py` in pr-a1a branch.
-- `tests/test_esm_catalog/test_stac_contacts.py` — write new tests
+**Design decisions:**
+- `Contact` dataclass added to `context.py` (name, orcid, institution, roles).
+  `pi_name`/`PI_name` keys from pr-a1a were AI-invented and don't exist in any config;
+  replaced with a structured `general.contacts` list in the runscript config.
+- Contact data flows via `CollectionContext.contacts: list[Contact]` — same pattern
+  as `namelists_by_component`; scan layer populates, STAC layer reads.
+- Production validation: `CollectionContext(production=True)` requires at least one
+  contact with name + institution.
+- `add_contacts(item, ctx)` in `contacts.py` maps contacts to STAC format.
+- External community schema URL (already resolves); no schema file needed.
+- 12 tests, 29 total passing.
 
-**Note:** contacts uses an external community schema URL (already resolves); no schema file
-needed in `configs/stac-extensions/`.
+**Runscript config convention (new — document in user guide):**
 
-**Open question before implementing:** verify that `general.pi_name` / `general.PI_name` etc. are
-actually present in any existing ESM-Tools runscript configs. If not, define the canonical key name
-and document it. Check `configs/` and `runscripts/` in the repo.
+    general:
+        contacts:
+            - name: "Jane Doe"
+              orcid: "0000-0001-2345-6789"   # optional
+              institution: "AWI"             # required in production
 
 ---
 

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -159,7 +159,15 @@ add_hpc_extension(item, path, machine_config: dict | None = None)
 
 ---
 
-### [ ] PR-A1d — Datacube extension
+### [x] PR-A1d — Datacube extension
+
+**Branch:** `esm-catalog/pr-a1d-datacube-extension` (PR #1507) ✓ design decisions:
+- Ported as planned with one behavioral tightening: the v2.2.0 schema requires
+  `cube:dimensions` whenever the extension URL is declared, so the extension is a
+  no-op unless dimensions are present (variables alone don't trigger it).
+- Wired into `make_item`; tests validate built items against the community
+  datacube v2.2.0 schema via jsonschema (schema vendored under
+  `tests/test_esm_catalog/schemas/`).
 
 **Branch from:** `release` (after PR-A1b is merged)
 **Goal:** Add cube:dimensions and cube:variables to items. Fields: 12, 13.

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -16,7 +16,6 @@ subdirectories. `esm_catalog` IS the STAC catalog layer; the extra nesting is re
 ```
 src/esm_catalog/
     context.py      ← PR-A1b
-    uri.py          ← PR-A1b
     registry.py     ← PR-A1b
     collection.py   ← PR-A1b
     item.py         ← PR-A1b
@@ -101,10 +100,9 @@ No extension calls.
 
 **Files created:**
 - `src/esm_catalog/context.py` — `CollectionContext` dataclass
-- `src/esm_catalog/uri.py` — `parse_uri`, `to_uri`, `_has_protocol`
 - `src/esm_catalog/registry.py` — `EXTENSION_URLS` dict
 - `src/esm_catalog/collection.py` — `ESMCollection(dict)` with `update_extent` method
-- `src/esm_catalog/item.py` — `ESMItem(dict)` with `_build_*` methods; core fields only (1, 3, 5, 8, 10)
+- `src/esm_catalog/item.py` — `ESMItem(dict)` with `_build_*` methods; core fields only (1, 3, 5, 8, 10); URI conversion inlined in `_to_href` (no separate `uri.py` — UPath 0.3.x drops the SSH host from `str(path)`, workaround uses `storage_options['host']`)
 
 **Item properties in this PR:**
 ```
@@ -113,7 +111,6 @@ variable, datetime/start_datetime/end_datetime, format, output_frequency, variab
 
 **Tests created:**
 - `tests/test_esm_catalog/test_context.py`
-- `tests/test_esm_catalog/test_uri.py`
 - `tests/test_esm_catalog/test_stac_collection.py`
 - `tests/test_esm_catalog/test_stac_item.py`
 - `tests/test_esm_catalog/test_no_scan_dependency.py`

--- a/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
+++ b/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md
@@ -88,25 +88,30 @@ branch — the file won't exist at that path until it's on `release`.
 
 ## PRs
 
-### [ ] PR-A1b — Core infrastructure
+### [x] PR-A1b — Core infrastructure
+
+**Branch:** `esm-catalog/pr-a1b-core-infrastructure` ✓ merged design decisions:
+- `ESMCollection(dict)` and `ESMItem(dict)` — dict subclasses with instance methods
+- Flat layout: all files directly in `src/esm_catalog/`, no subdirectories
+- `test_no_scan_dependency.py` deferred — add it in the PR that introduces `esm_catalog.scan`
 
 **Branch from:** `release`
 **Goal:** Minimal working STAC Item + Collection with only the confirmed core fields.
 No extension calls.
 
-**Files to create:**
-- `src/esm_catalog/context.py` — `CollectionContext` dataclass (fields: `experiment_id`, `component`, `collection_id`, `experiment_path`, `namelists_by_component`)
-- `src/esm_catalog/uri.py` — `parse_uri`, `to_uri`, `_has_protocol`; keep lazy UPath import but drop the verbose install-hint error message
-- `src/esm_catalog/registry.py` — `EXTENSION_URLS` dict (keep all URLs; unused ones cost nothing)
-- `src/esm_catalog/collection.py` — `make_collection`, `update_collection_extent`; **no** `add_namelist_extension` call
-- `src/esm_catalog/item.py` — `make_item` with core fields only (1, 3, 5, 8, 10); **no** extension calls, **no** `_add_experiment_type`
+**Files created:**
+- `src/esm_catalog/context.py` — `CollectionContext` dataclass
+- `src/esm_catalog/uri.py` — `parse_uri`, `to_uri`, `_has_protocol`
+- `src/esm_catalog/registry.py` — `EXTENSION_URLS` dict
+- `src/esm_catalog/collection.py` — `ESMCollection(dict)` with `update_extent` method
+- `src/esm_catalog/item.py` — `ESMItem(dict)` with `_build_*` methods; core fields only (1, 3, 5, 8, 10)
 
 **Item properties in this PR:**
 ```
 variable, datetime/start_datetime/end_datetime, format, output_frequency, variables (list)
 ```
 
-**Tests to create:**
+**Tests created:**
 - `tests/test_esm_catalog/test_context.py`
 - `tests/test_esm_catalog/test_uri.py`
 - `tests/test_esm_catalog/test_stac_collection.py`

--- a/src/esm_catalog/context.py
+++ b/src/esm_catalog/context.py
@@ -21,8 +21,6 @@ class CollectionContext:
         experiment_id: Experiment name (e.g. "exp-alpha").
         component: Model component for the current scan (e.g. "echam").
         collection_id: STAC collection id (Option A: == experiment_id).
-        collection_title: Human-readable title for the collection.
-            Copied verbatim from the source scan.context.CollectionContext.
         experiment_path: Optional path to the experiment root.
         namelists_by_component: Pre-scanned namelists, mapping
             component name -> {filename -> {group -> {key -> value}}}.
@@ -32,6 +30,5 @@ class CollectionContext:
     experiment_id: str
     component: str
     collection_id: str
-    collection_title: str = ""
     experiment_path: Optional[Path] = None
     namelists_by_component: dict = field(default_factory=dict)

--- a/src/esm_catalog/context.py
+++ b/src/esm_catalog/context.py
@@ -1,0 +1,37 @@
+"""Shared CollectionContext value object.
+
+Relocated from esm_catalog.scan.context so that the STAC model (stac/) can use
+it without importing the scan layer. The scan layer now imports it from here
+and is responsible for populating `namelists_by_component` before STAC items
+are built (this is what breaks the former scan<->stac import cycle).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class CollectionContext:
+    """Identity + pre-scanned context for building a collection's items.
+
+    Attributes:
+        experiment_id: Experiment name (e.g. "exp-alpha").
+        component: Model component for the current scan (e.g. "echam").
+        collection_id: STAC collection id (Option A: == experiment_id).
+        collection_title: Human-readable title for the collection.
+            Copied verbatim from the source scan.context.CollectionContext.
+        experiment_path: Optional path to the experiment root.
+        namelists_by_component: Pre-scanned namelists, mapping
+            component name -> {filename -> {group -> {key -> value}}}.
+            Populated by the scan layer; the STAC model only reads it.
+    """
+
+    experiment_id: str
+    component: str
+    collection_id: str
+    collection_title: str = ""
+    experiment_path: Optional[Path] = None
+    namelists_by_component: dict = field(default_factory=dict)

--- a/src/esm_catalog/hpc/__init__.py
+++ b/src/esm_catalog/hpc/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+"""HPC-specific utilities: storage tier detection and HSM state queries."""

--- a/src/esm_catalog/hpc/detect.py
+++ b/src/esm_catalog/hpc/detect.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+"""Detect HPC storage type and facility from a file path or filesystem."""
+
+import os
+from pathlib import Path
+
+
+# Map filesystem f_type magic numbers to storage type names
+# (from linux/magic.h)
+_FS_TYPE_NAMES = {
+    0x65735546: "fuse",    # FUSE_SUPER_MAGIC
+    0x01021994: "tmpfs",
+    0xEF53: "ext4",
+    0x6969: "nfs",
+    0x5346544E: "ntfs",
+    0x9123683E: "btrfs",
+    0x58465342: "xfs",
+    0x47504653: "gpfs",    # GPFS (IBM Spectrum Scale)
+    0x0BD00BD0: "lustre",  # LUSTRE_SUPER_MAGIC
+}
+
+
+def detect_hpc_storage(path) -> dict:
+    """Return HPC storage metadata for *path*.
+
+    Tries path-pattern matching first (fast, no syscall).  Falls back to
+    filesystem statvfs for unknown paths.
+
+    Works with both local Path and remote UPath objects.
+
+    Returns a dict with a subset of these keys:
+        hpc:facility, hpc:system, hpc:storage_type, hpc:state,
+        hpc:recall_time_estimate
+    """
+    # Check if remote path (UPath with protocol)
+    is_remote = hasattr(path, "protocol") and path.protocol and path.protocol != "file"
+
+    # For remote paths, use the path attribute or string representation
+    # For local paths, resolve to absolute
+    if is_remote:
+        path_str = path.path if hasattr(path, "path") else str(path)
+    else:
+        path_str = str(Path(path).resolve())
+
+    # AWI Albedo cluster (Lustre)
+    if "/albedo/" in path_str:
+        return {
+            "hpc:facility": "AWI",
+            "hpc:system": "albedo",
+            "hpc:storage_type": "lustre",
+            "hpc:state": "online",
+        }
+
+    # DKRZ Levante cluster (Lustre)
+    if "/work/" in path_str and "/levante" not in path_str:
+        # Heuristic: /work/ on DKRZ is Lustre, checked via hostname elsewhere
+        return {
+            "hpc:facility": "DKRZ",
+            "hpc:system": "levante",
+            "hpc:storage_type": "lustre",
+            "hpc:state": "online",
+        }
+
+    # Tape/HPSS archive paths
+    if "/arch/" in path_str or "/hpss/" in path_str:
+        return {
+            "hpc:storage_type": "hpss",
+            "hpc:state": "offline",
+            "hpc:recall_time_estimate": 300,
+        }
+
+    # Fallback: probe the actual filesystem (only for local paths)
+    if is_remote:
+        # Can't statvfs a remote path - return generic remote storage
+        return {"hpc:storage_type": "remote", "hpc:state": "online"}
+
+    return _detect_from_statvfs(path)
+
+
+def _detect_from_statvfs(path: Path) -> dict:
+    """Use os.statvfs to identify the filesystem type."""
+    try:
+        import ctypes
+        buf = _statfs(path)
+        fs_type = _FS_TYPE_NAMES.get(buf, "posix")
+        return {"hpc:storage_type": fs_type, "hpc:state": "online"}
+    except Exception:
+        return {"hpc:storage_type": "posix", "hpc:state": "online"}
+
+
+def _statfs(path: Path) -> int:
+    """Return f_type from statfs(2).  Linux only.
+
+    On non-Linux platforms (macOS, BSD), returns 0 to fall back to
+    generic POSIX detection since statfs structure differs significantly.
+    """
+    import sys
+
+    # Only Linux has f_type in statfs - macOS/BSD have different structures
+    if sys.platform != "linux":
+        return 0
+
+    import ctypes
+    import ctypes.util
+
+    libc_name = ctypes.util.find_library("c")
+    if not libc_name:
+        return 0
+    libc = ctypes.CDLL(libc_name, use_errno=True)
+
+    # struct statfs layout (simplified — f_type is the first unsigned long)
+    class _StatfsResult(ctypes.Structure):
+        _fields_ = [
+            ("f_type", ctypes.c_long),
+            ("f_bsize", ctypes.c_long),
+            ("f_blocks", ctypes.c_ulong),
+            ("f_bfree", ctypes.c_ulong),
+            ("f_bavail", ctypes.c_ulong),
+            ("f_files", ctypes.c_ulong),
+            ("f_ffree", ctypes.c_ulong),
+            ("f_fsid", ctypes.c_long * 2),
+            ("f_namelen", ctypes.c_long),
+            ("f_frsize", ctypes.c_long),
+            ("f_flags", ctypes.c_long),
+            ("f_spare", ctypes.c_long * 4),
+        ]
+
+    result = _StatfsResult()
+    ret = libc.statfs(str(path).encode(), ctypes.byref(result))
+    if ret != 0:
+        return 0
+    return result.f_type

--- a/src/esm_catalog/hpc/detect.py
+++ b/src/esm_catalog/hpc/detect.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 """Detect HPC storage type and facility from a file path or filesystem."""
 
-import os
+import re
+from functools import lru_cache
 from pathlib import Path
+
+import esm_parser
 
 
 # Map filesystem f_type magic numbers to storage type names
@@ -19,12 +22,35 @@ _FS_TYPE_NAMES = {
     0x0BD00BD0: "lustre",  # LUSTRE_SUPER_MAGIC
 }
 
+# storage: entry fields that get copied straight into the returned dict,
+# prefixed with "hpc:".
+_STORAGE_FIELDS = ("facility", "system", "storage_type", "state", "recall_time_estimate")
+
+
+@lru_cache(maxsize=1)
+def _load_storage_entries() -> dict:
+    """Load all `storage:` entries from `configs/machines/*.yaml` and
+    `configs/storage/*.yaml`.
+
+    Returns a dict mapping entry name -> its fields (``path_str`` plus any of
+    ``_STORAGE_FIELDS``), in the order the yaml files were read.
+    """
+    config_root = Path(esm_parser.CONFIG_PATH)
+    entries = {}
+    for subdir in ("machines", "storage"):
+        for yaml_path in sorted((config_root / subdir).glob("*.yaml")):
+            data = esm_parser.yaml_file_to_dict(str(yaml_path))
+            entries.update(data.get("storage") or {})
+    return entries
+
 
 def detect_hpc_storage(path) -> dict:
     """Return HPC storage metadata for *path*.
 
-    Tries path-pattern matching first (fast, no syscall).  Falls back to
-    filesystem statvfs for unknown paths.
+    Tries path-pattern matching first (fast, no syscall), matching against
+    `storage:` entries loaded from `configs/machines/*.yaml` and
+    `configs/storage/*.yaml`.  Falls back to filesystem statvfs for
+    unmatched paths.
 
     Works with both local Path and remote UPath objects.
 
@@ -42,32 +68,14 @@ def detect_hpc_storage(path) -> dict:
     else:
         path_str = str(Path(path).resolve())
 
-    # AWI Albedo cluster (Lustre)
-    if "/albedo/" in path_str:
-        return {
-            "hpc:facility": "AWI",
-            "hpc:system": "albedo",
-            "hpc:storage_type": "lustre",
-            "hpc:state": "online",
-        }
-
-    # DKRZ Levante cluster (Lustre)
-    if "/work/" in path_str and "/levante" not in path_str:
-        # Heuristic: /work/ on DKRZ is Lustre, checked via hostname elsewhere
-        return {
-            "hpc:facility": "DKRZ",
-            "hpc:system": "levante",
-            "hpc:storage_type": "lustre",
-            "hpc:state": "online",
-        }
-
-    # Tape/HPSS archive paths
-    if "/arch/" in path_str or "/hpss/" in path_str:
-        return {
-            "hpc:storage_type": "hpss",
-            "hpc:state": "offline",
-            "hpc:recall_time_estimate": 300,
-        }
+    for fields in _load_storage_entries().values():
+        pattern = fields.get("path_str")
+        if pattern and re.search(pattern, path_str):
+            return {
+                f"hpc:{field}": fields[field]
+                for field in _STORAGE_FIELDS
+                if field in fields
+            }
 
     # Fallback: probe the actual filesystem (only for local paths)
     if is_remote:

--- a/src/esm_catalog/hpc/state.py
+++ b/src/esm_catalog/hpc/state.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+"""HSM (Hierarchical Storage Management) state queries with rate limiting."""
+
+import subprocess
+import time
+from pathlib import Path
+from threading import Lock
+
+from loguru import logger
+
+
+# Simple token-bucket rate limiter: max 10 HSM queries per second
+_RATE_LIMIT_INTERVAL = 0.1  # seconds between queries
+_rate_lock = Lock()
+_last_query_time: float = 0.0
+
+
+def _throttle():
+    """Block if we are querying faster than the rate limit."""
+    global _last_query_time
+    with _rate_lock:
+        now = time.monotonic()
+        elapsed = now - _last_query_time
+        if elapsed < _RATE_LIMIT_INTERVAL:
+            time.sleep(_RATE_LIMIT_INTERVAL - elapsed)
+        _last_query_time = time.monotonic()
+
+
+def get_hsm_state(path: Path) -> str:
+    """Return the HSM state of *path*.
+
+    Returns one of: "online", "nearline", "offline", "migrating", "unknown"
+
+    Tries dmattr (GPFS/Spectrum Scale) first, then scoutfs inode flags.
+    Falls back to "online" if neither tool is available.
+    """
+    _throttle()
+
+    state = _dmattr_state(path)
+    if state != "unknown":
+        return state
+
+    state = _scoutfs_state(path)
+    if state != "unknown":
+        return state
+
+    logger.debug("No HSM tool available for {}; assuming online", path)
+    return "online"
+
+
+def _dmattr_state(path: Path) -> str:
+    """Query dmattr (IBM Spectrum Scale / GPFS DMF)."""
+    try:
+        result = subprocess.run(
+            ["dmattr", "-l", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return "unknown"
+        output = result.stdout.lower()
+        # dmattr output contains "state:" field
+        if "state: reg" in output or "state: dls" in output:
+            return "online"
+        if "state: mig" in output:
+            return "migrating"
+        if "state: dul" in output or "state: ofl" in output:
+            return "nearline"
+        if "state: offl" in output:
+            return "offline"
+        return "online"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"
+
+
+def _scoutfs_state(path: Path) -> str:
+    """Query scoutfs inode staging flags (DDN Lustre HSM variant)."""
+    try:
+        result = subprocess.run(
+            ["lfs", "hsm_state", str(path)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return "unknown"
+        output = result.stdout.lower()
+        if "released" in output:
+            return "nearline"
+        if "archived" in output and "exists" not in output:
+            return "nearline"
+        return "online"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "unknown"

--- a/src/esm_catalog/stac/__init__.py
+++ b/src/esm_catalog/stac/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+"""STAC object construction: Items, Collections, and extensions."""

--- a/src/esm_catalog/stac/collection.py
+++ b/src/esm_catalog/stac/collection.py
@@ -110,6 +110,6 @@ def _parse_iso(s: str | None) -> datetime | None:
     if not s:
         return None
     try:
-        return datetime.fromisoformat(s.rstrip("Z"))
+        return datetime.fromisoformat(s.removesuffix("Z"))
     except (ValueError, AttributeError):
         return None

--- a/src/esm_catalog/stac/collection.py
+++ b/src/esm_catalog/stac/collection.py
@@ -1,0 +1,115 @@
+"""Create and update STAC Collection objects."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from esm_catalog.stac.extensions.namelist import add_namelist_extension
+
+
+def make_collection(ctx, namelists: dict | None = None,
+                    fesom_info: dict | None = None) -> dict:
+    """Return a STAC Collection dict for the given CollectionContext.
+
+    Args:
+        ctx: CollectionContext (experiment_id, component, collection_id).
+        namelists: Optional pre-scanned namelists ({filename -> {group -> {k: v}}}).
+            Scanned by the scan layer and passed in; this function never scans.
+        fesom_info: Optional pre-extracted FESOM mesh fields to merge in.
+
+    Returns:
+        STAC Collection dict.
+    """
+    collection = {
+        "type": "Collection",
+        "id": ctx.collection_id,
+        "stac_version": "1.0.0",
+        "stac_extensions": [],
+        "title": ctx.experiment_id,
+        "description": f"All model output for experiment {ctx.experiment_id}",
+        "license": "proprietary",
+        "extent": {
+            "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
+            "temporal": {"interval": [[None, None]]},
+        },
+        "links": [
+            {"rel": "parent", "href": f"#{ctx.experiment_id}",
+             "type": "application/json"},
+        ],
+        "experiment": ctx.experiment_id,
+        "components": [ctx.component],
+    }
+
+    if namelists:
+        collection = add_namelist_extension(collection, namelists)
+    if fesom_info:
+        collection.update(fesom_info)
+
+    return collection
+
+
+def update_collection_extent(collection: dict, item: dict) -> dict:
+    """Expand collection spatial and temporal extent to include *item*.
+
+    Modifies *collection* in-place and returns it.
+    """
+    # Spatial extent
+    item_bbox = item.get("bbox")
+    if item_bbox and len(item_bbox) == 4:
+        current_bboxes = collection["extent"]["spatial"]["bbox"]
+        if current_bboxes == [[-180.0, -90.0, 180.0, 90.0]]:
+            # Still at global placeholder; replace with item's bbox
+            collection["extent"]["spatial"]["bbox"] = [item_bbox]
+        else:
+            merged = _merge_bbox(current_bboxes[0], item_bbox)
+            collection["extent"]["spatial"]["bbox"] = [merged]
+
+    # Temporal extent
+    props = item.get("properties", {})
+    item_dt = props.get("datetime") or props.get("start_datetime")
+    item_dt_end = props.get("end_datetime") or item_dt
+
+    if item_dt:
+        interval = collection["extent"]["temporal"]["interval"][0]
+        start = interval[0]
+        end = interval[1]
+
+        item_dt_parsed = _parse_iso(item_dt)
+        item_end_parsed = _parse_iso(item_dt_end)
+
+        if start is None:
+            start = item_dt
+        else:
+            start_parsed = _parse_iso(start)
+            if item_dt_parsed and start_parsed and item_dt_parsed < start_parsed:
+                start = item_dt
+
+        if end is None:
+            end = item_dt_end
+        else:
+            end_parsed = _parse_iso(end)
+            if item_end_parsed and end_parsed and item_end_parsed > end_parsed:
+                end = item_dt_end
+
+        collection["extent"]["temporal"]["interval"] = [[start, end]]
+
+    return collection
+
+
+def _merge_bbox(a: list, b: list) -> list:
+    """Return the bounding box that contains both a and b."""
+    return [
+        min(a[0], b[0]),
+        min(a[1], b[1]),
+        max(a[2], b[2]),
+        max(a[3], b[3]),
+    ]
+
+
+def _parse_iso(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.rstrip("Z"))
+    except (ValueError, AttributeError):
+        return None

--- a/src/esm_catalog/stac/extensions/__init__.py
+++ b/src/esm_catalog/stac/extensions/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+"""STAC extension helpers."""

--- a/src/esm_catalog/stac/extensions/contacts.py
+++ b/src/esm_catalog/stac/extensions/contacts.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+"""Contacts STAC extension: authors, ORCID, institution."""
+
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+
+def add_contacts_extension(item: dict, config: dict | None = None) -> dict:
+    """Inject contacts extension fields into *item* from ESM-Tools *config*.
+
+    Looks for these keys in config["general"]:
+        pi_name, pi_orcid, pi_institution
+
+    Does nothing if config is None or no PI information is present.
+    """
+    if not config:
+        return item
+
+    general = config.get("general", {})
+    pi_name = general.get("pi_name") or general.get("PI_name")
+    pi_orcid = general.get("pi_orcid") or general.get("PI_orcid")
+    pi_institution = general.get("pi_institution") or general.get("PI_institution")
+
+    if not pi_name:
+        return item
+
+    contact: dict = {"name": pi_name, "roles": ["principal_investigator"]}
+    if pi_orcid:
+        contact["identifier"] = {
+            "scheme": "orcid",
+            "identifier": pi_orcid,
+        }
+    if pi_institution:
+        contact["organization"] = pi_institution
+
+    item["properties"].setdefault("contacts", []).append(contact)
+
+    url = EXTENSION_URLS["contacts"]
+    if url not in item["stac_extensions"]:
+        item["stac_extensions"].append(url)
+
+    return item

--- a/src/esm_catalog/stac/extensions/datacube.py
+++ b/src/esm_catalog/stac/extensions/datacube.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+"""Datacube STAC extension: cube:dimensions and cube:variables."""
+
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+
+def add_datacube_extension(item: dict, metadata: dict) -> dict:
+    """Inject datacube extension fields into *item* from *metadata*.
+
+    Populates:
+        item["properties"]["cube:dimensions"]
+        item["properties"]["cube:variables"]
+
+    Appends the datacube schema URL to item["stac_extensions"].
+    """
+    dims = metadata.get("dimensions", {})
+    variables = metadata.get("variables", [])
+
+    if not dims and not variables:
+        return item
+
+    if dims:
+        item["properties"]["cube:dimensions"] = dims
+
+    if variables:
+        cube_vars = {}
+        for v in variables:
+            name = v["name"]
+            entry: dict = {"dimensions": v.get("dimensions", [])}
+            if "standard_name" in v:
+                entry["description"] = v["standard_name"]
+            if "units" in v:
+                entry["unit"] = v["units"]
+            if "long_name" in v:
+                entry["description"] = v["long_name"]
+            cube_vars[name] = entry
+        item["properties"]["cube:variables"] = cube_vars
+
+    url = EXTENSION_URLS["datacube"]
+    if url not in item["stac_extensions"]:
+        item["stac_extensions"].append(url)
+
+    return item

--- a/src/esm_catalog/stac/extensions/hpc.py
+++ b/src/esm_catalog/stac/extensions/hpc.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+"""HPC storage STAC extension: tape state, recall time, storage tier."""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from esm_catalog.hpc.detect import detect_hpc_storage
+from esm_catalog.hpc.state import get_hsm_state
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+
+def add_hpc_extension(item: dict, path) -> dict:
+    """Inject HPC storage extension fields into *item* for *path*.
+
+    Item-level fields (item["properties"]):
+        hpc:facility, hpc:system, hpc:storage_tier, hpc:last_access
+
+    Asset-level fields (item["assets"]["data"]):
+        hpc:storage_type, hpc:state, hpc:recall_time_estimate
+
+    Works with both local Path and remote UPath objects.
+    """
+    # Check if remote path (UPath with protocol)
+    is_remote = hasattr(path, "protocol") and path.protocol and path.protocol != "file"
+
+    # For local paths, convert to Path; for remote, keep as-is
+    if not is_remote:
+        path = Path(path)
+
+    storage_info = detect_hpc_storage(path)
+
+    # Item-level properties
+    props = item["properties"]
+    if "hpc:facility" in storage_info:
+        props["hpc:facility"] = storage_info["hpc:facility"]
+    if "hpc:system" in storage_info:
+        props["hpc:system"] = storage_info["hpc:system"]
+    if "hpc:storage_tier" in storage_info:
+        props["hpc:storage_tier"] = storage_info["hpc:storage_tier"]
+    else:
+        # Derive tier from storage type
+        storage_type = storage_info.get("hpc:storage_type", "posix")
+        state = storage_info.get("hpc:state", "online")
+        props["hpc:storage_tier"] = _derive_tier(storage_type, state)
+
+    # Last access time from stat (works for both local Path and UPath)
+    try:
+        stat = path.stat()  # UPath and Path both support .stat()
+        props["hpc:last_access"] = datetime.fromtimestamp(
+            stat.st_atime, tz=timezone.utc
+        ).isoformat()
+    except (OSError, Exception):
+        pass  # Remote stat may fail for some protocols
+
+    # Asset-level fields
+    asset = item["assets"].get("data", {})
+    asset["hpc:storage_type"] = storage_info.get("hpc:storage_type", "posix")
+    if "hpc:system" in storage_info:
+        asset["hpc:system"] = storage_info["hpc:system"]
+
+    # Only query HSM state if file appears to be on tape
+    if storage_info.get("hpc:storage_type") in ("hpss", "dmf"):
+        asset["hpc:state"] = get_hsm_state(path)
+    else:
+        asset["hpc:state"] = storage_info.get("hpc:state", "online")
+
+    if "hpc:recall_time_estimate" in storage_info:
+        asset["hpc:recall_time_estimate"] = storage_info["hpc:recall_time_estimate"]
+
+    item["assets"]["data"] = asset
+
+    url = EXTENSION_URLS["hpc"]
+    if url not in item["stac_extensions"]:
+        item["stac_extensions"].append(url)
+
+    return item
+
+
+def _derive_tier(storage_type: str, state: str) -> str:
+    if storage_type in ("hpss", "dmf") or state in ("offline", "nearline"):
+        return "cold"
+    if storage_type in ("gpfs",):
+        return "warm"
+    return "hot"

--- a/src/esm_catalog/stac/extensions/namelist.py
+++ b/src/esm_catalog/stac/extensions/namelist.py
@@ -36,15 +36,9 @@ This allows CQL2 queries like:
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import TYPE_CHECKING
-
 from loguru import logger
 
 from esm_catalog.stac.extensions.registry import EXTENSION_URLS
-
-if TYPE_CHECKING:
-    pass
 
 
 def add_namelist_extension(
@@ -142,7 +136,7 @@ def add_namelist_item_extension(item: dict, ctx) -> dict:
     Reads ctx.namelists_by_component (populated by the scan layer); this
     function performs no scanning and imports nothing from scan/.
     """
-    by_component = getattr(ctx, "namelists_by_component", None) or {}
+    by_component = ctx.namelists_by_component
     total_params = 0
 
     for component_name, namelists in by_component.items():
@@ -170,29 +164,3 @@ def add_namelist_item_extension(item: dict, ctx) -> dict:
     return item
 
 
-def get_namelist_config_path(
-    experiment_path: Path,
-    component: str,
-) -> "Path | None":
-    """Determine the config directory for a component.
-
-    ESM-Tools convention: config/{component}/ contains namelists.
-
-    Args:
-        experiment_path: Path to experiment root (e.g., /exp/basic-001/).
-        component: Component name (e.g., "echam", "fesom").
-
-    Returns:
-        Path to config directory if it exists, None otherwise.
-    """
-    # Try standard ESM-Tools layout
-    config_path = experiment_path / "config" / component
-    if config_path.is_dir():
-        return config_path
-
-    # Try alternative layout (config at experiment root)
-    alt_path = experiment_path / component / "config"
-    if alt_path.is_dir():
-        return alt_path
-
-    return None

--- a/src/esm_catalog/stac/extensions/namelist.py
+++ b/src/esm_catalog/stac/extensions/namelist.py
@@ -1,0 +1,198 @@
+"""Namelist STAC extension: simulation parameters from Fortran namelists.
+
+Adds namelist configuration data to STAC collections, allowing users to
+search for simulations by their runtime parameters (timestep, coupling
+settings, physics options, etc.).
+
+Properties added at collection level:
+    nml:files        - List of namelist filenames
+    nml:groups       - List of namelist groups (chapters) across all files
+    nml:parameters   - Flattened key-value parameters for search
+    nml:raw          - Full nested namelist structure for display
+
+Example collection properties::
+
+    {
+        "nml:files": ["namelist.echam", "namelist.jsbach"],
+        "nml:groups": ["runctl", "radctl", "jsbach_ctl"],
+        "nml:parameters": {
+            "runctl:delta_time": 450,
+            "runctl:lcouple": true,
+            "radctl:co2vmr": 0.000284
+        },
+        "nml:raw": {
+            "namelist.echam": {
+                "runctl": {"delta_time": 450, ...},
+                "radctl": {"co2vmr": 0.000284, ...}
+            }
+        }
+    }
+
+This allows CQL2 queries like:
+    - Find simulations with delta_time > 300
+    - Find all coupled simulations (lcouple = true)
+    - Find simulations with specific CO2 levels
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+if TYPE_CHECKING:
+    pass
+
+
+def add_namelist_extension(
+    collection: dict,
+    namelists: dict,
+) -> dict:
+    """Inject namelist extension fields into a STAC collection.
+
+    Args:
+        collection: STAC collection dict to modify.
+        namelists: Output from scan_namelist_directory(), mapping
+            filename -> {group -> {key -> value}}.
+
+    Returns:
+        Modified collection dict with namelist properties.
+    """
+    if not namelists:
+        return collection
+
+    # Extract file list
+    files = sorted(namelists.keys())
+
+    # Extract unique group names across all files
+    groups: set[str] = set()
+    for file_data in namelists.values():
+        groups.update(file_data.keys())
+
+    # Flatten parameters for searchable properties
+    parameters = _flatten_for_search(namelists)
+
+    # Add to collection properties (or root for collection-level metadata)
+    # STAC collections can have arbitrary properties at root level
+    collection["nml:files"] = files
+    collection["nml:groups"] = sorted(groups)
+    collection["nml:parameters"] = parameters
+    collection["nml:raw"] = namelists
+
+    # Register extension
+    url = EXTENSION_URLS.get("namelist")
+    if url and url not in collection.get("stac_extensions", []):
+        collection.setdefault("stac_extensions", []).append(url)
+
+    logger.debug(
+        "Added namelist extension: {} files, {} groups, {} parameters",
+        len(files),
+        len(groups),
+        len(parameters),
+    )
+
+    return collection
+
+
+def _flatten_for_search(namelists: dict) -> dict:
+    """Flatten namelist structure for searchable parameters.
+
+    Creates keys in format "group:key" for CQL2 filtering.
+    Only includes scalar values that are useful for search.
+    """
+    result: dict = {}
+
+    for _filename, groups in namelists.items():
+        for group_name, values in groups.items():
+            for key, value in values.items():
+                # Skip None values
+                if value is None:
+                    continue
+
+                # Skip complex nested structures
+                if isinstance(value, dict):
+                    continue
+
+                # For lists, only keep simple scalar lists
+                if isinstance(value, list):
+                    if len(value) > 10:
+                        continue  # Skip large arrays
+                    if not all(
+                        isinstance(v, (int, float, str, bool, type(None)))
+                        for v in value
+                    ):
+                        continue
+
+                flat_key = f"{group_name}:{key}"
+
+                # If key already exists from another file, prefer the first
+                # (or we could merge, but that gets complicated)
+                if flat_key not in result:
+                    result[flat_key] = value
+
+    return result
+
+
+def add_namelist_item_extension(item: dict, ctx) -> dict:
+    """Inject namelist parameters from ALL components into a STAC item.
+
+    Reads ctx.namelists_by_component (populated by the scan layer); this
+    function performs no scanning and imports nothing from scan/.
+    """
+    by_component = getattr(ctx, "namelists_by_component", None) or {}
+    total_params = 0
+
+    for component_name, namelists in by_component.items():
+        for _filename, groups in namelists.items():
+            for group_name, values in groups.items():
+                for key, value in values.items():
+                    if value is None or isinstance(value, dict):
+                        continue
+                    if isinstance(value, list):
+                        if len(value) > 10:
+                            continue
+                        if not all(
+                            isinstance(v, (int, float, str, bool, type(None)))
+                            for v in value
+                        ):
+                            continue
+                    item["properties"][f"nml:{component_name}:{group_name}:{key}"] = value
+                    total_params += 1
+
+    if total_params > 0:
+        url = EXTENSION_URLS.get("namelist")
+        if url and url not in item.get("stac_extensions", []):
+            item.setdefault("stac_extensions", []).append(url)
+
+    return item
+
+
+def get_namelist_config_path(
+    experiment_path: Path,
+    component: str,
+) -> "Path | None":
+    """Determine the config directory for a component.
+
+    ESM-Tools convention: config/{component}/ contains namelists.
+
+    Args:
+        experiment_path: Path to experiment root (e.g., /exp/basic-001/).
+        component: Component name (e.g., "echam", "fesom").
+
+    Returns:
+        Path to config directory if it exists, None otherwise.
+    """
+    # Try standard ESM-Tools layout
+    config_path = experiment_path / "config" / component
+    if config_path.is_dir():
+        return config_path
+
+    # Try alternative layout (config at experiment root)
+    alt_path = experiment_path / component / "config"
+    if alt_path.is_dir():
+        return alt_path
+
+    return None

--- a/src/esm_catalog/stac/extensions/paleo.py
+++ b/src/esm_catalog/stac/extensions/paleo.py
@@ -1,0 +1,212 @@
+"""Paleoclimate STAC extension: geological time representation.
+
+Adds properties for paleoclimate simulations where model years represent
+geological time periods (e.g., Last Glacial Maximum at 20,000 years ago,
+Eocene at 50 million years ago).
+
+The paleo extension maps model datetime to geological years and provides
+human-readable formatting (e.g., "20.0 ka", "66.0 Ma").
+
+Properties added:
+    paleo:year          - Geological year (negative = BCE/past, e.g., -20000)
+    paleo:display       - Human-readable format (e.g., "20.0 ka", "66.0 Ma")
+    paleo:reference_year - Reference year for "years ago" calculation
+    paleo:epoch         - Optional geological epoch (e.g., "Pleistocene")
+    paleo:period        - Optional geological period (e.g., "Quaternary")
+
+Configuration:
+    The paleo offset can be specified in ESM-Tools config:
+
+        general:
+            paleo:
+                reference_year: -20000  # LGM
+                epoch: "Pleistocene"
+
+    Or passed directly to add_paleo_extension().
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+if TYPE_CHECKING:
+    pass
+
+
+def add_paleo_extension(
+    item: dict,
+    config: dict | None = None,
+    paleo_year: int | None = None,
+    reference_year: int = 2024,
+) -> dict:
+    """Inject paleoclimate extension fields into a STAC item.
+
+    The geological year can be determined in three ways (in priority order):
+    1. Explicit `paleo_year` parameter
+    2. ESM-Tools config `general.paleo.reference_year`
+    3. Derived from item datetime if year < 0 or year > 9999
+
+    Args:
+        item: STAC item dict to modify.
+        config: Optional ESM-Tools config dict.
+        paleo_year: Explicit geological year (overrides config).
+        reference_year: Reference year for "years ago" calculation.
+
+    Returns:
+        Modified item dict with paleo properties.
+    """
+    props = item["properties"]
+
+    # Determine the geological year for full paleo extension fields
+    geo_year = _resolve_paleo_year(item, config, paleo_year)
+
+    if geo_year is None:
+        # Not an explicitly configured paleoclimate simulation
+        return item
+
+    # Add full paleo properties
+    props["paleo:year"] = geo_year
+    props["paleo:display"] = _format_geological(geo_year, reference_year)
+    props["paleo:reference_year"] = reference_year
+
+    # Add epoch/period from config if available
+    paleo_config = _get_paleo_config(config)
+    if paleo_config:
+        if "epoch" in paleo_config:
+            props["paleo:epoch"] = paleo_config["epoch"]
+        if "period" in paleo_config:
+            props["paleo:period"] = paleo_config["period"]
+
+    # Register extension
+    url = EXTENSION_URLS.get("paleo")
+    if url and url not in item.get("stac_extensions", []):
+        item.setdefault("stac_extensions", []).append(url)
+
+    logger.debug(
+        "Added paleo extension: year={}, display={}",
+        geo_year,
+        props["paleo:display"],
+    )
+
+    return item
+
+
+def _resolve_paleo_year(
+    item: dict,
+    config: dict | None,
+    explicit_year: int | None,
+) -> int | None:
+    """Determine the geological year for an item.
+
+    Priority:
+    1. Explicit paleo_year parameter
+    2. Config general.paleo.reference_year
+    3. Item datetime if year is extreme (< 0 or > 9999)
+    """
+    # 1. Explicit parameter
+    if explicit_year is not None:
+        return explicit_year
+
+    # 2. Config-based
+    paleo_config = _get_paleo_config(config)
+    if paleo_config and "reference_year" in paleo_config:
+        return paleo_config["reference_year"]
+
+    # 3. From item datetime (only if extreme year)
+    props = item.get("properties", {})
+    dt_str = props.get("datetime") or props.get("start_datetime")
+    if dt_str:
+        try:
+            # Handle ISO format with potentially large/negative years
+            year = _parse_year_from_iso(dt_str)
+            if year is not None and (year < 0 or year > 9999):
+                return year
+        except Exception:
+            pass
+
+    return None
+
+
+def _get_paleo_config(config: dict | None) -> dict | None:
+    """Extract paleo configuration from ESM-Tools config."""
+    if not config:
+        return None
+    general = config.get("general", {})
+    return general.get("paleo")
+
+
+def _parse_year_from_iso(dt_str: str) -> int | None:
+    """Parse year from ISO datetime string, handling large/negative years.
+
+    Standard datetime.fromisoformat() doesn't handle years < 1 or > 9999.
+    """
+    if not dt_str:
+        return None
+
+    # Handle negative years: "-65000000-01-01T00:00:00"
+    if dt_str.startswith("-"):
+        parts = dt_str[1:].split("-", 1)
+        if parts:
+            try:
+                return -int(parts[0])
+            except ValueError:
+                pass
+    else:
+        parts = dt_str.split("-", 1)
+        if parts:
+            try:
+                return int(parts[0])
+            except ValueError:
+                pass
+
+    return None
+
+
+def _format_geological(year: int, reference_year: int = 2024) -> str:
+    """Format a geological year as human-readable string.
+
+    Uses Ma (millions of years ago) for dates > 1 million years ago,
+    ka (thousands of years ago) for dates > 10,000 years ago,
+    and CE/BCE for more recent dates.
+
+    Args:
+        year: Geological year (negative = past).
+        reference_year: Reference year for "years ago" calculation.
+
+    Returns:
+        Formatted string like "66.0 Ma", "20.0 ka", "500 BCE", "1492 CE".
+    """
+    years_ago = reference_year - year
+
+    if abs(years_ago) >= 1_000_000:
+        ma = years_ago / 1_000_000
+        return f"{ma:.1f} Ma"
+    elif abs(years_ago) >= 10_000:
+        ka = years_ago / 1_000
+        return f"{ka:.1f} ka"
+    elif year <= 0:
+        # BCE dates (astronomical year numbering: year 0 = 1 BCE)
+        bce_year = 1 - year
+        return f"{bce_year} BCE"
+    else:
+        return f"{year} CE"
+
+
+def detect_paleo_simulation(config: dict | None) -> bool:
+    """Check if an experiment is a paleoclimate simulation.
+
+    Looks for paleo configuration in the ESM-Tools config.
+
+    Args:
+        config: ESM-Tools config dict.
+
+    Returns:
+        True if this appears to be a paleoclimate simulation.
+    """
+    paleo_config = _get_paleo_config(config)
+    return paleo_config is not None and "reference_year" in paleo_config

--- a/src/esm_catalog/stac/extensions/registry.py
+++ b/src/esm_catalog/stac/extensions/registry.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+"""Extension URL registry — canonical schema URLs for all STAC extensions used."""
+
+EXTENSION_URLS: dict[str, str] = {
+    "datacube": "https://stac-extensions.github.io/datacube/v2.2.0/schema.json",
+    "cf": "https://stac-extensions.github.io/cf/v0.2.0/schema.json",
+    "file": "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+    "contacts": "https://stac-extensions.github.io/contacts/v0.1.1/schema.json",
+    "scientific": "https://stac-extensions.github.io/scientific/v1.0.0/schema.json",
+    # Custom ESM-Tools extensions — https://esm-tools.github.io/stac-extensions/
+    "hpc": "https://esm-tools.github.io/stac-extensions/hpc/v1.0.0/schema.json",
+    "paleo": "https://esm-tools.github.io/stac-extensions/paleo/v1.0.0/schema.json",
+    "namelist": "https://esm-tools.github.io/stac-extensions/namelist/v1.0.0/schema.json",
+}

--- a/src/esm_catalog/stac/item.py
+++ b/src/esm_catalog/stac/item.py
@@ -1,0 +1,255 @@
+"""Build a STAC Item dict from scan metadata and collection context."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import timezone
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING, Union
+
+from loguru import logger
+
+from esm_catalog.stac.extensions.contacts import add_contacts_extension
+from esm_catalog.stac.extensions.datacube import add_datacube_extension
+from esm_catalog.stac.extensions.hpc import add_hpc_extension
+from esm_catalog.stac.extensions.namelist import add_namelist_item_extension
+from esm_catalog.stac.extensions.paleo import add_paleo_extension
+from esm_catalog.stac.extensions.registry import EXTENSION_URLS
+
+if TYPE_CHECKING:
+    from upath import UPath
+
+
+def make_item(
+    path: "Union[Path, UPath, str]",
+    metadata: dict,
+    ctx,
+    config: dict | None = None,
+) -> dict:
+    """Construct a STAC Item dict.
+
+    Args:
+        path:     Path to the source file (local Path, UPath, or URI string).
+        metadata: Dict returned by scan_netcdf() or scan_grib().
+        ctx:      CollectionContext with experiment_id, component, collection_id.
+        config:   Optional ESM-Tools config dict (for contacts extension).
+
+    Returns:
+        A STAC-conformant Item dict (GeoJSON Feature).
+    """
+    # Handle different path types
+    if isinstance(path, str):
+        from esm_catalog.uri import parse_uri
+        path = parse_uri(path)
+
+    variable = metadata.get("variable", "unknown")
+    stream = metadata.get("stream")  # GRIB stream type (echam, accw, co2)
+    dt_str = metadata.get("datetime_str", "000000")
+    # For GRIB files, use stream type for item ID; otherwise use variable
+    id_prefix = stream if stream else variable
+    item_id = _make_id(id_prefix, ctx.component, dt_str, path)
+
+    dt_start = metadata.get("datetime_start")
+    dt_end = metadata.get("datetime_end")
+
+    if dt_start and dt_start.tzinfo is None:
+        dt_start = dt_start.replace(tzinfo=timezone.utc)
+    if dt_end and dt_end.tzinfo is None:
+        dt_end = dt_end.replace(tzinfo=timezone.utc)
+
+    # Single-time files: datetime = start; multi-time: use interval
+    if dt_start == dt_end or dt_end is None:
+        item_datetime = dt_start.isoformat() if dt_start else None
+        start_datetime = None
+        end_datetime = None
+    else:
+        item_datetime = None
+        start_datetime = dt_start.isoformat() if dt_start else None
+        end_datetime = dt_end.isoformat() if dt_end else None
+
+    # Build properties
+    properties: dict = {
+        "datetime": item_datetime,
+        "variable": variable,
+        "experiment": ctx.experiment_id,
+        "component": ctx.component,
+        "file:size": metadata.get("file_size"),  # STAC File extension
+        "format": metadata.get("format", "unknown"),
+        "keywords": [ctx.collection_id],  # Shows as badge in STAC Browser
+    }
+    if stream:
+        properties["stream"] = stream
+    if start_datetime:
+        properties["start_datetime"] = start_datetime
+    if end_datetime:
+        properties["end_datetime"] = end_datetime
+    if metadata.get("conventions"):
+        properties["conventions"] = metadata["conventions"]
+    if metadata.get("output_frequency"):
+        properties["output_frequency"] = metadata["output_frequency"]
+
+    # Include all global attributes from the file (model version, mesh, schemes, etc.)
+    # These become searchable via the queryables endpoint
+    global_attrs = metadata.get("global_attributes", {})
+    for key, value in global_attrs.items():
+        # Prefix with "file:" to avoid collisions with STAC standard properties
+        properties[f"file:{key}"] = value
+
+    # All variable names for multi-variable files (GRIB _echam/_accw/_co2).
+    # Stored as a JSON array so users can filter items by any contained variable,
+    # not just the primary one.  Excluded from single-variable NetCDF files where
+    # it would duplicate `variable`.
+    all_var_names = [
+        v["name"] for v in metadata.get("variables", [])
+        if v.get("name") and v["name"] != "unknown"
+    ]
+    if len(all_var_names) > 1:
+        properties["variables"] = all_var_names
+
+    # Determine asset media type
+    fmt = metadata.get("format", "")
+    if fmt == "grib":
+        media_type = "application/x-grib2"
+    else:
+        media_type = "application/x-netcdf"
+
+    item: dict = {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "stac_extensions": [EXTENSION_URLS["cf"], EXTENSION_URLS["file"]],
+        "id": item_id,
+        "geometry": metadata.get("geometry"),
+        "bbox": metadata.get("bbox"),
+        "properties": properties,
+        "assets": {
+            "data": {
+                "href": _to_href(path),
+                "type": media_type,
+                "title": _get_filename(path),
+                "roles": ["data"],
+            }
+        },
+        "links": [
+            {
+                "rel": "collection",
+                "href": f"#{ctx.collection_id}",
+                "type": "application/json",
+            }
+        ],
+        "collection": ctx.collection_id,
+    }
+
+    # Add CF parameters from scan metadata
+    cf_params = metadata.get("cf_parameters", [])
+    if cf_params:
+        item["properties"]["cf:parameter"] = cf_params
+
+    # Apply datacube extension
+    item = add_datacube_extension(item, metadata)
+
+    # Apply HPC storage extension (facility, storage tier, state)
+    item = add_hpc_extension(item, path)
+
+    # Apply paleo extension (geological time for paleoclimate simulations)
+    item = add_paleo_extension(item, config)
+
+    # Apply namelist extension (simulation parameters for combined queries)
+    item = add_namelist_item_extension(item, ctx)
+
+    # Apply contacts extension (optional, requires config)
+    item = add_contacts_extension(item, config)
+
+    # Derive experiment_type from start year and experiment name
+    item = _add_experiment_type(item, ctx.experiment_id)
+
+    return item
+
+
+def _make_id(
+    variable: str, component: str, dt_str: str, path: "Union[Path, UPath]"
+) -> str:
+    """Build a stable, unique item ID.
+
+    Format: {variable}.{component}.{datetime_str}[.{hash}]
+
+    The optional hash suffix deduplicates items that share the same
+    variable/component/datetime but differ in path (e.g. ensemble members).
+    """
+    base = f"{variable}.{component}.{dt_str}"
+    # Append short path hash only when needed for uniqueness
+    path_hash = hashlib.md5(str(path).encode()).hexdigest()[:6]
+    return f"{base}.{path_hash}"
+
+
+def _to_href(path: "Union[Path, UPath]") -> str:
+    """Convert path to a STAC-compatible href string.
+
+    For local files: file:///absolute/path/to/file.nc
+    For remote files: ssh://host/path/to/file.nc (preserves protocol)
+    """
+    if hasattr(path, "protocol") and path.protocol and path.protocol != "file":
+        # Remote path - reconstruct full URI with hostname
+        from esm_catalog.uri import to_uri
+        return to_uri(path)
+    else:
+        # Local path - resolve and convert to file:// URI
+        resolved = Path(path).resolve()
+        return f"file://{resolved}"
+
+
+def _get_filename(path: "Union[Path, UPath]") -> str:
+    """Get the filename from a path (works for both Path and UPath)."""
+    return PurePosixPath(str(path)).name
+
+
+def _add_experiment_type(item: dict, experiment_id: str) -> dict:
+    """Derive experiment_type and paleo:years_bp and add them to item properties.
+
+    This runs AFTER add_namelist_item_extension so nml:echam:runctl:dt_start
+    is available.  Both properties use the same start-year logic:
+
+    experiment_type classification:
+    - year < 1800  → "paleo"    (deep-time or pre-industrial paleo)
+    - 1800–1950    → "control"  (pre-industrial control / spinup)
+    - year > 1950  → "historical"
+
+    paleo:years_bp = 1950 - start_year  (years before present, present = 1950 CE)
+    Examples: 1850 → 100 BP, -21000 → 22950 BP, 1960 → -10 BP
+
+    Start year priority:
+    1. nml:echam:runctl:dt_start (most authoritative — experiment config)
+    2. Item start_datetime / datetime (GRIB/NetCDF time coordinate)
+    """
+    from esm_catalog.stac.extensions.paleo import _parse_year_from_iso
+
+    props = item["properties"]
+    start_year = None
+
+    # 1. From namelist dt_start (already added by add_namelist_item_extension)
+    dt_start_nml = props.get("nml:echam:runctl:dt_start")
+    if isinstance(dt_start_nml, list) and dt_start_nml:
+        try:
+            start_year = int(dt_start_nml[0])
+        except (TypeError, ValueError):
+            pass
+
+    # 2. Fallback: item datetime (set before namelist extension runs)
+    if start_year is None:
+        dt_str = props.get("start_datetime") or props.get("datetime")
+        if dt_str:
+            start_year = _parse_year_from_iso(dt_str)
+
+    # Classify experiment type and compute years BP
+    if start_year is not None:
+        if start_year < 1800:
+            exp_type = "paleo"
+        elif start_year <= 1950:
+            exp_type = "control"
+        else:
+            exp_type = "historical"
+        props["paleo:years_bp"] = 1950 - start_year
+    else:
+        exp_type = "control"
+
+    props["experiment_type"] = exp_type
+    return item

--- a/src/esm_catalog/uri.py
+++ b/src/esm_catalog/uri.py
@@ -1,0 +1,98 @@
+"""Neutral URI helpers shared by stac/ and scan/ (no internal esm_catalog deps).
+
+parse_uri / to_uri were previously in esm_catalog.scan.upath; they are pure
+path<->URI converters with no scanning responsibility, so they live here to
+keep the STAC model free of any dependency on the scan layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from upath import UPath
+
+
+def _get_upath() -> type:
+    """Import UPath lazily to avoid hard dependency."""
+    try:
+        from upath import UPath
+        return UPath
+    except ImportError:
+        raise ImportError(
+            "universal-pathlib is required for remote filesystem support.\n"
+            "Install with: pip install universal-pathlib fsspec paramiko"
+        )
+
+
+def parse_uri(uri: str, **storage_options) -> "UPath":
+    """Parse a URI string into a UPath object.
+
+    Supports both explicit protocols (ssh://host/path) and local paths (/path).
+
+    Args:
+        uri: URI string like "ssh://albedo0/work/user/exp" or "/local/path"
+        **storage_options: Protocol-specific options (e.g., username, key_filename)
+
+    Returns:
+        UPath object that can be used like pathlib.Path but works with any fsspec protocol.
+
+    Examples:
+        >>> path = parse_uri("ssh://albedo0/work/user/experiment")
+        >>> path = parse_uri("/local/path/to/data")
+        >>> path = parse_uri("s3://bucket/prefix", anon=True)
+    """
+    UPath = _get_upath()
+
+    # Handle local paths without protocol
+    if not _has_protocol(uri):
+        # It's a local path - use regular Path for efficiency
+        return UPath(Path(uri).resolve())
+
+    # Parse the URI
+    return UPath(uri, **storage_options)
+
+
+def _has_protocol(uri: str) -> bool:
+    """Check if a URI string has an explicit protocol."""
+    # Common protocols we support
+    protocols = ("ssh://", "sftp://", "scoutfs://", "s3://", "gs://",
+                 "file://", "http://", "https://", "ftp://",
+                 "simplecache://", "filecache://")
+    return any(uri.startswith(p) for p in protocols)
+
+
+def to_uri(path: "UPath | Path") -> str:
+    """Convert a UPath or Path to a URI string.
+
+    Args:
+        path: UPath or Path object
+
+    Returns:
+        URI string suitable for storage in STAC item href
+    """
+    if hasattr(path, "protocol") and path.protocol:
+        # UPath with explicit protocol - need to reconstruct full URI with host
+        # str(UPath) sometimes loses the hostname for SSH paths
+        protocol = path.protocol
+
+        # Try to get host from the path's filesystem
+        if hasattr(path, "fs") and hasattr(path.fs, "host"):
+            host = path.fs.host
+            # path.path gives the path portion without protocol
+            path_part = path.path if hasattr(path, "path") else str(path)
+            if host:
+                return f"{protocol}://{host}{path_part}"
+
+        # Fallback to str() representation
+        uri = str(path)
+        # Fix malformed URIs like ssh:///path (missing host)
+        if uri.startswith(f"{protocol}:///") and not uri.startswith(f"{protocol}://localhost"):
+            # Can't recover host here, just return as-is
+            pass
+        return uri
+    else:
+        # Local path - return as file:// URI for consistency
+        resolved = Path(path).resolve()
+        return f"file://{resolved}"

--- a/tests/test_esm_catalog/test_context.py
+++ b/tests/test_esm_catalog/test_context.py
@@ -1,0 +1,29 @@
+"""Unit tests for CollectionContext."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from esm_catalog.context import CollectionContext
+
+
+def test_context_minimal():
+    ctx = CollectionContext(
+        experiment_id="exp-alpha",
+        component="echam",
+        collection_id="exp-alpha",
+    )
+    assert ctx.experiment_id == "exp-alpha"
+    assert ctx.experiment_path is None
+    assert ctx.namelists_by_component == {}
+
+
+def test_context_carries_prescanned_namelists():
+    ctx = CollectionContext(
+        experiment_id="exp-alpha",
+        component="echam",
+        collection_id="exp-alpha",
+        experiment_path=Path("/exp/alpha"),
+        namelists_by_component={"echam": {"namelist.echam": {"runctl": {"dt": 450}}}},
+    )
+    assert ctx.namelists_by_component["echam"]["namelist.echam"]["runctl"]["dt"] == 450

--- a/tests/test_esm_catalog/test_hpc_detect.py
+++ b/tests/test_esm_catalog/test_hpc_detect.py
@@ -1,0 +1,114 @@
+"""detect_hpc_storage matches paths against configs/machines/*.yaml and
+configs/storage/*.yaml `storage:` entries, loaded via esm_parser."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from esm_catalog.hpc import detect
+
+
+@pytest.fixture
+def storage_config(tmp_path, monkeypatch):
+    """Point esm_parser.CONFIG_PATH at a throwaway configs/ tree."""
+    machines_dir = tmp_path / "machines"
+    storage_dir = tmp_path / "storage"
+    machines_dir.mkdir()
+    storage_dir.mkdir()
+
+    (machines_dir / "testmachine.yaml").write_text(
+        textwrap.dedent(
+            """\
+            storage:
+                testmachine-work:
+                    path_str: "/testmachine/"
+                    facility: "TESTFACILITY"
+                    system: "testmachine"
+                    storage_type: "lustre"
+                    state: "online"
+            """
+        )
+    )
+    (storage_dir / "hpss.yaml").write_text(
+        textwrap.dedent(
+            """\
+            storage:
+                hpss:
+                    path_str: "/arch/|/hpss/"
+                    storage_type: "hpss"
+                    state: "offline"
+                    recall_time_estimate: 300
+            """
+        )
+    )
+
+    monkeypatch.setattr(detect.esm_parser, "CONFIG_PATH", str(tmp_path))
+    detect._load_storage_entries.cache_clear()
+    yield
+    detect._load_storage_entries.cache_clear()
+
+
+def test_matches_machine_storage_entry(storage_config):
+    result = detect.detect_hpc_storage("/testmachine/work/exp/output.nc")
+    assert result == {
+        "hpc:facility": "TESTFACILITY",
+        "hpc:system": "testmachine",
+        "hpc:storage_type": "lustre",
+        "hpc:state": "online",
+    }
+
+
+@pytest.mark.parametrize("path", ["/arch/ab1234/output.nc", "/hpss/ab1234/output.nc"])
+def test_matches_generic_storage_entry_without_facility(storage_config, path):
+    result = detect.detect_hpc_storage(path)
+    assert result == {
+        "hpc:storage_type": "hpss",
+        "hpc:state": "offline",
+        "hpc:recall_time_estimate": 300,
+    }
+
+
+def test_falls_back_to_statvfs_when_no_entry_matches(storage_config, monkeypatch):
+    monkeypatch.setattr(
+        detect,
+        "_detect_from_statvfs",
+        lambda path: {"hpc:storage_type": "stub", "hpc:state": "online"},
+    )
+    result = detect.detect_hpc_storage("/unrelated/path/output.nc")
+    assert result == {"hpc:storage_type": "stub", "hpc:state": "online"}
+
+
+def test_real_albedo_config_matches():
+    result = detect.detect_hpc_storage("/albedo/work/projects/foo/output.nc")
+    assert result == {
+        "hpc:facility": "AWI",
+        "hpc:system": "albedo",
+        "hpc:storage_type": "lustre",
+        "hpc:state": "online",
+    }
+
+
+def test_real_levante_config_matches():
+    result = detect.detect_hpc_storage("/work/mh0033/m300000/output.nc")
+    assert result == {
+        "hpc:facility": "DKRZ",
+        "hpc:system": "levante",
+        "hpc:storage_type": "lustre",
+        "hpc:state": "online",
+    }
+
+
+def test_real_levante_config_excludes_levante_substring_in_path():
+    result = detect.detect_hpc_storage("/some/levante_home/work/output.nc")
+    assert result.get("hpc:system") != "levante"
+
+
+def test_real_hpss_config_matches():
+    result = detect.detect_hpc_storage("/arch/ab1234/experiment/output.nc")
+    assert result == {
+        "hpc:storage_type": "hpss",
+        "hpc:state": "offline",
+        "hpc:recall_time_estimate": 300,
+    }

--- a/tests/test_esm_catalog/test_hpc_detect.py
+++ b/tests/test_esm_catalog/test_hpc_detect.py
@@ -105,6 +105,22 @@ def test_real_levante_config_excludes_levante_substring_in_path():
     assert result.get("hpc:system") != "levante"
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/work/randomdir/output.nc",  # /work/ without a DKRZ project code
+        "/scratch/b/b12345/work/output.nc",  # /work/ nested under an unrelated tree
+    ],
+)
+def test_real_levante_config_does_not_shadow_generic_work_paths(path):
+    # Regression guard: a bare "/work/" match (the pre-refactor heuristic) would
+    # misclassify any non-DKRZ path containing "/work/" as Levante, and could
+    # shadow a later-loaded machine's own "/work/"-based pattern. The pattern
+    # must require the DKRZ project-code shape ("/work/<xx####>/").
+    result = detect.detect_hpc_storage(path)
+    assert result.get("hpc:system") != "levante"
+
+
 def test_real_hpss_config_matches():
     result = detect.detect_hpc_storage("/arch/ab1234/experiment/output.nc")
     assert result == {
@@ -112,3 +128,21 @@ def test_real_hpss_config_matches():
         "hpc:state": "offline",
         "hpc:recall_time_estimate": 300,
     }
+
+
+def test_remote_path_fallback():
+    class DummyRemotePath:
+        def __init__(self, path_str, protocol="s3"):
+            self.path = path_str
+            self.protocol = protocol
+
+    path = DummyRemotePath("/mybucket/exp/output.nc")
+    result = detect.detect_hpc_storage(path)
+    assert result == {"hpc:storage_type": "remote", "hpc:state": "online"}
+
+
+def test_statvfs_fallback_real(tmp_path):
+    # Runs the actual, unmocked statvfs check on a local path.
+    result = detect.detect_hpc_storage(tmp_path)
+    assert "hpc:storage_type" in result
+    assert result["hpc:state"] == "online"

--- a/tests/test_esm_catalog/test_no_scan_dependency.py
+++ b/tests/test_esm_catalog/test_no_scan_dependency.py
@@ -47,6 +47,14 @@ def test_stac_imports_without_scan(monkeypatch):
     import esm_catalog.stac.item
     import esm_catalog.stac.collection
     import esm_catalog.stac.extensions.namelist
+    import esm_catalog.stac.extensions.hpc
+    import esm_catalog.stac.extensions.contacts
+    import esm_catalog.stac.extensions.datacube
+    import esm_catalog.stac.extensions.paleo
     importlib.reload(esm_catalog.stac.item)
     importlib.reload(esm_catalog.stac.collection)
     importlib.reload(esm_catalog.stac.extensions.namelist)
+    importlib.reload(esm_catalog.stac.extensions.hpc)
+    importlib.reload(esm_catalog.stac.extensions.contacts)
+    importlib.reload(esm_catalog.stac.extensions.datacube)
+    importlib.reload(esm_catalog.stac.extensions.paleo)

--- a/tests/test_esm_catalog/test_no_scan_dependency.py
+++ b/tests/test_esm_catalog/test_no_scan_dependency.py
@@ -1,0 +1,52 @@
+"""Regression guard: the STAC model must not depend on the scan layer.
+
+If this fails, someone reintroduced a scan import into stac/ — breaking the
+ability to ship the STAC foundation as a standalone, reviewable unit.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+STAC_DIR = pathlib.Path(__file__).resolve().parent.parent / "stac"
+
+
+def _imports(py_file: pathlib.Path) -> set[str]:
+    tree = ast.parse(py_file.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+        elif isinstance(node, ast.Import):
+            names.update(a.name for a in node.names)
+    return names
+
+
+def test_stac_has_no_scan_imports():
+    offenders = {}
+    for py in STAC_DIR.rglob("*.py"):
+        bad = {m for m in _imports(py) if m.startswith("esm_catalog.scan")}
+        if bad:
+            offenders[str(py.relative_to(STAC_DIR))] = bad
+    assert not offenders, f"stac/ imports scan: {offenders}"
+
+
+def test_stac_imports_without_scan(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def blocked(name, *args, **kwargs):
+        if name.startswith("esm_catalog.scan"):
+            raise ImportError(f"scan import blocked: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", blocked)
+    import importlib
+    import esm_catalog.stac.item
+    import esm_catalog.stac.collection
+    import esm_catalog.stac.extensions.namelist
+    importlib.reload(esm_catalog.stac.item)
+    importlib.reload(esm_catalog.stac.collection)
+    importlib.reload(esm_catalog.stac.extensions.namelist)

--- a/tests/test_esm_catalog/test_stac_collection.py
+++ b/tests/test_esm_catalog/test_stac_collection.py
@@ -1,0 +1,35 @@
+"""make_collection is pure: accepts pre-scanned namelist data, never scans."""
+
+from __future__ import annotations
+
+from esm_catalog.context import CollectionContext
+from esm_catalog.stac.collection import make_collection, update_collection_extent
+
+
+def _ctx():
+    return CollectionContext(
+        experiment_id="exp-alpha", component="echam", collection_id="exp-alpha"
+    )
+
+
+def test_make_collection_minimal_skeleton():
+    col = make_collection(_ctx())
+    assert col["type"] == "Collection"
+    assert col["id"] == "exp-alpha"
+    assert col["components"] == ["echam"]
+    assert "nml:files" not in col  # no namelists passed -> none added
+
+
+def test_make_collection_applies_prescanned_namelists():
+    namelists = {"namelist.echam": {"runctl": {"delta_time": 450, "lcouple": True}}}
+    col = make_collection(_ctx(), namelists=namelists)
+    assert col["nml:files"] == ["namelist.echam"]
+    assert col["nml:parameters"]["runctl:delta_time"] == 450
+
+
+def test_update_collection_extent_expands_temporal():
+    col = make_collection(_ctx())
+    item = {"bbox": [0, 0, 1, 1],
+            "properties": {"datetime": "2000-01-01T00:00:00"}}
+    col = update_collection_extent(col, item)
+    assert col["extent"]["temporal"]["interval"][0][0] == "2000-01-01T00:00:00"

--- a/tests/test_esm_catalog/test_stac_item.py
+++ b/tests/test_esm_catalog/test_stac_item.py
@@ -1,0 +1,28 @@
+"""make_item builds a STAC Item from scan metadata + a CollectionContext."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from esm_catalog.context import CollectionContext
+from esm_catalog.stac.item import make_item
+
+
+def test_make_item_basic(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    ctx = CollectionContext(
+        experiment_id="exp-alpha", component="echam", collection_id="exp-alpha"
+    )
+    metadata = {
+        "variable": "temp",
+        "format": "netcdf",
+        "file_size": 1,
+        "datetime_start": datetime(2000, 1, 1, tzinfo=timezone.utc),
+        "datetime_end": datetime(2000, 1, 1, tzinfo=timezone.utc),
+    }
+    item = make_item(f, metadata, ctx)
+    assert item["type"] == "Feature"
+    assert item["properties"]["variable"] == "temp"
+    assert item["collection"] == "exp-alpha"
+    assert item["assets"]["data"]["href"].startswith("file://")

--- a/tests/test_esm_catalog/test_stac_namelist_ext.py
+++ b/tests/test_esm_catalog/test_stac_namelist_ext.py
@@ -1,0 +1,36 @@
+"""add_namelist_item_extension reads pre-scanned ctx data; it never scans."""
+
+from __future__ import annotations
+
+from esm_catalog.context import CollectionContext
+from esm_catalog.stac.extensions.namelist import (
+    add_namelist_extension,
+    add_namelist_item_extension,
+)
+
+
+def test_collection_extension_flattens_parameters():
+    col = {"type": "Collection", "id": "x", "stac_extensions": []}
+    col = add_namelist_extension(
+        col, {"namelist.echam": {"runctl": {"delta_time": 450, "lcouple": True}}}
+    )
+    assert col["nml:parameters"]["runctl:delta_time"] == 450
+    assert col["nml:parameters"]["runctl:lcouple"] is True
+
+
+def test_item_extension_uses_prescanned_context():
+    ctx = CollectionContext(
+        experiment_id="exp", component="echam", collection_id="exp",
+        namelists_by_component={
+            "echam": {"namelist.echam": {"runctl": {"co2vmr": 0.000284}}},
+        },
+    )
+    item = {"id": "i", "properties": {}, "stac_extensions": []}
+    item = add_namelist_item_extension(item, ctx)
+    assert item["properties"]["nml:echam:runctl:co2vmr"] == 0.000284
+
+
+def test_item_extension_noop_without_namelists():
+    ctx = CollectionContext(experiment_id="e", component="c", collection_id="e")
+    item = {"id": "i", "properties": {}, "stac_extensions": []}
+    assert add_namelist_item_extension(item, ctx) == item

--- a/tests/test_esm_catalog/test_uri.py
+++ b/tests/test_esm_catalog/test_uri.py
@@ -1,0 +1,19 @@
+"""Unit tests for the neutral URI helpers (no scan/ dependency)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from esm_catalog.uri import _has_protocol, to_uri
+
+
+def test_has_protocol_detects_remote_and_local():
+    assert _has_protocol("ssh://host/path") is True
+    assert _has_protocol("s3://bucket/key") is True
+    assert _has_protocol("/local/abs/path") is False
+
+
+def test_to_uri_local_path_is_file_uri(tmp_path):
+    f = tmp_path / "data.nc"
+    f.write_bytes(b"x")
+    assert to_uri(f) == f"file://{Path(f).resolve()}"


### PR DESCRIPTION
## PR-A1a — STAC data-model foundation (+ scan⇄stac cycle-break)


> **Provenance:** `hpc/`, the STAC extensions (`paleo`, `datacube`, `contacts`, `registry`, `hpc`), and `stac/item.py` are ported from Paul Gierz's `esm-tools-plus/simcat/pgierz-workbench` prototype branch; `context.py`/`uri.py` (breaking the `scan`⇔`stac` import cycle) are new for this decomposition.

Second slice of #1473's decomposition. Lands the STAC data model so it stands alone — reviewable and testable **without** the scan, storage, or api layers present.

> **Stacked on 1483 (`esm-catalog/pr-0-scaffold`).** Review that first; this PR's diff shows only the STAC foundation. Will be retargeted to `release` once PR-0 merges.

### What's here (+1,502 lines, 21 files)
- `stac/` — `collection.py`, `item.py`, and extensions (`datacube`, `contacts`, `hpc`, `paleo`, `namelist`, `registry`)
- `hpc/` — dependency leaf (storage-state detection)
- `uri.py` (new, neutral) — `parse_uri`/`to_uri`, moved out of `scan/upath.py`
- `context.py` (new, neutral) — `CollectionContext`, carrying pre-scanned `namelists_by_component`
- focused unit tests + a cycle-guard test

### The cycle-break (the point of this PR)
`stac/` previously reached into `scan/` through three lazy imports — a hidden dependency cycle that hurts reviewability/maintainability. This PR removes all of it:
- URI helpers → neutral `esm_catalog.uri`
- `CollectionContext` → neutral `esm_catalog.context`
- `make_collection` and `add_namelist_item_extension` are now **pure** — they receive pre-scanned namelist data instead of scanning. The scanning itself moves to the scan layer (next PR, A1b).

`tests/test_no_scan_dependency.py` keeps it broken: an AST test fails if any `stac/` file imports `esm_catalog.scan`, plus a runtime test that reloads the stac modules with scan imports blocked.

### Tests
15/15 pass (`pytest src/esm_catalog/tests`), Python 3.12.

### Context
Full plan: [decomposition design](https://github.com/esm-tools/esm_tools/blob/esm-tools-plus/simcat/collapsed-collections/docs/superpowers/specs/2026-06-13-esm-catalog-pr-decomposition-design.md). Follows: **PR-A1b** (scanners), which reintroduces the namelist scanning and `scan→stac` (one-directional) usage.

