### PR TITLE
enable esm_master cli config options, to overrid config yamls

### DIFF
--- a/docs/esm_master.rst
+++ b/docs/esm_master.rst
@@ -82,3 +82,37 @@ It is possible that some models have special compile-time settings that need to 
                     SPECIAL_COMPILE_VAR: "compile_value"        
 
 See :ref:`esm_environment:ESM Environment` for more details on environment configuration options.
+
+CLI Configuration Overrides
+----------------------------
+
+``esm_master`` supports Spack-style ``key=value`` overrides directly on the command line, so you can
+change any configuration value without creating a YAML file::
+
+    $ esm_master install-awiesm-2.6.2 computer.mpi_implementation=openmpi_2026
+
+Keys use dot notation to address nested sections (``section.key``). Multiple overrides can be
+passed at once::
+
+    $ esm_master install-awiesm-2.6.2 computer.mpi_implementation=openmpi_2026 computer.fc=ifort
+
+Values are parsed as YAML scalars, so strings, integers, booleans, and ``null`` all work::
+
+    $ esm_master install-fesom-2.0 computer.omp_num_threads=4
+
+.. note::
+
+   Some configuration keys are themselves named with a dot (e.g. ``namelist.echam`` inside
+   ``add_namelist_changes``). In those cases, change the separator with ``--separator`` so the dot
+   in the key name is not interpreted as a level separator::
+
+      $ esm_master install-awiesm-2.6.2 --separator , general,some.dotted.key=value
+
+The overrides are applied after the target/model config is loaded but **before** ``choose_``
+blocks are resolved, so they are visible to ``choose_mpi_implementation`` and similar switch
+blocks in the machine and component configs.
+
+.. note::
+
+   This feature is only available for ``esm_master``. In ``esm_runscripts`` you always need
+   a runscript YAML so modifications to the config should always be done there.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.65.1
+current_version = 6.66.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.65.1",
+    version="6.66.0",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_calendar import *

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 
 from . import database

--- a/src/esm_master/cli.py
+++ b/src/esm_master/cli.py
@@ -98,7 +98,7 @@ def main():
         action="store_true",
     )
 
-    parsed_args = vars(parser.parse_args())
+    parsed_args = vars(parser.parse_intermixed_args())
     parsed_args["overrides"] = esm_parser.cli_overrides_to_dict(
         parsed_args["overrides"], separator=parsed_args["separator"]
     )

--- a/src/esm_master/cli.py
+++ b/src/esm_master/cli.py
@@ -4,6 +4,7 @@ import sys
 
 from loguru import logger
 
+import esm_parser
 from esm_motd import check_all_esm_packages
 
 # import logging
@@ -24,6 +25,26 @@ def main():
         nargs="?",
         type=str,
         help="name of the target (leave empty for full list of targets)",
+    )
+    parser.add_argument(
+        "overrides",
+        metavar="key=value",
+        nargs="*",
+        help=(
+            "Override configuration values, e.g. "
+            "'computer.mpi_implementation=openmpi_2026'. Keys are split on "
+            "--separator to address nested sections. Can be given multiple "
+            "times."
+        ),
+    )
+    parser.add_argument(
+        "--separator",
+        default=".",
+        help=(
+            "Character used to split nested keys in the 'key=value' "
+            "overrides (default: '.'). Use a different separator if a key "
+            "itself contains a literal dot, e.g. 'namelist.echam'."
+        ),
     )
     parser.add_argument(
         "--check",
@@ -76,6 +97,9 @@ def main():
     )
 
     parsed_args = vars(parser.parse_args())
+    parsed_args["overrides"] = esm_parser.cli_overrides_to_dict(
+        parsed_args["overrides"], separator=parsed_args["separator"]
+    )
 
     target = ""
     check = False

--- a/src/esm_master/cli.py
+++ b/src/esm_master/cli.py
@@ -1,4 +1,5 @@
 """Console script for esm_master."""
+
 import argparse
 import sys
 
@@ -43,7 +44,8 @@ def main():
         help=(
             "Character used to split nested keys in the 'key=value' "
             "overrides (default: '.'). Use a different separator if a key "
-            "itself contains a literal dot, e.g. 'namelist.echam'."
+            "itself contains a literal dot, e.g. --separator , "
+            "general,namelist.echam=value."
         ),
     )
     parser.add_argument(

--- a/src/esm_master/esm_master.py
+++ b/src/esm_master/esm_master.py
@@ -20,6 +20,7 @@ from .compile_info import setup_and_model_infos
 
 from .task import Task
 
+import esm_parser
 from esm_parser import yaml_dump
 
 def main_flow(parsed_args, target):
@@ -36,6 +37,13 @@ def main_flow(parsed_args, target):
 
     user_config["computer"] = user_config.get("computer", {})
     user_config["general"]["execution_mode"] = "compile"
+
+    # Apply Spack-style ``key=value`` CLI overrides (see ``cli.py``) before
+    # SimulationSetup resolves the ``choose_`` blocks, so that e.g.
+    # ``computer.mpi_implementation=openmpi_2026`` is visible to
+    # ``choose_mpi_implementation`` in the machine config.
+    if parsed_args.get("overrides"):
+        esm_parser.dict_merge(user_config, parsed_args["overrides"])
 
     # deniz: verbose is supposed to be a boolean right? It is initialized as
     # 0 in cli.py. Is it then a debug_level?

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 
 from .dict_to_yaml import *

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -792,6 +792,84 @@ def dict_merge(dct, merge_dct, resolve_nested_adds=False, **kwargs):
             dct[k] = merge_dct[k]
 
 
+def cli_overrides_to_dict(overrides, separator="."):
+    """
+    Converts a list of Spack-style ``key=value`` command line overrides into a
+    nested dictionary suitable for merging into a configuration with
+    ``dict_merge``.
+
+    Keys are split on ``separator`` to address nested sections, e.g. with the
+    default separator ``computer.mpi_implementation`` becomes
+    ``config["computer"]["mpi_implementation"]``. Some config keys are
+    themselves named with a literal dot (e.g. ``namelist.echam``, used inside
+    ``add_namelist_changes``/``remove_namelist_changes`` chapters); for those,
+    the caller should pick a different ``separator`` (e.g. ``"/"``) so that the
+    dot in the key name is not split on. Values are parsed with
+    ``yaml.safe_load`` so that booleans, numbers and lists are typed correctly
+    instead of remaining plain strings.
+
+    Every value is tagged with ``category: "command_line"`` provenance (the
+    same category used elsewhere in ``esm_master`` for values coming from the
+    command line, see ``esm_master.compile_info.split_raw_target``), so that
+    the existing hierarchy and conflict-resolution logic in
+    ``DictWithProvenance.__setitem__`` applies: a CLI override outranks values
+    from ``runscript``, ``couplings``, ``setups``, ``components``,
+    ``machines`` and ``defaults``, but not ``backend``-set values. Without
+    this tagging, a plain (provenance-less) value would silently overwrite
+    whatever it is merged into with no conflict checks, and would itself be
+    silently overwritable later on.
+
+    Parameters
+    ----------
+    overrides : list of str
+        Strings of the form ``key=value``, e.g.
+        ``"computer.mpi_implementation=openmpi_2026"``.
+    separator : str
+        The character used to separate nested keys (default ``"."``).
+
+    Returns
+    -------
+    esm_parser.DictWithProvenance
+        Nested dictionary representing the requested overrides, with
+        ``command_line`` provenance attached to every value.
+
+    Note
+    ----
+    Invalid override : esm_parser.user_error
+        If one of the ``overrides`` does not contain a ``=`` sign, this exits
+        the code with a ``esm_parser.user_error``.
+    """
+    result = {}
+    for override in overrides:
+        if "=" not in override:
+            user_error(
+                "Invalid override",
+                f"Invalid override ``{override}``, expected the form "
+                "``key=value`` (e.g. "
+                "``computer.mpi_implementation=openmpi_2026``).",
+            )
+        key, value = override.split("=", 1)
+        target = result
+        path = key.split(separator)
+        for part in path[:-1]:
+            target = target.setdefault(part, {})
+        target[path[-1]] = yaml.safe_load(value)
+
+    result = DictWithProvenance(result, {})
+    result.set_provenance(
+        Provenance(
+            {
+                "category": "command_line",
+                "subcategory": None,
+                "line": None,
+                "col": None,
+                "yaml_file": "command_line",
+            }
+        )
+    )
+    return result
+
+
 def deep_update(chapter, entries, config, blackdict={}):
     if "choose_" in chapter:
         chapter_with_no_add = chapter.replace("add_", "")

--- a/src/esm_parser/esm_parser.py
+++ b/src/esm_parser/esm_parser.py
@@ -849,11 +849,30 @@ def cli_overrides_to_dict(overrides, separator="."):
                 "``computer.mpi_implementation=openmpi_2026``).",
             )
         key, value = override.split("=", 1)
+        try:
+            parsed_value = yaml.safe_load(value)
+        except yaml.YAMLError as e:
+            user_error(
+                "Invalid override value",
+                f"Could not parse value ``{value}`` in override "
+                f"``{override}``: {e}",
+            )
         target = result
         path = key.split(separator)
-        for part in path[:-1]:
-            target = target.setdefault(part, {})
-        target[path[-1]] = yaml.safe_load(value)
+        for indx, part in enumerate(path):
+            existing = target.get(part)
+            if existing is not None and not isinstance(existing, dict):
+                current_path = separator.join(path[: indx + 1])
+                user_error(
+                    "Invalid override",
+                    f"Conflicting overrides: ``{override}`` and "
+                    f"``{current_path}={existing}`` both set values for the same key. "
+                    "Please, remove one of them.",
+                )
+            if indx == len(path) - 1:
+                target[part] = parsed_value
+            else:
+                target = target.setdefault(part, {})
 
     result = DictWithProvenance(result, {})
     result.set_provenance(

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.65.1"
+__version__ = "6.66.0"
 
 from .utils import *


### PR DESCRIPTION
Allows to run `esm_master <command>-<model>-<version> section.key=value` to override yaml file configurations.

This is particularly useful for switched like `computer.mpi_implementation`.

This is not needed in runscripts as the user has to provide a runscript.yaml anyway.

# TODOs

- [x] isort and black
- [x] docs
- [x] docstrings