### PR TITLE
feat(esm_catalog): PR-B4 — federation API (/catalogs CRUD + auth middleware)

### DIFF
--- a/src/esm_catalog/api/app.py
+++ b/src/esm_catalog/api/app.py
@@ -34,7 +34,9 @@ from stac_fastapi.types.config import ApiSettings
 from starlette.middleware import Middleware
 from starlette.requests import Request
 
+from esm_catalog.api.auth import Authenticator, NoAuthenticator
 from esm_catalog.api.cache import CollectionCache, QueryablesCache
+from esm_catalog.api.catalog_routes import create_catalog_router
 from esm_catalog.api.client import (
     DuckDBCatalogClient,
     FilteredSearchPostRequest,
@@ -59,6 +61,7 @@ _DEFAULT_VERSION = "1.0"
 def create_app(
     catalogs: List[Union[str, Path]] | None = None,
     registry_persist_path: str | Path | None = None,
+    authenticator: Authenticator | None = None,
     title: str = _DEFAULT_TITLE,
     description: str = _DEFAULT_DESCRIPTION,
     version: str = _DEFAULT_VERSION,
@@ -90,6 +93,7 @@ def create_app(
         persist_path=registry_persist_path,
     )
     pool = CatalogPool()
+    auth = authenticator or NoAuthenticator()
     collection_cache = CollectionCache(ttl_seconds=300)
     queryables_cache = QueryablesCache(ttl_seconds=300)
 
@@ -205,6 +209,10 @@ def create_app(
             "catalogs_accessible": accessible,
             "catalogs_total": len(paths),
         }
+
+    # Catalog management routes (CRUD for dynamically adding/removing catalogs)
+    catalog_router = create_catalog_router(registry, pool, auth, queryables_cache)
+    api.app.include_router(catalog_router)
 
     # Experiment hierarchy routes
     experiment_router = create_experiment_router(client)

--- a/src/esm_catalog/api/auth.py
+++ b/src/esm_catalog/api/auth.py
@@ -1,0 +1,455 @@
+"""Pluggable authentication module for the ESM-Catalog API.
+
+Provides a JupyterHub-style authentication pattern where the authenticator
+class can be swapped out for different backends (API key, OAuth, SSO, etc.)
+without changing the API structure.
+
+The default NoAuthenticator allows all access. For production deployments,
+provide a custom authenticator implementation.
+
+Example::
+
+    from esm_catalog.api.auth import Authenticator, User
+
+    class MyInstitutionAuthenticator(Authenticator):
+        async def authenticate(self, request: Request) -> User | None:
+            token = request.headers.get("Authorization")
+            if not token:
+                return None
+            user_info = await my_sso_client.validate(token)
+            if user_info:
+                return User(
+                    name=user_info["username"],
+                    admin=user_info.get("is_admin", False),
+                    groups=user_info.get("groups", []),
+                )
+            return None
+
+        def get_permissions(self, user: User, resource: str) -> set[str]:
+            if user.admin:
+                return {"read", "write", "delete"}
+            if "catalog-managers" in user.groups:
+                return {"read", "write"}
+            return {"read"}
+
+    # Use in app creation
+    app = create_app(
+        catalogs=[...],
+        authenticator=MyInstitutionAuthenticator(),
+    )
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Callable
+
+from fastapi import Depends, HTTPException, Request
+
+if TYPE_CHECKING:
+    pass
+
+
+@dataclass
+class User:
+    """Authenticated user information.
+
+    Attributes:
+        name: Username or identifier.
+        admin: Whether the user has admin privileges.
+        groups: Optional list of group memberships for RBAC.
+        metadata: Optional additional user metadata.
+    """
+
+    name: str
+    admin: bool = False
+    groups: list[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+class Authenticator(ABC):
+    """Base class for authentication backends.
+
+    Subclass this to implement custom authentication logic for your
+    institution's SSO, OAuth, API keys, or other authentication mechanism.
+
+    The authenticator is called on each request to protected endpoints.
+    Return a User object if authentication succeeds, or None if it fails.
+    """
+
+    @abstractmethod
+    async def authenticate(self, request: "Request") -> User | None:
+        """Authenticate a request and return the user if successful.
+
+        Args:
+            request: The incoming HTTP request.
+
+        Returns:
+            User object if authenticated, None otherwise.
+        """
+        pass
+
+    def get_permissions(self, user: User, resource: str) -> set[str]:
+        """Return permissions for user on resource.
+
+        Override this method to implement Role-Based Access Control (RBAC).
+        The default implementation grants read-only access to all users
+        and full access to admins.
+
+        Args:
+            user: Authenticated user.
+            resource: Resource identifier (e.g., "catalogs", "items").
+
+        Returns:
+            Set of permission strings (e.g., {"read", "write", "delete"}).
+        """
+        if user.admin:
+            return {"read", "write", "delete"}
+        return {"read"}
+
+    def requires_auth(self, resource: str, action: str) -> bool:
+        """Check if a resource/action combination requires authentication.
+
+        Override to make certain endpoints public. The default requires
+        authentication for all write operations.
+
+        Args:
+            resource: Resource identifier.
+            action: Action being performed (e.g., "read", "write", "delete").
+
+        Returns:
+            True if authentication is required.
+        """
+        return action in {"write", "delete"}
+
+
+class NoAuthenticator(Authenticator):
+    """Default authenticator that allows all access without authentication.
+
+    All requests are treated as coming from an anonymous admin user.
+    Use this for development or single-user deployments.
+    """
+
+    async def authenticate(self, request: "Request") -> User | None:
+        """Always returns an anonymous admin user."""
+        return User(name="anonymous", admin=True)
+
+    def requires_auth(self, resource: str, action: str) -> bool:
+        """Never requires authentication."""
+        return False
+
+
+class APIKeyAuthenticator(Authenticator):
+    """Simple API key authentication.
+
+    Validates requests against a configured API key passed in the
+    X-API-Key header or as a query parameter.
+
+    Example::
+
+        auth = APIKeyAuthenticator(
+            api_keys={"admin-key-123": User(name="admin", admin=True)},
+        )
+    """
+
+    def __init__(
+        self,
+        api_keys: dict[str, User] | None = None,
+        header_name: str = "X-API-Key",
+        query_param: str = "api_key",
+    ) -> None:
+        """Initialize the authenticator.
+
+        Args:
+            api_keys: Mapping from API key strings to User objects.
+            header_name: HTTP header name to check for API key.
+            query_param: Query parameter name to check for API key.
+        """
+        self.api_keys = api_keys or {}
+        self.header_name = header_name
+        self.query_param = query_param
+
+    async def authenticate(self, request: "Request") -> User | None:
+        """Validate API key from header or query parameter."""
+        # Check header first
+        key = request.headers.get(self.header_name)
+
+        # Fall back to query parameter
+        if not key:
+            key = request.query_params.get(self.query_param)
+
+        if not key:
+            return None
+
+        return self.api_keys.get(key)
+
+
+# Future authenticator stubs for reference
+# These would be implemented when integrating with specific auth providers
+
+
+class JupyterHubAuthenticator(Authenticator):
+    """JupyterHub OAuth integration for STAC API.
+
+    When running as a JupyterHub service, this authenticator validates
+    tokens against the JupyterHub API and extracts user/group information.
+
+    Setup:
+        1. Register as a JupyterHub service in jupyterhub_config.py
+        2. The service receives JUPYTERHUB_API_TOKEN and JUPYTERHUB_API_URL
+        3. User requests include Authorization header with their token
+
+    Example jupyterhub_config.py::
+
+        c.JupyterHub.services = [
+            {
+                "name": "stac-catalog",
+                "url": "http://127.0.0.1:8000",
+                "command": ["esm-catalog", "serve", "--port", "8000"],
+                "environment": {
+                    "JUPYTERHUB_API_URL": "http://127.0.0.1:8081/hub/api",
+                },
+            }
+        ]
+
+    Write permissions are granted to:
+        - Hub admins
+        - Users in the "catalog-managers" group (configurable)
+    """
+
+    def __init__(
+        self,
+        hub_api_url: str | None = None,
+        api_token: str | None = None,
+        write_groups: list[str] | None = None,
+    ) -> None:
+        """Initialize with JupyterHub API settings.
+
+        Args:
+            hub_api_url: URL of the JupyterHub API (e.g., http://hub:8081/hub/api).
+                        If not provided, uses JUPYTERHUB_API_URL environment variable.
+            api_token: Service API token for authenticating with Hub API.
+                      If not provided, uses JUPYTERHUB_API_TOKEN environment variable.
+            write_groups: List of group names that grant write access.
+                         Default: ["catalog-managers"]
+        """
+        import os
+
+        self.hub_api_url = (
+            hub_api_url or os.environ.get("JUPYTERHUB_API_URL", "")
+        ).rstrip("/")
+        self.api_token = api_token or os.environ.get("JUPYTERHUB_API_TOKEN", "")
+        self.write_groups = write_groups or ["catalog-managers"]
+
+        if not self.hub_api_url:
+            raise ValueError(
+                "JupyterHub API URL required. Set JUPYTERHUB_API_URL or pass hub_api_url."
+            )
+
+    async def authenticate(self, request: Request) -> User | None:
+        """Validate token against JupyterHub API.
+
+        Extracts the token from the Authorization header and validates it
+        against the Hub API to get user information.
+        """
+        import httpx
+
+        # Extract token from Authorization header
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer "):
+            token = auth_header[7:]
+        elif auth_header.startswith("token "):
+            token = auth_header[6:]
+        else:
+            # Also check for JupyterHub's cookie-based auth
+            token = request.cookies.get("jupyterhub-services")
+            if not token:
+                return None
+
+        # Validate token against Hub API
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(
+                    f"{self.hub_api_url}/user",
+                    headers={"Authorization": f"token {token}"},
+                    timeout=10,
+                )
+
+                if resp.status_code != 200:
+                    return None
+
+                user_info = resp.json()
+
+                return User(
+                    name=user_info.get("name", "unknown"),
+                    admin=user_info.get("admin", False),
+                    groups=user_info.get("groups", []),
+                    metadata={
+                        "kind": user_info.get("kind", "user"),
+                        "server": user_info.get("server"),
+                    },
+                )
+
+        except httpx.RequestError:
+            return None
+
+    def get_permissions(self, user: User, resource: str) -> set[str]:
+        """Return permissions based on Hub admin status or group membership.
+
+        Write/delete access is granted to:
+            - Hub admins
+            - Users in any of the configured write_groups
+        """
+        # Admins get full access
+        if user.admin:
+            return {"read", "write", "delete"}
+
+        # Check group membership for write access
+        user_groups = set(user.groups)
+        write_groups = set(self.write_groups)
+        if user_groups & write_groups:
+            return {"read", "write", "delete"}
+
+        # Default: read-only
+        return {"read"}
+
+
+# ---------------------------------------------------------------------------
+# FastAPI Dependency Injection Helpers
+# ---------------------------------------------------------------------------
+
+
+def create_auth_dependency(
+    authenticator: Authenticator,
+    resource: str,
+    action: str,
+) -> Callable:
+    """Create a FastAPI dependency for authentication and authorization.
+
+    Use this to create Depends() callables for route protection.
+
+    Example::
+
+        auth = APIKeyAuthenticator(api_keys={...})
+
+        # Create dependencies for different permission levels
+        require_read = create_auth_dependency(auth, "catalogs", "read")
+        require_write = create_auth_dependency(auth, "catalogs", "write")
+
+        @router.get("/catalogs")
+        async def list_catalogs(user: User = Depends(require_read)):
+            ...
+
+        @router.post("/catalogs")
+        async def add_catalog(body: CatalogCreate, user: User = Depends(require_write)):
+            ...
+
+    Args:
+        authenticator: The authenticator instance to use.
+        resource: Resource identifier (e.g., "catalogs", "items").
+        action: Required action (e.g., "read", "write", "delete").
+
+    Returns:
+        An async callable suitable for use with FastAPI Depends().
+    """
+
+    async def auth_dependency(request: Request) -> User:
+        """FastAPI dependency that authenticates and authorizes the request."""
+        # Check if this action requires authentication
+        if not authenticator.requires_auth(resource, action):
+            # Return anonymous user for public endpoints
+            return User(name="anonymous", admin=False)
+
+        # Authenticate the request
+        user = await authenticator.authenticate(request)
+        if user is None:
+            raise HTTPException(
+                status_code=401,
+                detail="Authentication required",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        # Check permissions
+        permissions = authenticator.get_permissions(user, resource)
+        if action not in permissions:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Permission denied: '{action}' on '{resource}'",
+            )
+
+        return user
+
+    return auth_dependency
+
+
+def create_optional_auth_dependency(authenticator: Authenticator) -> Callable:
+    """Create a FastAPI dependency that optionally authenticates.
+
+    Unlike create_auth_dependency, this does not raise errors if
+    authentication fails. Instead, it returns None for unauthenticated
+    requests. Useful for endpoints where authentication is optional
+    but provides additional features.
+
+    Example::
+
+        optional_auth = create_optional_auth_dependency(auth)
+
+        @router.get("/items")
+        async def list_items(user: User | None = Depends(optional_auth)):
+            if user and user.admin:
+                return all_items()  # Admins see everything
+            return public_items()  # Others see only public
+
+    Args:
+        authenticator: The authenticator instance to use.
+
+    Returns:
+        An async callable suitable for use with FastAPI Depends().
+    """
+
+    async def optional_auth_dependency(request: Request) -> User | None:
+        """FastAPI dependency that optionally authenticates the request."""
+        return await authenticator.authenticate(request)
+
+    return optional_auth_dependency
+
+
+class AuthDependencies:
+    """Container for pre-built auth dependencies.
+
+    Provides convenient access to common permission checks as
+    FastAPI Depends() callables.
+
+    Example::
+
+        auth_deps = AuthDependencies(my_authenticator)
+
+        @router.get("/catalogs")
+        async def list_catalogs(user: User = Depends(auth_deps.read_catalogs)):
+            ...
+
+        @router.post("/catalogs")
+        async def add_catalog(user: User = Depends(auth_deps.write_catalogs)):
+            ...
+    """
+
+    def __init__(self, authenticator: Authenticator) -> None:
+        """Initialize with an authenticator.
+
+        Args:
+            authenticator: The authenticator to use for all dependencies.
+        """
+        self.authenticator = authenticator
+
+        # Pre-build common dependencies
+        self.read_catalogs = create_auth_dependency(authenticator, "catalogs", "read")
+        self.write_catalogs = create_auth_dependency(authenticator, "catalogs", "write")
+        self.delete_catalogs = create_auth_dependency(
+            authenticator, "catalogs", "delete"
+        )
+
+        self.read_items = create_auth_dependency(authenticator, "items", "read")
+        self.write_items = create_auth_dependency(authenticator, "items", "write")
+
+        self.optional = create_optional_auth_dependency(authenticator)

--- a/src/esm_catalog/api/catalog_routes.py
+++ b/src/esm_catalog/api/catalog_routes.py
@@ -1,0 +1,305 @@
+"""Dynamic catalog management REST API routes.
+
+Provides CRUD endpoints for managing which catalogs are served by the API.
+Catalogs can be added, listed, updated, refreshed, and removed at runtime.
+
+Endpoints::
+
+    GET    /catalogs           - List all registered catalogs
+    GET    /catalogs/{id}      - Get single catalog info
+    POST   /catalogs           - Register a new catalog
+    PATCH  /catalogs/{id}      - Update catalog metadata
+    POST   /catalogs/{id}/refresh - Refresh catalog connection
+    DELETE /catalogs/{id}      - Unregister a catalog
+
+Example usage with curl::
+
+    # List catalogs
+    curl http://localhost:8000/catalogs
+
+    # Add a new catalog
+    curl -X POST http://localhost:8000/catalogs \\
+        -H "Content-Type: application/json" \\
+        -d '{"path": "/path/to/catalog.duckdb", "name": "Experiment 1"}'
+
+    # Update catalog metadata
+    curl -X PATCH http://localhost:8000/catalogs/abc123 \\
+        -H "Content-Type: application/json" \\
+        -d '{"name": "Experiment 1 (Updated)"}'
+
+    # Refresh after external modification
+    curl -X POST http://localhost:8000/catalogs/abc123/refresh
+
+    # Remove catalog
+    curl -X DELETE http://localhost:8000/catalogs/abc123
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from pydantic import BaseModel
+
+from loguru import logger
+
+from esm_catalog.api.registry import (
+    CatalogCreateRequest,
+    CatalogInfo,
+    CatalogRegistry,
+    CatalogUpdateRequest,
+)
+from esm_catalog.api.validation import ValidationError, validate_catalog_path
+
+if TYPE_CHECKING:
+    from esm_catalog.api.auth import Authenticator
+    from esm_catalog.api.cache import QueryablesCache
+    from esm_catalog.api.pool import CatalogPool
+
+
+class CatalogListResponse(BaseModel):
+    """Response for GET /catalogs."""
+
+    catalogs: list[CatalogInfo]
+    total: int
+
+
+class RefreshResponse(BaseModel):
+    """Response for POST /catalogs/{id}/refresh."""
+
+    id: str
+    path: str
+    refreshed: bool
+    message: str
+
+
+def create_catalog_router(
+    registry: CatalogRegistry,
+    pool: "CatalogPool",
+    authenticator: "Authenticator | None" = None,
+    queryables_cache: "QueryablesCache | None" = None,
+) -> APIRouter:
+    """Create the catalog management router with injected dependencies.
+
+    Args:
+        registry: Catalog registry instance.
+        pool: Connection pool for catalog access.
+        authenticator: Optional authenticator for access control.
+        queryables_cache: Optional queryables cache to invalidate on changes.
+
+    Returns:
+        FastAPI router with catalog CRUD endpoints.
+    """
+    router = APIRouter(prefix="/catalogs", tags=["Catalog Management"])
+
+    def _invalidate_caches() -> None:
+        """Invalidate queryables cache when catalog data changes."""
+        if queryables_cache is not None:
+            queryables_cache.invalidate()
+            logger.debug("Invalidated queryables cache due to catalog change")
+
+    async def _check_permission(
+        request: Request, action: str, raise_on_fail: bool = True
+    ) -> bool:
+        """Check if the current request has permission for the action.
+
+        Args:
+            request: HTTP request.
+            action: Action being performed (read, write, delete).
+            raise_on_fail: If True, raise HTTPException on failure.
+
+        Returns:
+            True if permitted.
+
+        Raises:
+            HTTPException: If authentication/authorization fails and raise_on_fail is True.
+        """
+        if authenticator is None:
+            return True
+
+        if not authenticator.requires_auth("catalogs", action):
+            return True
+
+        user = await authenticator.authenticate(request)
+        if user is None:
+            if raise_on_fail:
+                raise HTTPException(status_code=401, detail="Authentication required")
+            return False
+
+        permissions = authenticator.get_permissions(user, "catalogs")
+        if action not in permissions:
+            if raise_on_fail:
+                raise HTTPException(status_code=403, detail="Permission denied")
+            return False
+
+        return True
+
+    @router.get("", response_model=CatalogListResponse)
+    async def list_catalogs(request: Request) -> CatalogListResponse:
+        """List all registered catalogs with their current status.
+
+        Status is refreshed on each request to reflect whether the
+        catalog file currently exists on disk.
+        """
+        await _check_permission(request, "read")
+        catalogs = registry.list_catalogs()
+        return CatalogListResponse(catalogs=catalogs, total=len(catalogs))
+
+    @router.get("/{catalog_id}", response_model=CatalogInfo)
+    async def get_catalog(catalog_id: str, request: Request) -> CatalogInfo:
+        """Get a specific catalog by ID.
+
+        Returns the catalog metadata and current status.
+        """
+        await _check_permission(request, "read")
+        info = registry.get_catalog(catalog_id)
+        if info is None:
+            raise HTTPException(
+                status_code=404, detail=f"Catalog '{catalog_id}' not found"
+            )
+        return info
+
+    @router.post("", response_model=CatalogInfo, status_code=201)
+    async def add_catalog(
+        body: CatalogCreateRequest, request: Request
+    ) -> CatalogInfo:
+        """Register a new catalog to be served by the API.
+
+        The catalog file does not need to exist immediately; it will be
+        served once it becomes available. Status indicates whether the
+        file currently exists.
+
+        Request body:
+            - path: Path to the DuckDB catalog file (required)
+            - name: Human-readable name (optional, defaults to filename)
+            - description: Description text (optional)
+        """
+        await _check_permission(request, "write")
+        try:
+            # Validate and normalize the path
+            validated_path = validate_catalog_path(body.path)
+            # Update the request with the validated path
+            body_with_validated_path = CatalogCreateRequest(
+                path=validated_path,
+                name=body.name,
+                description=body.description,
+            )
+            result = registry.add_catalog(body_with_validated_path)
+            _invalidate_caches()
+            return result
+        except ValidationError as e:
+            logger.warning("Invalid catalog path: {}", e)
+            raise HTTPException(status_code=400, detail=str(e))
+        except ValueError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+
+    @router.patch("/{catalog_id}", response_model=CatalogInfo)
+    async def update_catalog(
+        catalog_id: str, body: CatalogUpdateRequest, request: Request
+    ) -> CatalogInfo:
+        """Update a catalog's metadata.
+
+        Any field can be updated independently. If the path is changed,
+        the old connection will be closed and a new one opened for the
+        new path.
+
+        Request body (all optional):
+            - path: New path to DuckDB file
+            - name: New human-readable name
+            - description: New description
+        """
+        await _check_permission(request, "write")
+
+        # Validate and normalize the path if provided
+        validated_body = body
+        if body.path is not None:
+            try:
+                validated_path = validate_catalog_path(body.path)
+                validated_body = CatalogUpdateRequest(
+                    path=validated_path,
+                    name=body.name,
+                    description=body.description,
+                )
+            except ValidationError as e:
+                logger.warning("Invalid catalog path: {}", e)
+                raise HTTPException(status_code=400, detail=str(e))
+
+        # If path is changing, close old connection first
+        if validated_body.path is not None:
+            old_path = registry.get_path(catalog_id)
+            if old_path and old_path != validated_body.path:
+                pool.close(old_path)
+
+        try:
+            info = registry.update_catalog(catalog_id, validated_body)
+        except ValueError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+
+        if info is None:
+            raise HTTPException(
+                status_code=404, detail=f"Catalog '{catalog_id}' not found"
+            )
+        _invalidate_caches()
+        return info
+
+    @router.post("/{catalog_id}/refresh", response_model=RefreshResponse)
+    async def refresh_catalog(catalog_id: str, request: Request) -> RefreshResponse:
+        """Force reconnection to a catalog file.
+
+        Use this when the underlying DuckDB file has been modified externally
+        (e.g., new items added via CLI scan) and you need the API to pick up
+        the changes.
+
+        This closes the pooled connection and invalidates the status cache;
+        the next query will open a fresh connection to the file.
+        """
+        await _check_permission(request, "write")
+
+        info = registry.get_catalog(catalog_id)
+        if info is None:
+            raise HTTPException(
+                status_code=404, detail=f"Catalog '{catalog_id}' not found"
+            )
+
+        # Close pooled connection and invalidate status cache
+        was_open = pool.close(info.path)
+        registry.invalidate_status(catalog_id)
+
+        if was_open:
+            message = "Connection closed; will reopen on next query"
+        else:
+            message = "No active connection; will open on next query"
+
+        _invalidate_caches()
+        return RefreshResponse(
+            id=catalog_id,
+            path=info.path,
+            refreshed=True,
+            message=message,
+        )
+
+    @router.delete("/{catalog_id}", status_code=204)
+    async def remove_catalog(catalog_id: str, request: Request) -> Response:
+        """Unregister a catalog from the API.
+
+        This does not delete the underlying DuckDB file; it only removes
+        it from the set of catalogs served by this API instance.
+
+        The pooled connection is closed if one exists.
+        """
+        await _check_permission(request, "delete")
+
+        # Close pooled connection first
+        info = registry.get_catalog(catalog_id)
+        if info:
+            pool.close(info.path)
+
+        if not registry.remove_catalog(catalog_id):
+            raise HTTPException(
+                status_code=404, detail=f"Catalog '{catalog_id}' not found"
+            )
+
+        _invalidate_caches()
+        return Response(status_code=204)
+
+    return router

--- a/tests/test_esm_catalog/test_api_federation.py
+++ b/tests/test_esm_catalog/test_api_federation.py
@@ -1,0 +1,197 @@
+"""Tests for catalog management (federation) API routes (PR-B4)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from fastapi.testclient import TestClient
+
+from esm_catalog.api.app import create_app
+from esm_catalog.storage.duckdb import persist_tree
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> Path:
+    out = tmp_path / "experiments" / "exp-alpha" / "outdata" / "echam"
+    out.mkdir(parents=True)
+    nc = out / "tas_200001.nc"
+    times = pd.date_range("2000-01-01", periods=1, freq="MS")
+    xr.Dataset(
+        {"tas": (("time", "lat", "lon"), np.zeros((1, 2, 2), dtype="float32"))},
+        coords={"time": times, "lat": [-45.0, 45.0], "lon": [0.0, 90.0]},
+    ).to_netcdf(nc)
+
+    from esm_catalog.scan.ingest import scan_tree
+
+    catalog = scan_tree(tmp_path)
+    db = tmp_path / "catalog.duckdb"
+    persist_tree(catalog, db)
+    return db
+
+
+@pytest.fixture()
+def api_client(db_path: Path) -> TestClient:
+    """Client with one pre-registered catalog."""
+    return TestClient(create_app(catalogs=[str(db_path)]).app)
+
+
+@pytest.fixture()
+def empty_client() -> TestClient:
+    """Client with no pre-registered catalogs."""
+    return TestClient(create_app(catalogs=[]).app)
+
+
+# ---------------------------------------------------------------------------
+# GET /catalogs
+# ---------------------------------------------------------------------------
+
+
+def test_list_catalogs_empty(empty_client: TestClient):
+    r = empty_client.get("/catalogs")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["catalogs"] == []
+    assert data["total"] == 0
+
+
+def test_list_catalogs_with_registered(api_client: TestClient):
+    r = api_client.get("/catalogs")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    assert len(data["catalogs"]) == 1
+    catalog = data["catalogs"][0]
+    assert "id" in catalog
+    assert "path" in catalog
+    assert "status" in catalog
+
+
+def test_list_catalogs_status_active_for_existing_file(api_client: TestClient):
+    catalogs = api_client.get("/catalogs").json()["catalogs"]
+    assert catalogs[0]["status"] == "active"
+
+
+# ---------------------------------------------------------------------------
+# GET /catalogs/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_catalog(api_client: TestClient):
+    catalog_id = api_client.get("/catalogs").json()["catalogs"][0]["id"]
+    r = api_client.get(f"/catalogs/{catalog_id}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == catalog_id
+    assert "path" in data
+
+
+def test_get_catalog_not_found(api_client: TestClient):
+    r = api_client.get("/catalogs/nonexistent")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /catalogs
+# ---------------------------------------------------------------------------
+
+
+def test_add_catalog(empty_client: TestClient, db_path: Path):
+    r = empty_client.post(
+        "/catalogs",
+        json={"path": str(db_path), "name": "Test Catalog"},
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert "id" in data
+    assert data["status"] == "active"
+    assert data["name"] == "Test Catalog"
+
+
+def test_add_catalog_duplicate_returns_409(empty_client: TestClient, db_path: Path):
+    empty_client.post("/catalogs", json={"path": str(db_path)})
+    r = empty_client.post("/catalogs", json={"path": str(db_path)})
+    assert r.status_code == 409
+
+
+def test_add_catalog_missing_file_is_allowed(empty_client: TestClient, tmp_path: Path):
+    nonexistent = str(tmp_path / "ghost.duckdb")
+    r = empty_client.post("/catalogs", json={"path": nonexistent})
+    assert r.status_code == 201
+    assert r.json()["status"] == "missing"
+
+
+def test_add_catalog_appears_in_list(empty_client: TestClient, db_path: Path):
+    empty_client.post("/catalogs", json={"path": str(db_path)})
+    data = empty_client.get("/catalogs").json()
+    assert data["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# PATCH /catalogs/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_update_catalog_name(api_client: TestClient):
+    catalog_id = api_client.get("/catalogs").json()["catalogs"][0]["id"]
+    r = api_client.patch(
+        f"/catalogs/{catalog_id}", json={"name": "Renamed Catalog"}
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "Renamed Catalog"
+
+
+def test_update_catalog_not_found(api_client: TestClient):
+    r = api_client.patch("/catalogs/nonexistent", json={"name": "X"})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /catalogs/{id}/refresh
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_catalog(api_client: TestClient):
+    catalog_id = api_client.get("/catalogs").json()["catalogs"][0]["id"]
+    r = api_client.post(f"/catalogs/{catalog_id}/refresh")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["refreshed"] is True
+    assert "message" in data
+    assert data["id"] == catalog_id
+
+
+def test_refresh_catalog_not_found(api_client: TestClient):
+    r = api_client.post("/catalogs/nonexistent/refresh")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /catalogs/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_catalog(api_client: TestClient):
+    catalog_id = api_client.get("/catalogs").json()["catalogs"][0]["id"]
+    r = api_client.delete(f"/catalogs/{catalog_id}")
+    assert r.status_code == 204
+
+
+def test_delete_catalog_removes_from_list(api_client: TestClient):
+    catalog_id = api_client.get("/catalogs").json()["catalogs"][0]["id"]
+    api_client.delete(f"/catalogs/{catalog_id}")
+    data = api_client.get("/catalogs").json()
+    assert data["total"] == 0
+
+
+def test_delete_catalog_not_found(api_client: TestClient):
+    r = api_client.delete("/catalogs/nonexistent")
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary


> **Provenance:** this implementation is substantially Paul Gierz's work, carried over from his `esm-tools-plus/simcat/pgierz-workbench` prototype branch (commits Mar–Apr 2026). This PR ports it, largely as-is, into the reviewable stack.

- Adds `auth.py`: `Authenticator` ABC + `NoAuthenticator` / `APIKeyAuthenticator` / `JupyterHubAuthenticator` implementations
- Adds `catalog_routes.py`: full CRUD for `/catalogs` (GET list, GET by ID, POST add, PATCH update, POST refresh, DELETE remove); auth-gated; invalidates queryables cache on mutations
- Wires `create_catalog_router(registry, pool, auth, queryables_cache)` into `create_app()`, which now accepts an optional `authenticator` parameter (defaults to `NoAuthenticator` / open access)
- 16 new tests covering every endpoint + edge cases (duplicate 409, missing 404, status `active`/`missing`)

## Test plan

- [ ] `pytest src/esm_catalog/tests/test_api_federation.py` — 16 tests
- [ ] `pytest src/esm_catalog/tests/` — 129 total tests green
- [ ] CI workflow `esm-catalog-tests` passes on Python 3.9 + 3.12

## Stack position

`release` → PR-0 → A1a → A1b-1 → A1b-2 → A2 → A3 → A4 → B1 → B2 → B3 → **B4 (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
