### PR TITLE
feat(esm_catalog): PR-B2 — queryables endpoints (OGC CQL2 filter schema)

### DIFF
--- a/src/esm_catalog/api/app.py
+++ b/src/esm_catalog/api/app.py
@@ -34,13 +34,14 @@ from stac_fastapi.types.config import ApiSettings
 from starlette.middleware import Middleware
 from starlette.requests import Request
 
-from esm_catalog.api.cache import CollectionCache
+from esm_catalog.api.cache import CollectionCache, QueryablesCache
 from esm_catalog.api.client import (
     DuckDBCatalogClient,
     FilteredSearchPostRequest,
     ItemCollectionUriWithToken,
 )
 from esm_catalog.api.pool import CatalogPool
+from esm_catalog.api.queryables import get_collection_queryables, get_queryables
 from esm_catalog.api.registry import CatalogRegistry
 
 _DEFAULT_TITLE = "ESM-Tools STAC Catalog"
@@ -86,6 +87,7 @@ def create_app(
     )
     pool = CatalogPool()
     collection_cache = CollectionCache(ttl_seconds=300)
+    queryables_cache = QueryablesCache(ttl_seconds=300)
 
     settings = ApiSettings(
         stac_fastapi_title=title,
@@ -133,6 +135,42 @@ def create_app(
     @api.app.post("/format", response_model=None, include_in_schema=False)
     async def cql2_format(request: Request):
         return {}
+
+    @api.app.get(
+        "/queryables",
+        response_model=None,
+        include_in_schema=True,
+        summary="Queryable properties for CQL2 filtering",
+        tags=["STAC API - Filter Extension"],
+    )
+    def queryables(request: Request):
+        return queryables_cache.get_or_compute(
+            "global",
+            lambda: get_queryables(request, registry.get_paths(), pool),
+        )
+
+    @api.app.get(
+        "/collections/{collection_id}/queryables",
+        response_model=None,
+        include_in_schema=True,
+        summary="Queryable properties for a specific collection",
+        tags=["STAC API - Filter Extension"],
+    )
+    def collection_queryables(collection_id: str, request: Request):
+        result = queryables_cache.get_or_compute(
+            f"collection:{collection_id}",
+            lambda: get_collection_queryables(
+                request, collection_id, registry.get_paths(), pool
+            ),
+        )
+        if result is None:
+            from fastapi import HTTPException
+
+            raise HTTPException(
+                status_code=404,
+                detail=f"Collection '{collection_id}' not found",
+            )
+        return result
 
     @api.app.get(
         "/health",

--- a/src/esm_catalog/api/queryables.py
+++ b/src/esm_catalog/api/queryables.py
@@ -1,0 +1,918 @@
+"""OGC API - Features Part 3 Queryables endpoint.
+
+Provides the /queryables endpoint required for STAC Browser's CQL2 filter
+builder. Property enums are populated from live catalog data via DISTINCT
+queries on the items and collections tables.
+
+This module uses a FULLY DYNAMIC approach:
+1. Discover all property keys present in the items table
+2. For each property, query distinct values
+3. Build JSON Schema with appropriate types and enums
+
+No properties are hardcoded - everything is discovered from the database.
+This means any metadata stored in STAC items (NetCDF global attributes,
+namelist parameters, HPC info, paleo data, etc.) automatically becomes
+queryable without code changes.
+
+Example response::
+
+    {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": "http://localhost:8000/queryables",
+        "type": "object",
+        "title": "Queryable properties for ESM-Tools STAC Catalog",
+        "properties": {
+            "datetime": {"title": "Datetime", "type": "string", "format": "date-time"},
+            "collection": {"title": "Collection", "type": "string", "enum": [...]},
+            "file:FESOM_model": {"title": "FESOM_model", "type": "string", "enum": ["FESOM2"]},
+            ...
+        }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from loguru import logger
+
+from esm_catalog.api.validation import is_safe_property_name
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+    from esm_catalog.api.pool import CatalogPool
+    from esm_catalog.storage.duckdb import CatalogDB
+
+
+class QueryablesError(Exception):
+    """Error during queryables computation."""
+
+    pass
+
+
+# Special properties that need custom schema (not auto-discovered)
+_SPECIAL_PROPERTIES: dict[str, dict] = {
+    "datetime": {
+        "title": "Datetime",
+        "type": "string",
+        "format": "date-time",
+    },
+}
+
+# Collection-level properties to expose as queryables (for collection search).
+# "model" was removed in Option A (collapsed collections): model components are
+# now stored as "components" (list) on the collection and as "component" on each
+# item, where they are auto-discovered by the item-property discovery loop.
+_COLLECTION_PROPERTIES: list[str] = [
+    "experiment",  # Experiment ID
+]
+
+# Properties to exclude from auto-discovery (too complex or not useful for filtering)
+_EXCLUDED_PROPERTIES: frozenset[str] = frozenset({
+    "cube:dimensions",
+    "cube:variables",
+    "cf:parameter",
+    "start_datetime",
+    "end_datetime",
+})
+
+# Maximum number of enum values to include (avoid huge dropdowns)
+_MAX_ENUM_VALUES = 100
+
+# Properties individually indexed in collection_item_props as strings.
+# For these, fetch from the index (not from the raw JSON array value)
+# so the browser gets a usable string enum rather than an unusable array type.
+# These bypass _MAX_ENUM_VALUES since they are known-categorical (bounded sets).
+_INDEX_AS_STRING: frozenset = frozenset({"variables"})
+
+# Maximum number of properties to discover (performance limit)
+_MAX_PROPERTIES = 200
+
+# GHG (greenhouse gas) parameters with unit conversion support
+# Maps parameter name patterns to their unit information
+# canonical_unit: the unit values are stored in (decimal = volume mixing ratio)
+# supported_units: units users can search with, with conversion factors to canonical
+_GHG_PARAMETERS: dict[str, dict] = {
+    "co2vmr": {
+        "title": "CO2 Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,        # No conversion
+            "ppm": 1e-6,           # Parts per million
+            "ppb": 1e-9,           # Parts per billion
+        },
+        "default_display_unit": "ppm",
+    },
+    "ch4vmr": {
+        "title": "CH4 Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,
+            "ppm": 1e-6,
+            "ppb": 1e-9,
+        },
+        "default_display_unit": "ppb",  # CH4 typically in ppb
+    },
+    "n2ovmr": {
+        "title": "N2O Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,
+            "ppm": 1e-6,
+            "ppb": 1e-9,
+        },
+        "default_display_unit": "ppb",  # N2O typically in ppb
+    },
+    # Add more GHG parameters as needed
+    "co2": {
+        "title": "CO2 Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,
+            "ppm": 1e-6,
+            "ppb": 1e-9,
+        },
+        "default_display_unit": "ppm",
+    },
+    "ch4": {
+        "title": "CH4 Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,
+            "ppm": 1e-6,
+            "ppb": 1e-9,
+        },
+        "default_display_unit": "ppb",
+    },
+    "n2o": {
+        "title": "N2O Concentration",
+        "canonical_unit": "decimal",
+        "supported_units": {
+            "decimal": 1.0,
+            "ppm": 1e-6,
+            "ppb": 1e-9,
+        },
+        "default_display_unit": "ppb",
+    },
+}
+
+
+def get_ghg_info(param_name: str) -> dict | None:
+    """Get GHG info for a parameter name.
+
+    Checks if the last part of the property name (after the last colon or dot)
+    matches a known GHG parameter.
+
+    Args:
+        param_name: Full property name (e.g., "nml:radctl.co2vmr")
+
+    Returns:
+        GHG info dict if matched, None otherwise.
+    """
+    import re as _re
+    # Split on both ":" and "." to handle both old and new formats
+    parts = _re.split(r"[.:]", param_name)
+    key = parts[-1].lower()
+
+    return _GHG_PARAMETERS.get(key)
+
+
+def convert_ghg_value(value: float, from_unit: str, param_name: str) -> float:
+    """Convert a GHG value from user unit to canonical (decimal) unit.
+
+    Args:
+        value: The numeric value to convert.
+        from_unit: The unit the value is in ("ppm", "ppb", or "decimal").
+        param_name: The parameter name (to look up conversion info).
+
+    Returns:
+        Value converted to canonical decimal unit.
+    """
+    ghg_info = get_ghg_info(param_name)
+    if ghg_info is None:
+        return value  # Not a GHG parameter, no conversion
+
+    factor = ghg_info["supported_units"].get(from_unit.lower(), 1.0)
+    return value * factor
+
+
+def _sort_paleo_display(display: str) -> float:
+    """Sort key for paleo display strings (oldest first).
+
+    Converts "66.0 Ma", "21.0 ka", "500 BCE", "1850 CE" to comparable floats.
+    """
+    display = display.strip()
+
+    ma_match = re.match(r"([\d.]+)\s*Ma", display, re.IGNORECASE)
+    if ma_match:
+        return -float(ma_match.group(1)) * 1_000_000
+
+    ka_match = re.match(r"([\d.]+)\s*ka", display, re.IGNORECASE)
+    if ka_match:
+        return -float(ka_match.group(1)) * 1_000
+
+    bce_match = re.match(r"(\d+)\s*BCE", display, re.IGNORECASE)
+    if bce_match:
+        return -int(bce_match.group(1))
+
+    ce_match = re.match(r"(\d+)\s*CE", display, re.IGNORECASE)
+    if ce_match:
+        return int(ce_match.group(1))
+
+    return 0
+
+
+def _discover_property_keys(db: "CatalogDB") -> set[str]:
+    """Discover all unique property keys from items table.
+
+    Only returns property names that pass validation (safe for SQL queries).
+    Samples a subset of items to avoid expensive full-table scans.
+    """
+    try:
+        # Get all top-level keys from properties JSON
+        # DuckDB's json_keys returns a list directly, not a JSON string
+        # Use USING SAMPLE to avoid scanning entire table on large catalogs
+        rows = db.db.execute("""
+            SELECT DISTINCT keys FROM (
+                SELECT json_keys(json_extract(data, '$.properties')) AS keys
+                FROM items
+                USING SAMPLE 500
+            ) WHERE keys IS NOT NULL
+        """).fetchall()
+
+        all_keys: set[str] = set()
+        for row in rows:
+            keys = row[0]
+            if keys:
+                # DuckDB returns this as a Python list already
+                if isinstance(keys, list):
+                    all_keys.update(keys)
+                elif isinstance(keys, str):
+                    # Fallback: try parsing as JSON
+                    try:
+                        parsed = json.loads(keys)
+                        if isinstance(parsed, list):
+                            all_keys.update(parsed)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+
+        # Filter to only safe property names (security: prevents SQL injection)
+        safe_keys = {k for k in all_keys if is_safe_property_name(k)}
+        if len(safe_keys) < len(all_keys):
+            logger.debug(
+                "Filtered {} unsafe property names from queryables",
+                len(all_keys) - len(safe_keys),
+            )
+        return safe_keys
+    except Exception as e:
+        logger.warning("Failed to discover property keys: {}", e)
+        return set()
+
+
+def _get_distinct_values(db: "CatalogDB", prop_name: str, limit: int = 100) -> list:
+    """Get distinct values for a property from items table.
+
+    Returns list of values with their native Python types.
+    """
+    # Validate property name before SQL interpolation (security)
+    if not is_safe_property_name(prop_name):
+        logger.warning(
+            "Skipping property with invalid name for SQL: {!r}", prop_name
+        )
+        return []
+
+    try:
+        # Property name is validated, safe for interpolation
+        # Double-quote the property name to handle any special JSON path chars
+        # Use subquery with SAMPLE to avoid expensive full-table scans
+        rows = db.db.execute(f"""
+            SELECT DISTINCT v FROM (
+                SELECT json_extract(data, '$.properties."{prop_name}"') AS v
+                FROM items
+                USING SAMPLE 1000
+            )
+            WHERE v IS NOT NULL
+            ORDER BY v
+            LIMIT {limit + 1}
+        """).fetchall()
+
+        values = []
+        for row in rows:
+            if row[0] is not None:
+                raw = row[0]
+                # json_extract returns JSON-encoded string, parse it
+                if isinstance(raw, str):
+                    try:
+                        val = json.loads(raw)
+                        values.append(val)
+                    except (json.JSONDecodeError, TypeError):
+                        # Not valid JSON, use as-is
+                        values.append(raw)
+                else:
+                    # Already a Python type
+                    values.append(raw)
+        return values
+    except Exception as e:
+        logger.debug("Failed to get values for {}: {}", prop_name, e)
+        return []
+
+
+def _get_indexed_values(db: "CatalogDB", prop_name: str) -> list[str]:
+    """Get distinct values for a property from the collection_item_props index.
+
+    Used for array-valued item properties (e.g. ``variables``) that are
+    individually indexed as string rows rather than stored as a list.
+    Returns each unique indexed value as a plain string.
+    """
+    if not is_safe_property_name(prop_name):
+        return []
+    try:
+        rows = db.db.execute(
+            "SELECT DISTINCT value FROM collection_item_props WHERE property = ? ORDER BY value",
+            [prop_name],
+        ).fetchall()
+        return [r[0] for r in rows if r[0]]
+    except Exception as e:
+        logger.debug("Failed to get indexed values for {}: {}", prop_name, e)
+        return []
+
+
+def _get_collection_distinct_values(db: "CatalogDB") -> list[str]:
+    """Get distinct collection IDs."""
+    try:
+        rows = db.db.execute("""
+            SELECT DISTINCT json_extract_string(data, '$.collection') AS v
+            FROM items
+            WHERE v IS NOT NULL
+            ORDER BY v
+            LIMIT 1000
+        """).fetchall()
+        return [r[0] for r in rows if r[0]]
+    except Exception as e:
+        logger.debug("Failed to get collection values: {}", e)
+        return []
+
+
+def _infer_json_schema_type(values: list) -> tuple[str, list | None]:
+    """Infer JSON Schema type and optional enum from sample values.
+
+    Returns (type, enum_or_none).
+    """
+    if not values:
+        return "string", None
+
+    # Check types
+    types = set(type(v).__name__ for v in values)
+
+    if types == {"bool"}:
+        return "boolean", None
+    if types <= {"int", "float"}:
+        if all(isinstance(v, int) for v in values):
+            return "integer", None
+        return "number", None
+    if types == {"list"}:
+        return "array", None
+    if types == {"dict"}:
+        return "object", None
+
+    # Default to string
+    str_values = [str(v) for v in values]
+
+    # Return enum if few enough unique values
+    if len(str_values) <= _MAX_ENUM_VALUES:
+        return "string", str_values
+
+    return "string", None
+
+
+def _make_title(prop_name: str) -> str:
+    """Generate human-readable title from property name."""
+    # Remove common prefixes
+    name = prop_name
+    for prefix in ("file:", "hpc:", "paleo:", "nml:"):
+        if name.startswith(prefix):
+            name = name[len(prefix):]
+            break
+
+    # Replace dot sub-separator (used in nml: keys) with space for readability
+    name = name.replace(".", " ")
+    # Convert FESOM_model -> FESOM model, etc.
+    name = name.replace("_", " ")
+
+    # Capitalize first letter
+    if name:
+        name = name[0].upper() + name[1:]
+
+    return name
+
+
+def _discover_namelist_groups(db: "CatalogDB") -> set[str]:
+    """Discover namelist groups from collections."""
+    try:
+        rows = db.db.execute("""
+            SELECT json_extract_string(data, '$."nml:groups"') AS v
+            FROM collections WHERE v IS NOT NULL
+        """).fetchall()
+        groups: set[str] = set()
+        for row in rows:
+            if row[0]:
+                try:
+                    arr = json.loads(row[0])
+                    if isinstance(arr, list):
+                        groups.update(arr)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return groups
+    except Exception as e:
+        logger.debug("Failed to discover namelist groups: {}", e)
+        return set()
+
+
+def _discover_namelist_parameters(db: "CatalogDB") -> dict[str, set]:
+    """Discover namelist parameters and their values from collections."""
+    try:
+        rows = db.db.execute("""
+            SELECT json_extract_string(data, '$."nml:parameters"') AS v
+            FROM collections WHERE v IS NOT NULL
+        """).fetchall()
+
+        params: dict[str, set] = {}
+        for row in rows:
+            if row[0]:
+                try:
+                    obj = json.loads(row[0])
+                    if isinstance(obj, dict):
+                        for key, value in obj.items():
+                            if key not in params:
+                                params[key] = set()
+                            if isinstance(value, (str, int, float, bool)):
+                                params[key].add(value)
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        return params
+    except Exception as e:
+        logger.debug("Failed to discover namelist parameters: {}", e)
+        return {}
+
+
+def _discover_collection_properties(db: "CatalogDB") -> dict[str, set]:
+    """Discover collection-level properties (model, experiment, etc.)."""
+    props: dict[str, set] = {}
+    for prop in _COLLECTION_PROPERTIES:
+        try:
+            rows = db.db.execute(f"""
+                SELECT DISTINCT json_extract_string(data, '$."{prop}"') AS v
+                FROM collections WHERE v IS NOT NULL
+                ORDER BY v
+                LIMIT 100
+            """).fetchall()
+            values = {r[0] for r in rows if r[0]}
+            if values:
+                props[prop] = values
+        except Exception as e:
+            logger.debug("Failed to discover collection property {}: {}", prop, e)
+    return props
+
+
+def get_queryables(
+    request: "Request",
+    catalog_paths: list[str | Path],
+    pool: "CatalogPool",
+) -> dict:
+    """Return the /queryables JSON Schema response.
+
+    Fully dynamic discovery of queryable properties:
+    1. Discovers all property keys from items table
+    2. Queries distinct values for each property
+    3. Infers JSON Schema types
+    4. Builds complete schema with enums where appropriate
+
+    Args:
+        request: HTTP request (for base URL extraction).
+        catalog_paths: List of catalog paths to query.
+        pool: Connection pool for catalog access.
+
+    Returns:
+        JSON Schema dict describing queryable properties.
+    """
+    base_url = str(request.base_url).rstrip("/")
+
+    # Collect all property keys and values across catalogs
+    all_keys: set[str] = set()
+    property_values: dict[str, list] = {}
+    collection_ids: set[str] = set()
+    nml_groups: set[str] = set()
+    nml_params: dict[str, set] = {}
+    collection_props: dict[str, set] = {}  # model, experiment, etc.
+
+    for path in catalog_paths:
+        db = pool.get(path)
+        if db is None:
+            logger.debug("Skipping unavailable catalog: {}", path)
+            continue
+
+        # Discover property keys
+        keys = _discover_property_keys(db)
+        all_keys.update(keys)
+
+        # Get collection IDs
+        collection_ids.update(_get_collection_distinct_values(db))
+
+        # Discover namelist data from collections
+        nml_groups.update(_discover_namelist_groups(db))
+        for key, values in _discover_namelist_parameters(db).items():
+            if key not in nml_params:
+                nml_params[key] = set()
+            nml_params[key].update(values)
+
+        # Discover collection-level properties (model, experiment)
+        for key, values in _discover_collection_properties(db).items():
+            if key not in collection_props:
+                collection_props[key] = set()
+            collection_props[key].update(values)
+
+    # nml:* properties are handled by the dedicated nml_params path below.
+    # Remove them from all_keys to prevent them inflating the count and
+    # randomly evicting ordinary properties (variable, stream, etc.) when
+    # the set is truncated to _MAX_PROPERTIES.
+    all_keys = {k for k in all_keys if not k.startswith("nml:")}
+
+    # Limit number of properties for performance
+    all_keys = set(list(all_keys)[:_MAX_PROPERTIES])
+
+    # Remove excluded properties
+    all_keys -= _EXCLUDED_PROPERTIES
+
+    # Get distinct values for each property (across all catalogs)
+    for prop_name in all_keys:
+        values: list = []
+        for path in catalog_paths:
+            db = pool.get(path)
+            if db:
+                if prop_name in _INDEX_AS_STRING:
+                    values.extend(_get_indexed_values(db, prop_name))
+                else:
+                    values.extend(_get_distinct_values(db, prop_name))
+        # Deduplicate while preserving order-ish
+        seen: set = set()
+        unique_values = []
+        for v in values:
+            key = str(v)
+            if key not in seen:
+                seen.add(key)
+                unique_values.append(v)
+        # Indexed properties are known-categorical; allow a larger enum limit.
+        limit = 1000 if prop_name in _INDEX_AS_STRING else _MAX_ENUM_VALUES + 1
+        property_values[prop_name] = unique_values[:limit]
+
+    # Build properties dict
+    properties: dict = {}
+
+    # Add special properties first
+    for name, schema in _SPECIAL_PROPERTIES.items():
+        properties[name] = schema.copy()
+
+    # Add collection property
+    if collection_ids:
+        properties["collection"] = {
+            "title": "Collection",
+            "type": "string",
+            "enum": sorted(collection_ids),
+        }
+
+    # Add collection-level properties (model, experiment)
+    for prop_name, values in sorted(collection_props.items()):
+        title_map = {
+            "model": "Model Component",
+            "experiment": "Experiment ID",
+        }
+        properties[prop_name] = {
+            "title": title_map.get(prop_name, _make_title(prop_name)),
+            "type": "string",
+            "enum": sorted(values),
+        }
+
+    # Add discovered item properties
+    for prop_name in sorted(all_keys):
+        values = property_values.get(prop_name, [])
+
+        if prop_name in _INDEX_AS_STRING:
+            # Indexed array properties: always expose as sorted string enum.
+            prop_schema: dict = {
+                "title": _make_title(prop_name),
+                "type": "string",
+            }
+            if values:
+                prop_schema["enum"] = sorted(str(v) for v in values)
+            properties[prop_name] = prop_schema
+            continue
+
+        schema_type, enum_values = _infer_json_schema_type(values)
+
+        prop_schema = {
+            "title": _make_title(prop_name),
+            "type": schema_type,
+        }
+
+        # Add enum if we have values and not too many
+        if enum_values and len(enum_values) <= _MAX_ENUM_VALUES:
+            # Special sorting for paleo:display
+            if prop_name == "paleo:display":
+                prop_schema["enum"] = sorted(enum_values, key=_sort_paleo_display)
+            else:
+                prop_schema["enum"] = sorted(enum_values)
+
+        properties[prop_name] = prop_schema
+
+    # Add namelist groups if present
+    if nml_groups:
+        properties["nml:group"] = {
+            "title": "Namelist Group",
+            "type": "string",
+            "enum": sorted(nml_groups),
+        }
+
+    # Add namelist parameters from collection-level discovery.
+    # Use "nml:group.param" (dot sub-separator) for the key so STAC Browser
+    # splits on ":" into exactly two segments (namespace + property).
+    #
+    # Skip a collection-level entry if an item-level key already covers the
+    # same parameter. Items store nml params as nml:{comp}:{group}:{key}
+    # (e.g. nml:FESOM:forcing_nml:atmbndy). These 4-segment keys produce the
+    # organized "FESOM / forcing_nml" accordion display in STAC Browser.
+    # Adding the collection-level nml:forcing_nml.atmbndy duplicate on top
+    # would create a redundant "General" group alongside the nice accordion.
+    for key, values in sorted(nml_params.items()):
+        prop_name = f"nml:{key.replace(':', '.')}"
+        if prop_name in properties:
+            continue  # Already added from items
+
+        # key format from collections: "group:param" (e.g. "forcing_nml:atmbndy")
+        # Item-level keys end with ":group:param" (e.g. "nml:FESOM:forcing_nml:atmbndy")
+        item_suffix = f":{key}"  # e.g. ":forcing_nml:atmbndy"
+        if any(
+            k.startswith("nml:") and k.count(":") >= 2 and k.endswith(item_suffix)
+            for k in properties
+        ):
+            continue  # Already covered by item-level key; avoid duplicate group
+
+        sample = next(iter(values), None)
+
+        # Check if this is a GHG parameter
+        ghg_info = get_ghg_info(prop_name)
+
+        if isinstance(sample, bool):
+            properties[prop_name] = {
+                "title": f"Namelist: {key}",
+                "type": "boolean",
+            }
+        elif isinstance(sample, int):
+            prop_schema = {
+                "title": f"Namelist: {key}",
+                "type": "integer",
+            }
+            # Add GHG unit info if applicable
+            if ghg_info:
+                prop_schema["title"] = ghg_info["title"]
+                prop_schema["x-ghg-units"] = {
+                    "canonical": ghg_info["canonical_unit"],
+                    "supported": list(ghg_info["supported_units"].keys()),
+                    "default": ghg_info["default_display_unit"],
+                }
+            properties[prop_name] = prop_schema
+        elif isinstance(sample, float):
+            prop_schema = {
+                "title": f"Namelist: {key}",
+                "type": "number",
+            }
+            # Add GHG unit info if applicable
+            if ghg_info:
+                prop_schema["title"] = ghg_info["title"]
+                prop_schema["x-ghg-units"] = {
+                    "canonical": ghg_info["canonical_unit"],
+                    "supported": list(ghg_info["supported_units"].keys()),
+                    "default": ghg_info["default_display_unit"],
+                }
+            properties[prop_name] = prop_schema
+        else:
+            prop_schema = {
+                "title": f"Namelist: {key}",
+                "type": "string",
+            }
+            if len(values) <= _MAX_ENUM_VALUES:
+                prop_schema["enum"] = sorted(str(v) for v in values)
+            properties[prop_name] = prop_schema
+
+    return {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": f"{base_url}/queryables",
+        "type": "object",
+        "title": "Queryable properties for ESM-Tools STAC Catalog",
+        "properties": properties,
+        "additionalProperties": True,
+    }
+
+
+def _get_collection_distinct_values_filtered(
+    db: "CatalogDB", prop_name: str, collection_id: str, limit: int = 100
+) -> list:
+    """Get distinct values for a property, filtered by collection."""
+    if not is_safe_property_name(prop_name):
+        return []
+
+    try:
+        rows = db.db.execute(f"""
+            SELECT DISTINCT v FROM (
+                SELECT json_extract(data, '$.properties."{prop_name}"') AS v
+                FROM items
+                WHERE json_extract_string(data, '$.collection') = ?
+            )
+            WHERE v IS NOT NULL
+            ORDER BY v
+            LIMIT {limit + 1}
+        """, [collection_id]).fetchall()
+
+        values = []
+        for row in rows:
+            if row[0] is not None:
+                raw = row[0]
+                if isinstance(raw, str):
+                    try:
+                        val = json.loads(raw)
+                        values.append(val)
+                    except (json.JSONDecodeError, TypeError):
+                        values.append(raw)
+                else:
+                    values.append(raw)
+        return values
+    except Exception as e:
+        logger.debug("Failed to get values for {} in {}: {}", prop_name, collection_id, e)
+        return []
+
+
+def get_collection_queryables(
+    request: "Request",
+    collection_id: str,
+    catalog_paths: list[str | Path],
+    pool: "CatalogPool",
+) -> dict | None:
+    """Return queryables scoped to a specific collection.
+
+    Similar to get_queryables() but enum values are filtered to only
+    include values present in items belonging to the specified collection.
+
+    Args:
+        request: HTTP request (for base URL extraction).
+        collection_id: The collection to scope queryables to.
+        catalog_paths: List of catalog paths to query.
+        pool: Connection pool for catalog access.
+
+    Returns:
+        JSON Schema dict, or None if collection not found.
+    """
+    base_url = str(request.base_url).rstrip("/")
+
+    # Check if collection exists and discover properties
+    collection_found = False
+    all_keys: set[str] = set()
+    property_values: dict[str, list] = {}
+
+    for path in catalog_paths:
+        db = pool.get(path)
+        if db is None:
+            continue
+
+        # Check if collection exists in this catalog (check both collections table and items)
+        try:
+            # First check collections table directly
+            row = db.db.execute(
+                "SELECT 1 FROM collections WHERE id = ?",
+                [collection_id],
+            ).fetchone()
+            if row:
+                collection_found = True
+            else:
+                # Fall back to checking if any items reference this collection
+                row = db.db.execute(
+                    "SELECT COUNT(*) FROM items WHERE json_extract_string(data, '$.collection') = ?",
+                    [collection_id],
+                ).fetchone()
+                if row and row[0] > 0:
+                    collection_found = True
+        except Exception:
+            pass
+
+        # Discover property keys from this collection's items
+        try:
+            rows = db.db.execute("""
+                SELECT DISTINCT json_keys(json_extract(data, '$.properties')) AS keys
+                FROM items
+                WHERE json_extract_string(data, '$.collection') = ?
+                LIMIT 500
+            """, [collection_id]).fetchall()
+
+            for row in rows:
+                keys = row[0]
+                if keys:
+                    if isinstance(keys, list):
+                        all_keys.update(keys)
+                    elif isinstance(keys, str):
+                        try:
+                            parsed = json.loads(keys)
+                            if isinstance(parsed, list):
+                                all_keys.update(parsed)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+        except Exception as e:
+            logger.debug("Failed to discover keys for {}: {}", collection_id, e)
+
+    if not collection_found:
+        return None
+
+    # Filter to safe property names; remove nml: (handled separately) and excluded
+    all_keys = {k for k in all_keys if is_safe_property_name(k) and not k.startswith("nml:")}
+    all_keys = set(list(all_keys)[:_MAX_PROPERTIES])
+    all_keys -= _EXCLUDED_PROPERTIES
+
+    # Get distinct values for each property within this collection
+    for prop_name in all_keys:
+        values: list = []
+        for path in catalog_paths:
+            db = pool.get(path)
+            if db:
+                if prop_name in _INDEX_AS_STRING:
+                    # Fetch individual indexed string values for this collection
+                    try:
+                        rows = db.db.execute(
+                            "SELECT DISTINCT value FROM collection_item_props "
+                            "WHERE collection_id = ? AND property = ? ORDER BY value",
+                            [collection_id, prop_name],
+                        ).fetchall()
+                        values.extend(r[0] for r in rows if r[0])
+                    except Exception as e:
+                        logger.debug("Failed indexed values for {}/{}: {}", collection_id, prop_name, e)
+                else:
+                    values.extend(_get_collection_distinct_values_filtered(
+                        db, prop_name, collection_id
+                    ))
+        # Deduplicate
+        seen: set = set()
+        unique_values = []
+        for v in values:
+            key = str(v)
+            if key not in seen:
+                seen.add(key)
+                unique_values.append(v)
+        # Indexed properties are known-categorical; allow a larger enum limit.
+        limit = 1000 if prop_name in _INDEX_AS_STRING else _MAX_ENUM_VALUES + 1
+        property_values[prop_name] = unique_values[:limit]
+
+    # Build properties dict
+    properties: dict = {}
+
+    # Add special properties
+    for name, schema in _SPECIAL_PROPERTIES.items():
+        properties[name] = schema.copy()
+
+    # Add discovered properties
+    for prop_name in sorted(all_keys):
+        values = property_values.get(prop_name, [])
+
+        if prop_name in _INDEX_AS_STRING:
+            # Indexed array properties: always expose as sorted string enum.
+            prop_schema: dict = {
+                "title": _make_title(prop_name),
+                "type": "string",
+            }
+            if values:
+                prop_schema["enum"] = sorted(str(v) for v in values)
+            properties[prop_name] = prop_schema
+            continue
+
+        schema_type, enum_values = _infer_json_schema_type(values)
+
+        prop_schema = {
+            "title": _make_title(prop_name),
+            "type": schema_type,
+        }
+
+        if enum_values and len(enum_values) <= _MAX_ENUM_VALUES:
+            if prop_name == "paleo:display":
+                prop_schema["enum"] = sorted(enum_values, key=_sort_paleo_display)
+            else:
+                prop_schema["enum"] = sorted(enum_values)
+
+        properties[prop_name] = prop_schema
+
+    return {
+        "$schema": "https://json-schema.org/draft/2019-09/schema",
+        "$id": f"{base_url}/collections/{collection_id}/queryables",
+        "type": "object",
+        "title": f"Queryable properties for collection {collection_id!r}",
+        "properties": properties,
+        "additionalProperties": True,
+    }

--- a/src/esm_catalog/api/validation.py
+++ b/src/esm_catalog/api/validation.py
@@ -1,0 +1,180 @@
+"""Input validation utilities for the ESM-Catalog API.
+
+Provides validation helpers for paths, request parameters, and other inputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from loguru import logger
+
+
+class ValidationError(Exception):
+    """Validation error with user-friendly message."""
+
+    pass
+
+
+def validate_catalog_path(
+    path: str,
+    must_exist: bool = False,
+    resolve: bool = True,
+) -> str:
+    """Validate and normalize a catalog path.
+
+    Args:
+        path: Path to the catalog file (absolute or relative).
+        must_exist: If True, raise ValidationError if path doesn't exist.
+        resolve: If True, resolve symlinks and normalize the path.
+
+    Returns:
+        Normalized absolute path string.
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    if not path or not path.strip():
+        raise ValidationError("Catalog path cannot be empty")
+
+    try:
+        p = Path(path)
+        if resolve:
+            p = p.resolve()
+        else:
+            p = p.absolute()
+    except Exception as e:
+        raise ValidationError(f"Invalid path format: {e}")
+
+    path_str = str(p)
+
+    if must_exist and not p.exists():
+        raise ValidationError(f"Catalog file does not exist: {path_str}")
+
+    if p.exists() and p.is_dir():
+        raise ValidationError(f"Path is a directory, expected file: {path_str}")
+
+    # Log for audit trail
+    logger.debug("Validated catalog path: {}", path_str)
+
+    return path_str
+
+
+def validate_catalog_id(catalog_id: str) -> str:
+    """Validate a catalog ID.
+
+    Args:
+        catalog_id: The catalog ID to validate.
+
+    Returns:
+        The validated catalog ID.
+
+    Raises:
+        ValidationError: If validation fails.
+    """
+    if not catalog_id or not catalog_id.strip():
+        raise ValidationError("Catalog ID cannot be empty")
+
+    # IDs should be alphanumeric with optional hyphens (UUID format)
+    clean_id = catalog_id.strip()
+    if not all(c.isalnum() or c == "-" for c in clean_id):
+        raise ValidationError(
+            f"Invalid catalog ID format: {catalog_id}. "
+            "Must contain only alphanumeric characters and hyphens."
+        )
+
+    return clean_id
+
+
+def validate_limit(limit: int | None, default: int = 10, max_value: int = 10000) -> int:
+    """Validate and bound a limit parameter.
+
+    Args:
+        limit: Requested limit, or None for default.
+        default: Default limit if None provided.
+        max_value: Maximum allowed limit.
+
+    Returns:
+        Validated limit value.
+    """
+    if limit is None:
+        return default
+    if limit < 0:
+        return default
+    if limit > max_value:
+        logger.warning("Limit {} exceeds maximum {}, capping", limit, max_value)
+        return max_value
+    return limit
+
+
+def validate_offset(offset: int | str | None, default: int = 0) -> int:
+    """Validate an offset/token parameter.
+
+    Args:
+        offset: Offset value (int or string token).
+        default: Default offset if None or invalid.
+
+    Returns:
+        Validated offset as integer.
+    """
+    if offset is None:
+        return default
+
+    if isinstance(offset, str):
+        if not offset.isdigit():
+            return default
+        offset = int(offset)
+
+    if offset < 0:
+        return default
+
+    return offset
+
+
+import re
+
+# Pattern for safe property names in SQL queries.
+# Allows alphanumeric, underscores, hyphens, colons (for namespaced properties).
+# Must start with alphanumeric or underscore.
+_SAFE_PROPERTY_PATTERN = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_:\-]*$")
+
+# Maximum length for property names
+_MAX_PROPERTY_NAME_LENGTH = 256
+
+
+def is_safe_property_name(name: str) -> bool:
+    """Check if a property name is safe for use in SQL queries.
+
+    Property names discovered from JSON keys are generally safe, but this
+    provides an additional layer of validation before string interpolation.
+
+    Args:
+        name: Property name to validate.
+
+    Returns:
+        True if the name is safe for SQL interpolation.
+    """
+    if not name or len(name) > _MAX_PROPERTY_NAME_LENGTH:
+        return False
+    return bool(_SAFE_PROPERTY_PATTERN.match(name))
+
+
+def validate_property_name(name: str) -> str:
+    """Validate a property name for use in SQL queries.
+
+    Args:
+        name: Property name to validate.
+
+    Returns:
+        The validated property name.
+
+    Raises:
+        ValidationError: If the property name is invalid.
+    """
+    if not is_safe_property_name(name):
+        raise ValidationError(
+            f"Invalid property name: {name!r}. "
+            "Must start with a letter/underscore and contain only "
+            "alphanumeric characters, underscores, colons, or hyphens."
+        )
+    return name

--- a/tests/test_esm_catalog/test_api_queryables.py
+++ b/tests/test_esm_catalog/test_api_queryables.py
@@ -1,0 +1,154 @@
+"""Tests for the /queryables endpoints (PR-B2)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from esm_catalog.api.app import create_app
+from esm_catalog.storage.duckdb import CatalogDB, persist_tree
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (same path structure as test_api_core.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    out = tmp_path / "experiments" / "exp-alpha" / "outdata" / "echam"
+    out.mkdir(parents=True)
+    nc = out / "tas_200001.nc"
+    times = pd.date_range("2000-01-01", periods=1, freq="MS")
+    xr.Dataset(
+        {"tas": (("time", "lat", "lon"), np.zeros((1, 2, 2), dtype="float32"))},
+        coords={"time": times, "lat": [-45.0, 45.0], "lon": [0.0, 90.0]},
+    ).to_netcdf(nc)
+
+    from esm_catalog.scan.ingest import scan_tree
+
+    catalog = scan_tree(tmp_path)
+    db = tmp_path / "catalog.duckdb"
+    persist_tree(catalog, db)
+    return db
+
+
+@pytest.fixture()
+def api_client(db_path: Path) -> TestClient:
+    return TestClient(create_app(catalogs=[str(db_path)]).app)
+
+
+@pytest.fixture()
+def empty_client() -> TestClient:
+    return TestClient(create_app(catalogs=[]).app)
+
+
+# ---------------------------------------------------------------------------
+# /queryables
+# ---------------------------------------------------------------------------
+
+
+def test_queryables_returns_200(api_client: TestClient):
+    r = api_client.get("/queryables")
+    assert r.status_code == 200
+
+
+def test_queryables_json_schema_structure(api_client: TestClient):
+    data = api_client.get("/queryables").json()
+    assert data["$schema"] == "https://json-schema.org/draft/2019-09/schema"
+    assert data["type"] == "object"
+    assert "properties" in data
+    assert "$id" in data
+
+
+def test_queryables_always_has_datetime(api_client: TestClient):
+    props = api_client.get("/queryables").json()["properties"]
+    assert "datetime" in props
+    assert props["datetime"]["type"] == "string"
+
+
+def test_queryables_empty_catalog_still_valid(empty_client: TestClient):
+    r = empty_client.get("/queryables")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["type"] == "object"
+    assert "properties" in data
+
+
+def test_queryables_base_id_matches_request(api_client: TestClient):
+    data = api_client.get("/queryables").json()
+    assert data["$id"].endswith("/queryables")
+
+
+# ---------------------------------------------------------------------------
+# /collections/{id}/queryables
+# ---------------------------------------------------------------------------
+
+
+def test_collection_queryables_returns_200(api_client: TestClient, db_path: Path):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    assert cols
+    col_id = cols[0]["id"]
+
+    r = api_client.get(f"/collections/{col_id}/queryables")
+    assert r.status_code == 200
+
+
+def test_collection_queryables_json_schema_structure(
+    api_client: TestClient, db_path: Path
+):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    col_id = cols[0]["id"]
+
+    data = api_client.get(f"/collections/{col_id}/queryables").json()
+    assert data["$schema"] == "https://json-schema.org/draft/2019-09/schema"
+    assert data["type"] == "object"
+    assert "properties" in data
+    assert col_id in data["$id"]
+
+
+def test_collection_queryables_not_found(api_client: TestClient):
+    r = api_client.get("/collections/no-such-collection/queryables")
+    assert r.status_code == 404
+
+
+def test_collection_queryables_scoped_to_collection(
+    api_client: TestClient, db_path: Path
+):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    col_id = cols[0]["id"]
+
+    data = api_client.get(f"/collections/{col_id}/queryables").json()
+    # Should have datetime at minimum
+    assert "datetime" in data["properties"]
+
+
+# ---------------------------------------------------------------------------
+# Links
+# ---------------------------------------------------------------------------
+
+
+def test_landing_page_advertises_queryables(api_client: TestClient):
+    data = api_client.get("/").json()
+    rels = {lnk["rel"] for lnk in data.get("links", [])}
+    assert "http://www.opengis.net/def/rel/ogc/1.0/queryables" in rels
+
+
+def test_collection_response_has_queryables_link(
+    api_client: TestClient, db_path: Path
+):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    col_id = cols[0]["id"]
+
+    data = api_client.get(f"/collections/{col_id}").json()
+    rels = {lnk["rel"] for lnk in data.get("links", [])}
+    assert "http://www.opengis.net/def/rel/ogc/1.0/queryables" in rels


### PR DESCRIPTION
## Summary


> **Provenance:** this implementation is substantially Paul Gierz's work, carried over from his `esm-tools-plus/simcat/pgierz-workbench` prototype branch (commits Mar–Apr 2026). This PR ports it, largely as-is, into the reviewable stack.

- Adds `api/queryables.py`: fully dynamic property discovery from live DuckDB data — no hardcoded property lists; works for NetCDF global attrs, namelist params, HPC info, and future extensions automatically
- Adds `api/validation.py`: `is_safe_property_name()` SQL injection guard used before any property name is interpolated into SQL
- Wires `/queryables` and `/collections/{id}/queryables` into `app.py` with `QueryablesCache` (5-minute TTL)
- STAC Browser's "Additional filters" CQL2 builder uses these endpoints to populate dropdown enum values

## What's deferred

| PR | Content |
|---|---|
| B3 | `/experiments` hierarchy routes + paleo time presets |
| B4 | `/catalogs` federation API + auth middleware |

## Test plan

- [ ] CI green on 3.9 + 3.12
- [ ] `GET /queryables` → 200, has `$schema`, `type: object`, `properties` with `datetime`
- [ ] `GET /collections/{id}/queryables` → 200, scoped to collection
- [ ] `GET /collections/no-such/queryables` → 404
- [ ] Landing page links include OGC queryables rel
- [ ] Each collection response has queryables link

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
