### PR TITLE
feat(esm_catalog): PR-B3 — experiment hierarchy routes + paleo presets

### DIFF
--- a/src/esm_catalog/api/app.py
+++ b/src/esm_catalog/api/app.py
@@ -40,6 +40,10 @@ from esm_catalog.api.client import (
     FilteredSearchPostRequest,
     ItemCollectionUriWithToken,
 )
+from esm_catalog.api.experiment_routes import (
+    create_collection_experiment_router,
+    create_experiment_router,
+)
 from esm_catalog.api.pool import CatalogPool
 from esm_catalog.api.queryables import get_collection_queryables, get_queryables
 from esm_catalog.api.registry import CatalogRegistry
@@ -201,6 +205,65 @@ def create_app(
             "catalogs_accessible": accessible,
             "catalogs_total": len(paths),
         }
+
+    # Experiment hierarchy routes
+    experiment_router = create_experiment_router(client)
+    api.app.include_router(experiment_router)
+
+    collection_experiment_router = create_collection_experiment_router(client)
+    api.app.include_router(collection_experiment_router)
+
+    # Paleo time presets (lazy import — only fails if duckdb missing, which
+    # is already a required dep, so this should always succeed)
+    @api.app.get(
+        "/paleo-presets",
+        response_model=None,
+        include_in_schema=True,
+        summary="Get available paleo time period presets",
+        tags=["Climate Science"],
+    )
+    def get_paleo_presets():
+        from esm_catalog.api.paleo_presets import get_presets
+
+        return {"presets": [p.to_dict() for p in get_presets()]}
+
+    @api.app.post(
+        "/paleo-presets",
+        response_model=None,
+        include_in_schema=True,
+        summary="Add a user-defined paleo time preset",
+        tags=["Climate Science"],
+    )
+    def add_paleo_preset(preset: dict):
+        from esm_catalog.api.paleo_presets import add_preset
+
+        result = add_preset(
+            preset_id=preset.get("id", ""),
+            name=preset.get("name", ""),
+            display=preset.get("display", ""),
+            years_bp=preset.get("years_bp", 0),
+            description=preset.get("description", ""),
+        )
+        return {"status": "created", "preset": result.to_dict()}
+
+    @api.app.delete(
+        "/paleo-presets/{preset_id}",
+        response_model=None,
+        include_in_schema=True,
+        summary="Delete a user-added paleo time preset",
+        tags=["Climate Science"],
+    )
+    def delete_paleo_preset(preset_id: str):
+        from fastapi import HTTPException
+
+        from esm_catalog.api.paleo_presets import delete_preset
+
+        if not delete_preset(preset_id):
+            raise HTTPException(
+                status_code=404,
+                detail=f"Preset '{preset_id}' not found or is a built-in preset",
+            )
+        return {"status": "deleted", "id": preset_id}
 
     # Register lifespan handler for cleanup on shutdown
     original_lifespan = api.app.router.lifespan_context

--- a/src/esm_catalog/api/experiment_routes.py
+++ b/src/esm_catalog/api/experiment_routes.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+"""Experiment-level STAC hierarchy endpoints.
+
+GET /experiments              → list all experiments with component lists
+GET /experiments?filter=...   → CQL2-filtered experiment search
+GET /experiments/{id}         → STAC Catalog object for one experiment
+
+With Option A (one collection per experiment) experiments and collections share
+the same ID. Filtering is delegated to search_collections() so that all existing
+CQL2 operators work — including component facet (component='fesom'),
+variable facet (variable='tas'), and namelist parameters (nml:...).
+"""
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from esm_catalog.api.client import DuckDBCatalogClient, _inject_experiment_catalog_links
+from esm_catalog.api.cql2 import parse_filter
+from esm_catalog.api.responses import (
+    ExperimentCatalog,
+    ExperimentLink,
+    ExperimentSummary,
+    ExperimentsListResponse,
+)
+
+
+def _collection_to_summary(col: dict, base_url: str) -> ExperimentSummary:
+    """Build an ExperimentSummary from a collection dict (Option A: col id == experiment id)."""
+    exp_id = col.get("experiment") or col["id"]
+    return ExperimentSummary(
+        id=exp_id,
+        title=col.get("title", exp_id),
+        components=sorted(col.get("components", [])),
+        href=f"{base_url}/experiments/{exp_id}",
+    )
+
+
+def create_experiment_router(client: DuckDBCatalogClient) -> APIRouter:
+    router = APIRouter(prefix="/experiments", tags=["Experiment Hierarchy"])
+
+    @router.get("", response_model=ExperimentsListResponse)
+    def list_experiments(
+        request: Request,
+        limit: int = Query(100, ge=1, le=1000),
+        offset: int = Query(0, ge=0),
+        filter: Optional[str] = Query(
+            None,
+            description=(
+                "CQL2 filter expression for experiment search. "
+                "Examples: component='fesom', variable='tas', "
+                "nml:radctl.co2vmr > 284.0"
+            ),
+        ),
+        filter_lang: Optional[str] = Query(
+            None, alias="filter-lang",
+            description="Filter language: cql2-text (default) or cql2-json",
+        ),
+    ) -> ExperimentsListResponse:
+        """List experiments, optionally filtered by component, variable, or namelist params.
+
+        With the collapsed-collection layout (Option A) each experiment maps to
+        exactly one STAC Collection.  Filtering is therefore identical to
+        collection search: any property visible in collection_item_props or the
+        collection's own fields can be used as a CQL2 predicate.
+
+        Common facets:
+        - ``component='fesom'``   — experiments that ran the FESOM ocean model
+        - ``variable='tas'``      — experiments that produced surface temperature
+        - ``nml:radctl.co2vmr > 284.0`` — experiments with elevated CO₂
+        """
+        base_url = str(request.base_url).rstrip("/")
+
+        filter_props: dict = {}
+        if filter:
+            filter_props = parse_filter(filter, filter_lang)
+
+        # Delegate to search_collections across all catalogs
+        dbs = client._open_catalogs()
+        try:
+            matched_cols: list[dict] = []
+            seen: set[str] = set()
+            for db in dbs:
+                cols, _ = db.search_collections(
+                    filter_props=filter_props if filter_props else None
+                )
+                for col in cols:
+                    exp_id = col.get("experiment") or col["id"]
+                    if exp_id not in seen:
+                        matched_cols.append(col)
+                        seen.add(exp_id)
+        finally:
+            client._close_catalogs(dbs)
+
+        total = len(matched_cols)
+        page_cols = matched_cols[offset:offset + limit]
+        summaries = [_collection_to_summary(col, base_url) for col in page_cols]
+
+        qs = f"limit={limit}"
+        if filter:
+            qs += f"&filter={filter}"
+            if filter_lang:
+                qs += f"&filter-lang={filter_lang}"
+
+        links = [
+            ExperimentLink(rel="self",  href=f"{base_url}/experiments?{qs}&offset={offset}"),
+            ExperimentLink(rel="root",  href=f"{base_url}/"),
+            ExperimentLink(rel="first", href=f"{base_url}/experiments?{qs}&offset=0"),
+        ]
+        if offset > 0:
+            links.append(ExperimentLink(
+                rel="prev",
+                href=f"{base_url}/experiments?{qs}&offset={max(0, offset - limit)}",
+            ))
+        if offset + limit < total:
+            links.append(ExperimentLink(
+                rel="next",
+                href=f"{base_url}/experiments?{qs}&offset={offset + limit}",
+            ))
+
+        return ExperimentsListResponse(
+            experiments=summaries,
+            numberMatched=total,
+            numberReturned=len(summaries),
+            links=links,
+        )
+
+    @router.get("/{experiment_id}", response_model=ExperimentCatalog,
+                responses={404: {"description": "Experiment not found"}})
+    def get_experiment(experiment_id: str, request: Request) -> ExperimentCatalog:
+        base_url = str(request.base_url).rstrip("/")
+        cols = client._get_collections_for_experiment(experiment_id)
+        if not cols:
+            raise HTTPException(404, detail=f"Experiment '{experiment_id}' not found")
+        catalog_dict = _inject_experiment_catalog_links(experiment_id, base_url, cols)
+        return ExperimentCatalog(**catalog_dict)
+
+    return router
+
+
+def create_collection_experiment_router(client: DuckDBCatalogClient) -> APIRouter:
+    """Router for GET /collections/{id}/experiment.
+
+    Convenience shortcut: given a component collection (e.g. ``basic-001-echam``),
+    return the parent experiment catalog — the same JSON as
+    ``GET /experiments/basic-001`` — without the caller needing to know the
+    experiment ID in advance.
+    """
+    router = APIRouter(tags=["Experiment Hierarchy"])
+
+    @router.get(
+        "/collections/{collection_id}/experiment",
+        response_model=ExperimentCatalog,
+        responses={404: {"description": "Collection or experiment not found"}},
+        summary="Get the experiment catalog for a collection",
+    )
+    def get_collection_experiment(
+        collection_id: str, request: Request
+    ) -> ExperimentCatalog:
+        base_url = str(request.base_url).rstrip("/")
+
+        # Find the collection across all catalogs to get its experiment field.
+        dbs = client._open_catalogs()
+        try:
+            found_col: dict | None = None
+            for db in dbs:
+                col = db.get_collection(collection_id)
+                if col is not None:
+                    found_col = col
+                    break
+        finally:
+            client._close_catalogs(dbs)
+
+        if found_col is None:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Collection '{collection_id}' not found",
+            )
+
+        experiment_id: str | None = found_col.get("experiment") or None
+        if not experiment_id:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Collection '{collection_id}' has no experiment field",
+            )
+
+        cols = client._get_collections_for_experiment(experiment_id)
+        catalog_dict = _inject_experiment_catalog_links(experiment_id, base_url, cols)
+        return ExperimentCatalog(**catalog_dict)
+
+    return router

--- a/src/esm_catalog/api/paleo_presets.py
+++ b/src/esm_catalog/api/paleo_presets.py
@@ -1,0 +1,189 @@
+"""In-memory DuckDB storage for paleo time period presets.
+
+Provides commonly simulated paleo time periods (LGM, Mid-Holocene, etc.)
+that users can reference when filtering climate model output.
+
+The presets are stored in an in-memory DuckDB table that persists for
+the lifetime of the API server. Users can add custom presets via the API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+try:
+    import duckdb
+except ImportError:
+    duckdb = None  # type: ignore[assignment]
+
+# In-memory database for paleo presets (survives API lifetime)
+_presets_db = None
+
+REFERENCE_YEAR: int = 1950
+
+
+@dataclass(frozen=True)
+class PaleoDatetimePreset:
+    id: str
+    name: str
+    display: str
+    _years_bp: float
+    description: str
+    user_added: bool = False
+
+    @property
+    def years_bp(self) -> float:
+        """Years before present (1950 CE)."""
+        return self._years_bp
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "PaleoDatetimePreset":
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            display=data["display"],
+            _years_bp=float(data["years_bp"]),
+            description=data["description"],
+            user_added=data.get("user_added", False),
+        )
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-safe dict for API responses."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "display": self.display,
+            "years_bp": self.years_bp,
+            "description": self.description,
+            "user_added": self.user_added,
+        }
+
+
+def _get_db():
+    """Get or create the in-memory database connection."""
+    global _presets_db
+    if _presets_db is None:
+        _presets_db = duckdb.connect(":memory:")
+        _init_presets_db(_presets_db)
+    return _presets_db
+
+
+def _init_presets_db(db) -> None:
+    """Initialize paleo time presets table with common periods."""
+    db.execute(
+        """
+        CREATE TABLE IF NOT EXISTS paleo_presets (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            display TEXT NOT NULL,
+            years_bp DOUBLE,
+            description TEXT,
+            user_added BOOLEAN DEFAULT FALSE
+        )
+    """
+    )
+
+    # Default presets (commonly simulated periods in climate modeling)
+    # years_bp is "years before present" (1950 CE); positive = past
+    defaults = [
+        ("lgm",           "Last Glacial Maximum",           "21.0 ka",   21_000,       "Peak ice extent ~21,000 years ago (MIS 2)"),
+        ("mid_holocene",  "Mid-Holocene",                   "6.0 ka",    6_000,        "Warm period ~6,000 years ago (MIS 1)"),
+        ("eemian",        "Last Interglacial (Eemian)",     "125.0 ka",  125_000,      "Previous warm period, MIS 5e"),
+        ("lig",           "Last Interglacial",              "130.0 ka",  130_000,      "MIS 5e warm period, ~130 ka"),
+        ("mis3",          "MIS 3",                          "50.0 ka",   50_000,       "Marine Isotope Stage 3, interstadial period"),
+        ("pliocene",      "Mid-Pliocene Warm Period",       "3.0 Ma",    3_000_000,    "Warm Pliocene period, ~3 million years ago"),
+        ("miocene",       "Late Miocene",                   "10.0 Ma",   10_000_000,   "Late Miocene, ~10 million years ago"),
+        ("preindustrial", "Pre-Industrial",                 "1850 CE",   100,          "Pre-industrial baseline (1850 CE)"),
+        ("historical",    "Historical Period",              "1850-2014 CE", -32,       "CMIP6 historical period"),
+    ]
+
+    for (pid, pname, pdisplay, pyears_bp, pdesc) in defaults:
+        db.execute(
+            """
+            INSERT OR IGNORE INTO paleo_presets (id, name, display, years_bp, description, user_added)
+            VALUES (?, ?, ?, ?, ?, FALSE)
+            """,
+            [pid, pname, pdisplay, pyears_bp, pdesc],
+        )
+
+
+def _row_to_preset(r) -> PaleoDatetimePreset:
+    return PaleoDatetimePreset.from_dict({
+        "id": r[0], "name": r[1], "display": r[2],
+        "years_bp": r[3], "description": r[4], "user_added": r[5],
+    })
+
+
+def get_presets() -> list[PaleoDatetimePreset]:
+    """Return all paleo presets sorted by age (oldest first)."""
+    db = _get_db()
+    rows = db.execute(
+        "SELECT id, name, display, years_bp, description, user_added "
+        "FROM paleo_presets ORDER BY years_bp DESC"
+    ).fetchall()
+    return [_row_to_preset(r) for r in rows]
+
+
+def get_preset(preset_id: str) -> PaleoDatetimePreset | None:
+    """Get a single preset by ID."""
+    db = _get_db()
+    rows = db.execute(
+        "SELECT id, name, display, years_bp, description, user_added "
+        "FROM paleo_presets WHERE id = ?",
+        [preset_id],
+    ).fetchall()
+    return _row_to_preset(rows[0]) if rows else None
+
+
+def add_preset(
+    preset_id: str,
+    name: str,
+    display: str,
+    years_bp: float,
+    description: str = "",
+) -> PaleoDatetimePreset:
+    """Add a user-defined preset."""
+    db = _get_db()
+    db.execute(
+        "INSERT OR REPLACE INTO paleo_presets "
+        "(id, name, display, years_bp, description, user_added) "
+        "VALUES (?, ?, ?, ?, ?, TRUE)",
+        [preset_id, name, display, years_bp, description],
+    )
+    return PaleoDatetimePreset.from_dict({
+        "id": preset_id, "name": name, "display": display,
+        "years_bp": years_bp, "description": description, "user_added": True,
+    })
+
+
+def delete_preset(preset_id: str) -> bool:
+    """Delete a user-added preset. Returns True if deleted, False if not found/built-in."""
+    db = _get_db()
+    row = db.execute(
+        "SELECT id FROM paleo_presets WHERE id = ? AND user_added = TRUE",
+        [preset_id],
+    ).fetchone()
+    if not row:
+        return False
+    db.execute(
+        "DELETE FROM paleo_presets WHERE id = ? AND user_added = TRUE",
+        [preset_id],
+    )
+    return True
+
+
+def years_bp_to_datetime(years_bp: float) -> str:
+    """Convert years before present to ISO datetime string."""
+    year = 1950 - int(years_bp)
+    if year < 1:
+        return f"{year:05d}-01-01T00:00:00Z"
+    return f"{year:04d}-01-01T00:00:00Z"
+
+
+def datetime_to_years_bp(datetime_str: str) -> float | None:
+    """Convert ISO datetime string to years before present."""
+    try:
+        year_str = datetime_str[:5] if datetime_str.startswith("-") else datetime_str[:4]
+        return float(1950 - int(year_str))
+    except (ValueError, IndexError):
+        return None

--- a/tests/test_esm_catalog/test_api_science.py
+++ b/tests/test_esm_catalog/test_api_science.py
@@ -1,0 +1,163 @@
+"""Tests for experiment routes + paleo presets (PR-B3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from esm_catalog.api.app import create_app
+from esm_catalog.storage.duckdb import CatalogDB, persist_tree
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    out = tmp_path / "experiments" / "exp-alpha" / "outdata" / "echam"
+    out.mkdir(parents=True)
+    nc = out / "tas_200001.nc"
+    times = pd.date_range("2000-01-01", periods=1, freq="MS")
+    xr.Dataset(
+        {"tas": (("time", "lat", "lon"), np.zeros((1, 2, 2), dtype="float32"))},
+        coords={"time": times, "lat": [-45.0, 45.0], "lon": [0.0, 90.0]},
+    ).to_netcdf(nc)
+
+    from esm_catalog.scan.ingest import scan_tree
+
+    catalog = scan_tree(tmp_path)
+    db = tmp_path / "catalog.duckdb"
+    persist_tree(catalog, db)
+    return db
+
+
+@pytest.fixture()
+def api_client(db_path: Path) -> TestClient:
+    return TestClient(create_app(catalogs=[str(db_path)]).app)
+
+
+@pytest.fixture()
+def empty_client() -> TestClient:
+    return TestClient(create_app(catalogs=[]).app)
+
+
+# ---------------------------------------------------------------------------
+# /experiments
+# ---------------------------------------------------------------------------
+
+
+def test_list_experiments_empty(empty_client: TestClient):
+    r = empty_client.get("/experiments")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["experiments"] == []
+    assert data["numberMatched"] == 0
+
+
+def test_list_experiments(api_client: TestClient):
+    r = api_client.get("/experiments")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["numberMatched"] >= 1
+    exp = data["experiments"][0]
+    assert "id" in exp
+    assert "href" in exp
+
+
+def test_list_experiments_has_pagination_links(api_client: TestClient):
+    data = api_client.get("/experiments").json()
+    rels = {lnk["rel"] for lnk in data.get("links", [])}
+    assert "self" in rels
+    assert "first" in rels
+
+
+def test_get_experiment(api_client: TestClient, db_path: Path):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    assert cols
+    exp_id = cols[0].get("experiment") or cols[0]["id"]
+
+    r = api_client.get(f"/experiments/{exp_id}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["type"] == "Catalog"
+    assert data["id"] == exp_id
+
+
+def test_get_experiment_not_found(api_client: TestClient):
+    r = api_client.get("/experiments/no-such-experiment")
+    assert r.status_code == 404
+
+
+def test_collection_experiment_shortcut(api_client: TestClient, db_path: Path):
+    with CatalogDB(db_path) as db:
+        cols = list(db.iter_collections())
+    col_id = cols[0]["id"]
+
+    r = api_client.get(f"/collections/{col_id}/experiment")
+    assert r.status_code == 200
+    assert r.json()["type"] == "Catalog"
+
+
+def test_collection_experiment_not_found(api_client: TestClient):
+    r = api_client.get("/collections/no-such-col/experiment")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /paleo-presets
+# ---------------------------------------------------------------------------
+
+
+def test_get_paleo_presets(api_client: TestClient):
+    r = api_client.get("/paleo-presets")
+    assert r.status_code == 200
+    data = r.json()
+    assert "presets" in data
+    assert len(data["presets"]) >= 1
+
+
+def test_paleo_presets_structure(api_client: TestClient):
+    presets = api_client.get("/paleo-presets").json()["presets"]
+    for p in presets:
+        assert "id" in p
+        assert "name" in p
+        assert "display" in p
+        assert "years_bp" in p
+
+
+def test_paleo_presets_contains_lgm(api_client: TestClient):
+    presets = api_client.get("/paleo-presets").json()["presets"]
+    ids = {p["id"] for p in presets}
+    assert "lgm" in ids
+
+
+def test_add_and_delete_paleo_preset(api_client: TestClient):
+    body = {
+        "id": "test-period",
+        "name": "Test Period",
+        "display": "42.0 ka",
+        "years_bp": 42000,
+        "description": "A test preset",
+    }
+    r = api_client.post("/paleo-presets", json=body)
+    assert r.status_code == 200
+    assert r.json()["preset"]["id"] == "test-period"
+
+    presets = api_client.get("/paleo-presets").json()["presets"]
+    assert any(p["id"] == "test-period" for p in presets)
+
+    r = api_client.delete("/paleo-presets/test-period")
+    assert r.status_code == 200
+
+
+def test_delete_builtin_preset_fails(api_client: TestClient):
+    r = api_client.delete("/paleo-presets/lgm")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary


> **Provenance:** `api/paleo_presets.py` is ported from Paul Gierz's `esm-tools-plus/simcat/pgierz-workbench` prototype branch; `api/experiment_routes.py` is new for this decomposition.

- `api/experiment_routes.py`: `GET /experiments` (list with CQL2 filter support), `GET /experiments/{id}` (STAC Catalog object), `GET /collections/{id}/experiment` (shortcut from collection to parent experiment)
- `api/paleo_presets.py`: in-memory DuckDB table of 9 built-in paleo periods (LGM, Mid-Holocene, Eemian, etc.); `POST /paleo-presets` to add custom presets, `DELETE /paleo-presets/{id}` for user-added presets only
- Adapted from source: removed `paleodatetime` dependency (not in project requirements); fixed DuckDB rowcount bug (always returns -1 on DELETE — now checks existence before delete)
- 12 new tests (113 total); no new dependencies

## Test plan

- [ ] CI green on 3.9 + 3.12
- [ ] `GET /experiments` → list with `numberMatched`
- [ ] `GET /experiments/{id}` → `{"type": "Catalog", ...}`
- [ ] `GET /collections/{id}/experiment` → parent experiment catalog
- [ ] `GET /paleo-presets` → list including `lgm`
- [ ] Add + delete custom preset roundtrip
- [ ] Delete built-in preset → 404

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
