### PR TITLE
feat(esm_catalog): PR-A3 — shard federation (merge_shards)

### DIFF
--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -47,5 +47,31 @@ def scan(path: str, output: str | None, db: str | None) -> None:
         click.echo(json.dumps(catalog, indent=2, default=str))
 
 
+@main.command()
+@click.argument("shards", nargs=-1, required=True, type=click.Path(exists=True))
+@click.option("--output", "-o", required=True, type=click.Path(),
+              help="Path to the global catalog .duckdb file (created if absent).")
+def merge(shards: tuple[str, ...], output: str) -> None:
+    """Merge per-experiment shard .duckdb files into a single global catalog.
+
+    Each SHARD is a .duckdb file produced by 'esm-catalog scan --db'.
+    Rows are upserted by ID so the command is safe to re-run.
+
+    Example::
+
+        esm-catalog merge exp-alpha/catalog.duckdb exp-beta/catalog.duckdb \\
+            --output global.duckdb
+    """
+    from pathlib import Path as _Path
+
+    from esm_catalog.storage.federation import merge_shards
+
+    n_cols, n_items = merge_shards(list(shards), _Path(output))
+    click.echo(
+        f"Merged {len(shards)} shard(s) into {output}: "
+        f"{n_cols} new collections, {n_items} new items."
+    )
+
+
 if __name__ == "__main__":
     main()

--- a/src/esm_catalog/storage/federation.py
+++ b/src/esm_catalog/storage/federation.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+"""Merge multiple per-experiment DuckDB shards into a single global catalog."""
+
+from pathlib import Path
+
+from loguru import logger
+
+from esm_catalog.storage.duckdb import CatalogDB
+
+
+def merge_shards(
+    shard_paths: list[Path | str],
+    output_path: Path | str,
+) -> tuple[int, int]:
+    """Merge per-experiment shard .duckdb files into a single global catalog.
+
+    Uses DuckDB ATTACH to read each shard and INSERT OR REPLACE all rows
+    into the output database.  The output file is created if it does not
+    exist; existing rows are updated (upserted) on ID conflict so the
+    command is safe to re-run as shards are refreshed.
+
+    Args:
+        shard_paths: Ordered list of paths to source .duckdb shard files.
+        output_path: Path to the global catalog .duckdb file (created if absent).
+
+    Returns:
+        (n_collections, n_items) — total rows merged across all shards.
+    """
+    output_path = Path(output_path).resolve()
+    n_collections = 0
+    n_items = 0
+
+    with CatalogDB(output_path) as global_db:
+        for shard_path in shard_paths:
+            shard_path = Path(shard_path).resolve()
+            if not shard_path.exists():
+                logger.warning("Shard not found, skipping: {}", shard_path)
+                continue
+
+            logger.info("Merging shard: {}", shard_path)
+            # Use a temporary alias; no two ATTACHed DBs can share a name.
+            alias = f"_shard_{abs(hash(str(shard_path)))}"
+            try:
+                global_db.db.execute(
+                    f"ATTACH '{shard_path}' AS {alias} (READ_ONLY)"
+                )
+
+                # collections: INSERT OR REPLACE on primary key (id)
+                before_cols = global_db.db.execute(
+                    "SELECT COUNT(*) FROM collections"
+                ).fetchone()[0]
+                global_db.db.execute(f"""
+                    INSERT OR REPLACE INTO collections (id, data)
+                    SELECT id, data FROM {alias}.collections
+                """)
+                after_cols = global_db.db.execute(
+                    "SELECT COUNT(*) FROM collections"
+                ).fetchone()[0]
+                merged_cols = after_cols - before_cols
+
+                # items: INSERT OR REPLACE on primary key (id)
+                before_items = global_db.db.execute(
+                    "SELECT COUNT(*) FROM items"
+                ).fetchone()[0]
+                global_db.db.execute(f"""
+                    INSERT OR REPLACE INTO items
+                        (id, collection, experiment, datetime, bbox, data)
+                    SELECT id, collection, experiment, datetime, bbox, data
+                    FROM {alias}.items
+                """)
+                after_items = global_db.db.execute(
+                    "SELECT COUNT(*) FROM items"
+                ).fetchone()[0]
+                merged_items = after_items - before_items
+
+                # collection_item_props: INSERT OR IGNORE (three-col PK)
+                global_db.db.execute(f"""
+                    INSERT OR IGNORE INTO collection_item_props
+                        (collection_id, property, value)
+                    SELECT collection_id, property, value
+                    FROM {alias}.collection_item_props
+                """)
+
+                logger.info(
+                    "  {} new collections, {} new items from {}",
+                    merged_cols, merged_items, shard_path.name,
+                )
+                n_collections += merged_cols
+                n_items += merged_items
+            finally:
+                try:
+                    global_db.db.execute(f"DETACH {alias}")
+                except Exception:
+                    pass
+
+    return n_collections, n_items

--- a/tests/test_esm_catalog/test_federation.py
+++ b/tests/test_esm_catalog/test_federation.py
@@ -1,0 +1,196 @@
+"""Tests for merge_shards() and 'esm-catalog merge' CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from esm_catalog.cli import main
+from esm_catalog.storage.duckdb import CatalogDB, persist_tree
+from esm_catalog.storage.federation import merge_shards
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _col(col_id: str, experiment: str) -> dict:
+    return {
+        "type": "Collection",
+        "id": col_id,
+        "stac_version": "1.0.0",
+        "description": f"Test {col_id}",
+        "title": col_id,
+        "experiment": experiment,
+        "links": [],
+        "extent": {
+            "spatial": {"bbox": [[-180.0, -90.0, 180.0, 90.0]]},
+            "temporal": {"interval": [[None, None]]},
+        },
+        "license": "proprietary",
+        "components": ["echam"],
+    }
+
+
+def _item(item_id: str, col_id: str, experiment: str, variable: str = "tas") -> dict:
+    return {
+        "type": "Feature",
+        "stac_version": "1.0.0",
+        "id": item_id,
+        "collection": col_id,
+        "bbox": [-180.0, -90.0, 180.0, 90.0],
+        "geometry": None,
+        "properties": {
+            "datetime": "2000-01-01T00:00:00Z",
+            "experiment": experiment,
+            "component": "echam",
+            "variable": variable,
+            "format": "netcdf",
+        },
+        "assets": {},
+        "links": [],
+    }
+
+
+def _make_shard(path: Path, col_id: str, experiment: str, item_ids: list[str]) -> Path:
+    catalog = {
+        "collections": [_col(col_id, experiment)],
+        "items": [_item(iid, col_id, experiment) for iid in item_ids],
+    }
+    persist_tree(catalog, path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# merge_shards()
+# ---------------------------------------------------------------------------
+
+def test_merge_two_shards(tmp_path):
+    shard_a = _make_shard(tmp_path / "a.duckdb", "exp-alpha-echam", "exp-alpha",
+                          ["item-a1", "item-a2"])
+    shard_b = _make_shard(tmp_path / "b.duckdb", "exp-beta-echam", "exp-beta",
+                          ["item-b1"])
+    global_db = tmp_path / "global.duckdb"
+
+    n_cols, n_items = merge_shards([shard_a, shard_b], global_db)
+
+    assert n_cols == 2
+    assert n_items == 3
+
+    with CatalogDB(global_db) as db:
+        _, total_items = db.search_items()
+        assert total_items == 3
+        _, total_cols = db.search_collections()
+        assert total_cols == 2
+
+        # Both experiments are queryable in the global DB
+        items_a, _ = db.search_items({"experiment": "exp-alpha"})
+        assert len(items_a) == 2
+        items_b, _ = db.search_items({"experiment": "exp-beta"})
+        assert len(items_b) == 1
+
+
+def test_merge_is_idempotent(tmp_path):
+    """Merging the same shard twice must not create duplicate rows."""
+    shard = _make_shard(tmp_path / "shard.duckdb", "exp-alpha-echam", "exp-alpha",
+                        ["item-1", "item-2"])
+    global_db = tmp_path / "global.duckdb"
+
+    merge_shards([shard], global_db)
+    merge_shards([shard], global_db)  # second merge
+
+    with CatalogDB(global_db) as db:
+        _, total = db.search_items()
+        assert total == 2  # still 2, not 4
+
+
+def test_merge_into_existing_global(tmp_path):
+    """Merging a shard into a non-empty global DB preserves existing data."""
+    shard_a = _make_shard(tmp_path / "a.duckdb", "exp-alpha-echam", "exp-alpha",
+                          ["item-a1"])
+    shard_b = _make_shard(tmp_path / "b.duckdb", "exp-beta-echam", "exp-beta",
+                          ["item-b1"])
+    global_db = tmp_path / "global.duckdb"
+
+    # First merge
+    merge_shards([shard_a], global_db)
+    # Second merge adds to existing global
+    merge_shards([shard_b], global_db)
+
+    with CatalogDB(global_db) as db:
+        _, total = db.search_items()
+        assert total == 2
+        _, col_total = db.search_collections()
+        assert col_total == 2
+
+
+def test_merge_skips_missing_shard(tmp_path):
+    """A missing shard path is skipped with a warning; other shards still merge."""
+    shard_a = _make_shard(tmp_path / "a.duckdb", "exp-alpha-echam", "exp-alpha",
+                          ["item-a1"])
+    missing = tmp_path / "does_not_exist.duckdb"
+    global_db = tmp_path / "global.duckdb"
+
+    n_cols, n_items = merge_shards([shard_a, missing], global_db)
+
+    assert n_cols == 1
+    assert n_items == 1
+
+
+def test_merge_collection_item_props_indexed(tmp_path):
+    """collection_item_props are transferred so the global DB supports property search."""
+    shard = tmp_path / "shard.duckdb"
+    col = _col("exp-alpha-echam", "exp-alpha")
+    item = _item("item-1", "exp-alpha-echam", "exp-alpha", variable="ssh")
+
+    with CatalogDB(shard) as db:
+        db.insert_collection(col)
+        db.insert_item(item)
+        db.upsert_collection_item_props("exp-alpha-echam", item)
+
+    global_db = tmp_path / "global.duckdb"
+    merge_shards([shard], global_db)
+
+    with CatalogDB(global_db) as db:
+        props = db.get_collection_item_props("exp-alpha-echam")
+        assert "ssh" in props.get("variable", set())
+
+
+# ---------------------------------------------------------------------------
+# CLI: 'esm-catalog merge'
+# ---------------------------------------------------------------------------
+
+def test_cli_merge(tmp_path):
+    shard_a = _make_shard(tmp_path / "a.duckdb", "exp-alpha-echam", "exp-alpha",
+                          ["item-a1", "item-a2"])
+    shard_b = _make_shard(tmp_path / "b.duckdb", "exp-beta-echam", "exp-beta",
+                          ["item-b1"])
+    global_db = tmp_path / "global.duckdb"
+
+    result = CliRunner().invoke(
+        main,
+        ["merge", str(shard_a), str(shard_b), "--output", str(global_db)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert global_db.exists()
+    assert "2 shard(s)" in result.output
+
+    with CatalogDB(global_db) as db:
+        _, total = db.search_items()
+        assert total == 3
+
+
+def test_cli_merge_idempotent(tmp_path):
+    shard = _make_shard(tmp_path / "shard.duckdb", "exp-alpha-echam", "exp-alpha",
+                        ["item-1"])
+    global_db = tmp_path / "global.duckdb"
+    runner = CliRunner()
+
+    runner.invoke(main, ["merge", str(shard), "--output", str(global_db)])
+    runner.invoke(main, ["merge", str(shard), "--output", str(global_db)])
+
+    with CatalogDB(global_db) as db:
+        _, total = db.search_items()
+        assert total == 1


### PR DESCRIPTION
## Summary

- Adds `storage/federation.py`: `merge_shards(shard_paths, output_path)` — uses DuckDB `ATTACH` to copy `collections`, `items`, and `collection_item_props` rows from any number of per-experiment `.duckdb` shards into a single global catalog file. Rows are upserted (INSERT OR REPLACE / INSERT OR IGNORE) so the command is safe to re-run as shards are refreshed. Missing paths are skipped with a warning.
- Adds `esm-catalog merge <shard>... --output <global.duckdb>` CLI subcommand.
- 7 new tests: two-shard merge, idempotency (no duplicates on re-merge), incremental merge into a non-empty global, missing-shard tolerance, property index propagation, and CLI end-to-end.

This is Miguel's third unit — "sync shard to global DB". Together with A1b-1/A1b-2 (scan) and A2 (shard), the full ingest pipeline is now:

```
esm-catalog scan <exp-dir> --db exp-alpha/catalog.duckdb
esm-catalog scan <exp-dir> --db exp-beta/catalog.duckdb
esm-catalog merge exp-alpha/catalog.duckdb exp-beta/catalog.duckdb --output global.duckdb
```

## Test plan

- [x] `pytest src/esm_catalog/tests/test_federation.py -v` — 7 tests pass locally
- [x] Full suite `pytest src/esm_catalog/tests` — 62 tests, 0 failures
- [ ] CI green on Python 3.9 + 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)