### PR TITLE
feat(esm_catalog): PR-A1d — datacube STAC extension

### DIFF
--- a/.github/workflows/esm-catalog-tests.yml
+++ b/.github/workflows/esm-catalog-tests.yml
@@ -34,6 +34,6 @@ jobs:
           # with --no-deps and add only the deps it actually imports (plus a modern
           # pytest; the base pins pytest==7.1.2, which predates 3.12 support).
           pip install -e . --no-deps
-          pip install -U "pytest>=7.4" click loguru pystac shapely universal-pathlib
+          pip install -U "pytest>=7.4" click loguru pystac shapely universal-pathlib jsonschema
       - name: Run esm_catalog tests
         run: pytest tests/test_esm_catalog -v

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.66.0
+current_version = 6.66.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -126,6 +126,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/esm-tools/esm_tools",
-    version="6.66.0",
+    version="6.66.1",
     zip_safe=False,
 )

--- a/src/esm_archiving/__init__.py
+++ b/src/esm_archiving/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_archiving import (archive_mistral, check_tar_lists,
                             delete_original_data, determine_datestamp_location,

--- a/src/esm_calendar/__init__.py
+++ b/src/esm_calendar/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_calendar import *

--- a/src/esm_catalog/datacube.py
+++ b/src/esm_catalog/datacube.py
@@ -1,0 +1,68 @@
+"""Datacube STAC extension: cube:dimensions and cube:variables.
+
+Expected metadata shapes (the contract the file scanners must meet):
+
+    metadata["dimensions"]: dict mapping dimension name to a STAC datacube
+        Dimension Object, e.g.
+        {"time": {"type": "temporal", "extent": ["2000-01-01T00:00:00Z",
+                                                 "2000-12-31T00:00:00Z"]},
+         "lon": {"type": "spatial", "axis": "x", "extent": [-180.0, 180.0]}}
+
+    metadata["variables"]: list of dicts with keys
+        name (str, required — entries without it are skipped),
+        dimensions (list[str]), units (str), and any of
+        description / long_name / standard_name (str).
+
+The v2.2.0 schema requires cube:dimensions whenever the extension URL is
+declared, so the extension is a no-op unless dimensions are present.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from esm_catalog.registry import EXTENSION_URLS
+
+if TYPE_CHECKING:
+    import pystac
+
+
+def add_datacube_extension(item: "pystac.Item", metadata: dict) -> None:
+    """Inject datacube extension fields into *item* from *metadata*.
+
+    Sets item.properties["cube:dimensions"] (pass-through) and
+    item.properties["cube:variables"] (mapped), and appends the datacube
+    schema URL to item.stac_extensions (idempotent). No-op when *metadata*
+    carries no dimensions.
+    """
+    dims = metadata.get("dimensions", {})
+    if not dims:
+        return
+
+    item.properties["cube:dimensions"] = dims
+
+    cube_vars = _to_cube_variables(metadata.get("variables", []))
+    if cube_vars:
+        item.properties["cube:variables"] = cube_vars
+
+    url = EXTENSION_URLS["datacube"]
+    if url not in item.stac_extensions:
+        item.stac_extensions.append(url)
+
+
+def _to_cube_variables(variables: list) -> dict:
+    """Map scanner variable entries to datacube Variable Objects."""
+    cube_vars = {}
+    for v in variables:
+        name = v.get("name")
+        if not name:
+            continue
+        entry: dict = {"dimensions": v.get("dimensions", [])}
+        if "units" in v:
+            entry["unit"] = v["units"]
+        for key in ("description", "long_name", "standard_name"):
+            if key in v:
+                entry["description"] = v[key]
+                break
+        cube_vars[name] = entry
+    return cube_vars

--- a/src/esm_catalog/item.py
+++ b/src/esm_catalog/item.py
@@ -10,6 +10,8 @@ from typing import Union
 from pystac import Asset, Item, Link
 from upath import UPath
 
+from esm_catalog.datacube import add_datacube_extension
+
 
 def make_item(
     path: Union[Path, UPath, str],
@@ -57,6 +59,8 @@ def make_item(
             media_type="application/json",
         )
     )
+
+    add_datacube_extension(item, metadata)
 
     return item
 

--- a/src/esm_cleanup/__init__.py
+++ b/src/esm_cleanup/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"

--- a/src/esm_database/__init__.py
+++ b/src/esm_database/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"

--- a/src/esm_environment/__init__.py
+++ b/src/esm_environment/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_environment import *

--- a/src/esm_master/__init__.py
+++ b/src/esm_master/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 
 from . import database

--- a/src/esm_motd/__init__.py
+++ b/src/esm_motd/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_motd import *

--- a/src/esm_parser/__init__.py
+++ b/src/esm_parser/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 
 from .dict_to_yaml import *

--- a/src/esm_plugin_manager/__init__.py
+++ b/src/esm_plugin_manager/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi, Paul Gierz, Sebastian Wahl"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_plugin_manager import *

--- a/src/esm_profile/__init__.py
+++ b/src/esm_profile/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .esm_profile import *

--- a/src/esm_runscripts/__init__.py
+++ b/src/esm_runscripts/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Dirk Barbi"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .batch_system import *
 from .chunky_parts import *

--- a/src/esm_tests/__init__.py
+++ b/src/esm_tests/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Miguel Andres-Martinez"""
 __email__ = "miguel.andres-martinez@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .initialization import *
 from .read_shipped_data import *

--- a/src/esm_tools/__init__.py
+++ b/src/esm_tools/__init__.py
@@ -23,7 +23,7 @@ so it's just the dictionary representation of the YAML.
 
 __author__ = """Dirk Barbi, Paul Gierz"""
 __email__ = "dirk.barbi@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 import functools
 import inspect

--- a/src/esm_utilities/__init__.py
+++ b/src/esm_utilities/__init__.py
@@ -2,6 +2,6 @@
 
 __author__ = """Paul Gierz"""
 __email__ = "pgierz@awi.de"
-__version__ = "6.66.0"
+__version__ = "6.66.1"
 
 from .utils import *

--- a/tests/test_esm_catalog/schemas/datacube-v2.2.0.json
+++ b/tests/test_esm_catalog/schemas/datacube-v2.2.0.json
@@ -1,0 +1,622 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/datacube/v2.2.0/schema.json",
+  "title": "Datacube Extension",
+  "description": "STAC Datacube Extension for STAC Items and STAC Collections.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ],
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "properties"
+          ],
+          "properties": {
+            "properties": {
+              "allOf": [
+                {
+                  "$ref": "#/definitions/require_field"
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$comment": "This validates the fields in Item Assets.",
+          "required": [
+            "assets"
+          ],
+          "properties": {
+            "assets": {
+              "type": "object",
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/require_field"
+                      },
+                      {
+                        "$ref": "#/definitions/fields"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "type": "object",
+      "allOf": [
+        {
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ],
+      "anyOf": [
+        {
+          "$comment": "This is the schema for the top-level fields in a Collection.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/require_field"
+            },
+            {
+              "$ref": "#/definitions/fields"
+            }
+          ]
+        },
+        {
+          "$comment": "This validates the fields in Collection Assets.",
+          "required": [
+            "assets"
+          ],
+          "properties": {
+            "assets": {
+              "type": "object",
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/require_field"
+                      },
+                      {
+                        "$ref": "#/definitions/fields"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$comment": "This is the schema for the fields in Item Asset Definitions.",
+          "required": [
+            "item_assets"
+          ],
+          "properties": {
+            "item_assets": {
+              "type": "object",
+              "not": {
+                "additionalProperties": {
+                  "not": {
+                    "allOf": [
+                      {
+                        "$ref": "#/definitions/require_any_field"
+                      },
+                      {
+                        "$ref": "#/definitions/fields"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$comment": "This is the schema for the fields in Summaries. By default, only checks the existance of the properties, but not the schema of the summaries.",
+          "required": [
+            "summaries"
+          ],
+          "properties": {
+            "summaries": {
+              "$ref": "#/definitions/require_any_field"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "const": "https://stac-extensions.github.io/datacube/v2.2.0/schema.json"
+          }
+        }
+      }
+    },
+    "require_any_field": {
+      "$comment": "Please list all fields here so that we can force the existance of one of them in other parts of the schemas.",
+      "anyOf": [
+        {"required": ["cube:dimensions"]},
+        {"required": ["cube:variables"]}
+      ]
+    },
+    "require_field": {
+      "required": [
+        "cube:dimensions"
+      ]
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the corresponding schema.",
+      "type": "object",
+      "properties": {
+        "cube:dimensions": {
+          "$ref": "#/definitions/cube:dimensions"
+        },
+        "cube:variables": {
+          "$ref": "#/definitions/cube:variables"
+        }
+      },
+      "patternProperties": {
+        "^(?!cube:)": {}
+      },
+      "additionalProperties": false
+    },
+    "cube:dimensions": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/vector_dimension"
+          },
+          {
+            "$ref": "#/definitions/horizontal_spatial_dimension"
+          },
+          {
+            "$ref": "#/definitions/vertical_spatial_dimension"
+          },
+          {
+            "$ref": "#/definitions/temporal_dimension"
+          },
+          {
+            "$ref": "#/definitions/additional_dimension"
+          }
+        ]
+      }
+    },
+    "cube:variables": {
+      "type": "object",
+      "additionalProperties": {
+          "$ref": "#/definitions/variable"
+      }
+    },
+    "additional_dimension": {
+      "title": "Additional Dimension Object",
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "type",
+            "extent"
+          ]
+        },
+        {
+          "required": [
+            "type",
+            "values"
+          ]
+        }
+      ],
+      "not": {
+        "required": [
+          "axis"
+        ]
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "not": {
+            "enum": [
+              "spatial",
+              "geometry"
+            ]
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "extent": {
+          "$ref": "#/definitions/extent_open"
+        },
+        "values": {
+          "$ref": "#/definitions/values"
+        },
+        "step": {
+          "$ref": "#/definitions/step"
+        },
+        "unit": {
+          "$ref": "#/definitions/unit"
+        },
+        "reference_system": {
+          "type": "string"
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string"
+            ]
+          }
+        }
+      }
+    },
+    "horizontal_spatial_dimension": {
+      "title": "Horizontal Spatial Raster Dimension Object",
+      "type": "object",
+      "required": [
+        "type",
+        "axis",
+        "extent"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type_spatial"
+        },
+        "axis": {
+          "$ref": "#/definitions/axis_xy"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "extent": {
+          "$ref": "#/definitions/extent_closed"
+        },
+        "values": {
+          "$ref": "#/definitions/values_numeric"
+        },
+        "step": {
+          "$ref": "#/definitions/step"
+        },
+        "reference_system": {
+          "$ref": "#/definitions/reference_system_spatial"
+        }
+      }
+    },
+    "vertical_spatial_dimension": {
+      "title": "Vertical Spatial Dimension Object",
+      "type": "object",
+      "anyOf": [
+        {
+          "required": [
+            "type",
+            "axis",
+            "extent"
+          ]
+        },
+        {
+          "required": [
+            "type",
+            "axis",
+            "values"
+          ]
+        }
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/type_spatial"
+        },
+        "axis": {
+          "$ref": "#/definitions/axis_z"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "extent": {
+          "$ref": "#/definitions/extent_open"
+        },
+        "values": {
+          "$ref": "#/definitions/values"
+        },
+        "step": {
+          "$ref": "#/definitions/step"
+        },
+        "unit": {
+          "$ref": "#/definitions/unit"
+        },
+        "reference_system": {
+          "$ref": "#/definitions/reference_system_spatial"
+        }
+      }
+    },
+    "vector_dimension": {
+      "title": "Spatial Vector Dimension Object",
+      "type": "object",
+      "required": [
+        "type",
+        "bbox"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "geometry"
+        },
+        "axes": {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "x",
+              "y",
+              "z"
+            ]
+          }
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "bbox": {
+          "title": "Spatial extent",
+          "type": "array",
+          "oneOf": [
+            {
+              "minItems":4,
+              "maxItems":4
+            },
+            {
+              "minItems":6,
+              "maxItems":6
+            }
+          ],
+          "items": {
+            "type": "number"
+          }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "description": "WKT or Identifier",
+            "type": "string"
+          }
+        },
+        "geometry_types":  {
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "enum": [
+              "Point",
+              "MultiPoint",
+              "LineString",
+              "MultiLineString",
+              "Polygon",
+              "MultiPolygon",
+              "GeometryCollection"
+            ]
+          }
+        },
+        "reference_system": {
+          "$ref": "#/definitions/reference_system_spatial"
+        }
+      }
+    },
+    "temporal_dimension": {
+      "title": "Temporal Dimension Object",
+      "type": "object",
+      "required": [
+        "type",
+        "extent"
+      ],
+      "not": {
+        "required": [
+          "axis"
+        ]
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "temporal"
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "extent": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "step": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "variable": {
+      "title": "Variable Object",
+      "type": "object",
+      "required": [
+        "dimensions"
+      ],
+      "properties": {
+        "variable_type": {
+          "type": "string",
+          "enum": [
+            "data",
+            "auxiliary"
+          ]
+        },
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1
+        },
+        "extent": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": [
+              "string",
+              "number",
+              "null"
+            ]
+          }
+        },
+        "unit": {
+          "$ref": "#/definitions/unit"
+        }
+      }
+    },
+    "type_spatial": {
+      "type": "string",
+      "const": "spatial"
+    },
+    "axis_xy": {
+      "type": "string",
+      "enum": [
+        "x",
+        "y"
+      ]
+    },
+    "axis_z": {
+      "type": "string",
+      "const": "z"
+    },
+    "extent_closed": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": "number"
+      }
+    },
+    "extent_open": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": {
+        "type": [
+          "number",
+          "null"
+        ]
+      }
+    },
+    "values_numeric": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "number"
+      }
+    },
+    "values": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "type": "number"
+          },
+          {
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "step": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "unit": {
+      "type": "string"
+    },
+    "reference_system_spatial": {
+      "oneOf": [
+        {
+          "description": "WKT2",
+          "type": "string"
+        },
+        {
+          "description": "EPSG code",
+          "type": "integer",
+          "minimum": 0
+        },
+        {
+          "$ref": "https://proj.org/schemas/v0.4/projjson.schema.json"
+        }
+      ],
+      "default": 4326
+    },
+    "description": {
+      "type": "string"
+    }
+  }
+}

--- a/tests/test_esm_catalog/test_stac_datacube.py
+++ b/tests/test_esm_catalog/test_stac_datacube.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
+from pathlib import Path
 
+import pytest
 from pystac import Item
 
 from esm_catalog.context import CollectionContext
@@ -12,6 +15,7 @@ from esm_catalog.item import make_item
 from esm_catalog.registry import EXTENSION_URLS
 
 DATACUBE_URL = EXTENSION_URLS["datacube"]
+SCHEMA_PATH = Path(__file__).parent / "schemas" / "datacube-v2.2.0.json"
 
 
 def _bare_item():
@@ -141,3 +145,23 @@ def test_make_item_with_dims_applies_datacube(tmp_path):
     assert item.properties["cube:dimensions"] == _dims()
     assert item.properties["cube:variables"]["temp"]["unit"] == "K"
     assert DATACUBE_URL in item.stac_extensions
+
+
+def test_item_validates_against_datacube_schema(tmp_path):
+    jsonschema = pytest.importorskip("jsonschema")
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    meta = _metadata(
+        dimensions=_dims(),
+        variables=[
+            {
+                "name": "temp",
+                "units": "K",
+                "long_name": "air temperature",
+                "dimensions": ["time", "lat", "lon"],
+            }
+        ],
+    )
+    item_dict = make_item(f, meta, _ctx()).to_dict()
+    schema = json.loads(SCHEMA_PATH.read_text())
+    jsonschema.validate(instance=item_dict, schema=schema)

--- a/tests/test_esm_catalog/test_stac_datacube.py
+++ b/tests/test_esm_catalog/test_stac_datacube.py
@@ -77,9 +77,7 @@ def test_variable_mapping():
         {"name": "precip", "description": "explicit", "long_name": "ignored"},
         {"name": "u10", "standard_name": "eastward_wind"},
     ]
-    add_datacube_extension(
-        item, {"dimensions": _dims(), "variables": variables}
-    )
+    add_datacube_extension(item, {"dimensions": _dims(), "variables": variables})
     cube_vars = item.properties["cube:variables"]
     assert cube_vars["temp"] == {
         "dimensions": ["time", "lat", "lon"],
@@ -94,9 +92,7 @@ def test_variable_mapping():
 def test_variable_without_name_is_skipped():
     item = _bare_item()
     variables = [{"units": "K"}, {"name": "temp"}]
-    add_datacube_extension(
-        item, {"dimensions": _dims(), "variables": variables}
-    )
+    add_datacube_extension(item, {"dimensions": _dims(), "variables": variables})
     assert list(item.properties["cube:variables"]) == ["temp"]
 
 
@@ -138,9 +134,7 @@ def test_make_item_without_dims_has_no_datacube(tmp_path):
 def test_make_item_with_dims_applies_datacube(tmp_path):
     f = tmp_path / "temp.nc"
     f.write_bytes(b"x")
-    meta = _metadata(
-        dimensions=_dims(), variables=[{"name": "temp", "units": "K"}]
-    )
+    meta = _metadata(dimensions=_dims(), variables=[{"name": "temp", "units": "K"}])
     item = make_item(f, meta, _ctx())
     assert item.properties["cube:dimensions"] == _dims()
     assert item.properties["cube:variables"]["temp"]["unit"] == "K"
@@ -165,3 +159,11 @@ def test_item_validates_against_datacube_schema(tmp_path):
     item_dict = make_item(f, meta, _ctx()).to_dict()
     schema = json.loads(SCHEMA_PATH.read_text())
     jsonschema.validate(instance=item_dict, schema=schema)
+
+
+def test_all_nameless_variables_omit_cube_variables():
+    item = _bare_item()
+    add_datacube_extension(item, {"dimensions": _dims(), "variables": [{"units": "K"}]})
+    assert "cube:variables" not in item.properties
+    assert item.properties["cube:dimensions"] == _dims()
+    assert DATACUBE_URL in item.stac_extensions

--- a/tests/test_esm_catalog/test_stac_datacube.py
+++ b/tests/test_esm_catalog/test_stac_datacube.py
@@ -6,7 +6,9 @@ from datetime import datetime, timezone
 
 from pystac import Item
 
+from esm_catalog.context import CollectionContext
 from esm_catalog.datacube import add_datacube_extension
+from esm_catalog.item import make_item
 from esm_catalog.registry import EXTENSION_URLS
 
 DATACUBE_URL = EXTENSION_URLS["datacube"]
@@ -99,3 +101,43 @@ def test_url_appended_once():
     add_datacube_extension(item, {"dimensions": _dims()})
     add_datacube_extension(item, {"dimensions": _dims()})
     assert item.stac_extensions.count(DATACUBE_URL) == 1
+
+
+# --- wiring through make_item ---
+
+
+def _ctx():
+    return CollectionContext(
+        experiment_id="exp-alpha", component="echam", collection_id="exp-alpha"
+    )
+
+
+def _metadata(**kwargs):
+    base = {
+        "variable": "temp",
+        "format": "netcdf",
+        "datetime_start": datetime(2000, 1, 1, tzinfo=timezone.utc),
+        "datetime_end": datetime(2000, 1, 1, tzinfo=timezone.utc),
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_make_item_without_dims_has_no_datacube(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(), _ctx())
+    assert "cube:dimensions" not in item.properties
+    assert item.stac_extensions == []
+
+
+def test_make_item_with_dims_applies_datacube(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    meta = _metadata(
+        dimensions=_dims(), variables=[{"name": "temp", "units": "K"}]
+    )
+    item = make_item(f, meta, _ctx())
+    assert item.properties["cube:dimensions"] == _dims()
+    assert item.properties["cube:variables"]["temp"]["unit"] == "K"
+    assert DATACUBE_URL in item.stac_extensions

--- a/tests/test_esm_catalog/test_stac_datacube.py
+++ b/tests/test_esm_catalog/test_stac_datacube.py
@@ -1,0 +1,101 @@
+"""Tests for the datacube STAC extension."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from pystac import Item
+
+from esm_catalog.datacube import add_datacube_extension
+from esm_catalog.registry import EXTENSION_URLS
+
+DATACUBE_URL = EXTENSION_URLS["datacube"]
+
+
+def _bare_item():
+    return Item(
+        id="x",
+        geometry=None,
+        bbox=None,
+        datetime=datetime(2000, 1, 1, tzinfo=timezone.utc),
+        properties={},
+    )
+
+
+def _dims():
+    return {
+        "time": {
+            "type": "temporal",
+            "extent": ["2000-01-01T00:00:00Z", "2000-12-31T00:00:00Z"],
+        },
+        "lat": {"type": "spatial", "axis": "y", "extent": [-90.0, 90.0]},
+        "lon": {"type": "spatial", "axis": "x", "extent": [-180.0, 180.0]},
+    }
+
+
+def test_noop_without_dimensions_or_variables():
+    item = _bare_item()
+    add_datacube_extension(item, {})
+    assert "cube:dimensions" not in item.properties
+    assert "cube:variables" not in item.properties
+    assert item.stac_extensions == []
+
+
+def test_noop_with_variables_but_no_dimensions():
+    # v2.2.0 requires cube:dimensions whenever the extension is declared,
+    # so variables alone must not trigger it.
+    item = _bare_item()
+    add_datacube_extension(item, {"variables": [{"name": "temp"}]})
+    assert item.properties == {}
+    assert item.stac_extensions == []
+
+
+def test_dimensions_only():
+    item = _bare_item()
+    add_datacube_extension(item, {"dimensions": _dims()})
+    assert item.properties["cube:dimensions"] == _dims()
+    assert "cube:variables" not in item.properties
+    assert DATACUBE_URL in item.stac_extensions
+
+
+def test_variable_mapping():
+    item = _bare_item()
+    variables = [
+        {
+            "name": "temp",
+            "units": "K",
+            "long_name": "air temperature",
+            "standard_name": "air_temperature",
+            "dimensions": ["time", "lat", "lon"],
+        },
+        {"name": "precip", "description": "explicit", "long_name": "ignored"},
+        {"name": "u10", "standard_name": "eastward_wind"},
+    ]
+    add_datacube_extension(
+        item, {"dimensions": _dims(), "variables": variables}
+    )
+    cube_vars = item.properties["cube:variables"]
+    assert cube_vars["temp"] == {
+        "dimensions": ["time", "lat", "lon"],
+        "unit": "K",
+        "description": "air temperature",
+    }
+    assert cube_vars["precip"]["description"] == "explicit"
+    assert cube_vars["precip"]["dimensions"] == []
+    assert cube_vars["u10"]["description"] == "eastward_wind"
+
+
+def test_variable_without_name_is_skipped():
+    item = _bare_item()
+    variables = [{"units": "K"}, {"name": "temp"}]
+    add_datacube_extension(
+        item, {"dimensions": _dims(), "variables": variables}
+    )
+    assert list(item.properties["cube:variables"]) == ["temp"]
+
+
+def test_url_appended_once():
+    item = _bare_item()
+    add_datacube_extension(item, {"dimensions": _dims()})
+    add_datacube_extension(item, {"dimensions": _dims()})
+    assert item.stac_extensions.count(DATACUBE_URL) == 1


### PR DESCRIPTION
Adds PR-A1d — Datacube extension from the [plan](https://github.com/esm-tools/esm_tools/blob/22519379dc96e17e65d8d302c6d969375f0ec139/src/esm_catalog/PR-A1A-STAC-FOUNDATION-PLAN.md): `cube:dimensions` and `cube:variables` on items when the scan metadata carries them.

Two notes. The extension is applied as one self-contained `add_datacube_extension()` called from `make_item` — the single-seam shape from the #1506 discussion, so guard, URL, and properties can't drift apart. And it turns out the v2.2.0 schema requires `cube:dimensions` whenever the extension is declared, so variables-only metadata is a no-op; there's a test validating a full item against a vendored copy of the schema to keep us honest (the CI workflow gets `jsonschema` added for that).