### PR TITLE
test(esm_catalog): additional coverage for the #1504 core

### DIFF
--- a/tests/test_esm_catalog/test_context.py
+++ b/tests/test_esm_catalog/test_context.py
@@ -39,3 +39,25 @@ def test_production_context_requires_description():
             collection_id="exp-alpha",
             production=True,
         )
+
+
+def test_production_missing_both_fields_names_both():
+    with pytest.raises(ValueError, match="description, data_license"):
+        CollectionContext(
+            experiment_id="exp-alpha",
+            component="echam",
+            collection_id="exp-alpha",
+            production=True,
+        )
+
+
+def test_production_empty_string_counts_as_missing():
+    with pytest.raises(ValueError, match="description"):
+        CollectionContext(
+            experiment_id="exp-alpha",
+            component="echam",
+            collection_id="exp-alpha",
+            production=True,
+            description="",
+            data_license="CC-BY-4.0",
+        )

--- a/tests/test_esm_catalog/test_stac_collection.py
+++ b/tests/test_esm_catalog/test_stac_collection.py
@@ -55,3 +55,66 @@ def test_update_extent_expands_to_wider_range():
     update_extent(col, _item(dt2, bbox=[0, 0, 1, 1]))
     assert col.extent.temporal.intervals[0][0] == dt2
     assert col.extent.temporal.intervals[0][1] == dt1
+
+
+# --- collection metadata ---
+
+
+def test_collection_license_defaults_to_proprietary():
+    assert make_collection(_ctx()).license == "proprietary"
+
+
+def test_collection_license_from_context():
+    ctx = CollectionContext(
+        experiment_id="exp-alpha",
+        component="echam",
+        collection_id="exp-alpha",
+        data_license="CC-BY-4.0",
+    )
+    assert make_collection(ctx).license == "CC-BY-4.0"
+
+
+def test_collection_parent_link():
+    # pystac auto-adds a "root" link at construction, so search by rel.
+    col = make_collection(_ctx())
+    parent_links = [link for link in col.links if link.rel == "parent"]
+    assert len(parent_links) == 1
+    assert parent_links[0].target == "#exp-alpha"
+
+
+# --- spatial extent ---
+
+
+def test_spatial_extent_replaces_default_with_first_bbox():
+    col = make_collection(_ctx())
+    dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    update_extent(col, _item(dt, bbox=[0, 0, 10, 10]))
+    assert col.extent.spatial.bboxes == [[0, 0, 10, 10]]
+
+
+def test_spatial_extent_merges_second_bbox():
+    col = make_collection(_ctx())
+    dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    update_extent(col, _item(dt, bbox=[0, 0, 10, 10]))
+    update_extent(col, _item(dt, bbox=[-20, 5, 5, 30]))
+    assert col.extent.spatial.bboxes == [[-20, 0, 10, 30]]
+
+
+def test_item_without_bbox_leaves_spatial_untouched():
+    col = make_collection(_ctx())
+    dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    update_extent(col, _item(dt))
+    assert col.extent.spatial.bboxes == [[-180.0, -90.0, 180.0, 90.0]]
+
+
+# --- temporal extent ---
+
+
+def test_temporal_extent_not_shrunk_by_inner_item():
+    col = make_collection(_ctx())
+    dt_lo = datetime(1990, 1, 1, tzinfo=timezone.utc)
+    dt_hi = datetime(2010, 1, 1, tzinfo=timezone.utc)
+    dt_mid = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    update_extent(col, _item(dt_lo, bbox=[0, 0, 1, 1], dt_end=dt_hi))
+    update_extent(col, _item(dt_mid, bbox=[0, 0, 1, 1]))
+    assert col.extent.temporal.intervals[0] == [dt_lo, dt_hi]

--- a/tests/test_esm_catalog/test_stac_item.py
+++ b/tests/test_esm_catalog/test_stac_item.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
-from pystac import Item
+import pytest
+from pystac import Item, STACError
+from upath import UPath
 
 from esm_catalog.context import CollectionContext
-from esm_catalog.item import _to_href, make_item
+from esm_catalog.item import _make_id, _to_href, make_item
 
 
 def _ctx():
@@ -103,3 +106,102 @@ def test_item_time_range_sets_interval(tmp_path):
     assert item.datetime is None
     assert item.properties["start_datetime"] == "2000-01-01T00:00:00Z"
     assert item.properties["end_datetime"] == "2000-12-31T00:00:00Z"
+
+
+# --- edge cases: paths, datetimes, ids, properties ---
+
+
+def test_make_item_accepts_local_string_path(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(str(f), _metadata(), _ctx())
+    href = item.assets["data"].href
+    assert href.startswith("file://")
+    assert href.endswith("/temp.nc")
+
+
+def test_make_item_accepts_uri_string():
+    uri = "ssh://hpc.example.org/data/temp.nc"
+    item = make_item(uri, _metadata(), _ctx())
+    assert item.assets["data"].href == uri
+
+
+def test_naive_datetimes_normalized_to_utc(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    meta = _metadata(
+        datetime_start=datetime(2000, 1, 1), datetime_end=datetime(2000, 1, 1)
+    )
+    item = make_item(f, meta, _ctx())
+    assert item.datetime == datetime(2000, 1, 1, tzinfo=timezone.utc)
+    assert item.datetime.tzinfo is not None
+
+
+def test_open_ended_range_keeps_datetime(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(datetime_end=None), _ctx())
+    assert item.datetime == datetime(2000, 1, 1, tzinfo=timezone.utc)
+    assert item.common_metadata.end_datetime is None
+
+
+def test_missing_datetimes_raise(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    meta = _metadata(datetime_start=None, datetime_end=None)
+    with pytest.raises(STACError):
+        make_item(f, meta, _ctx())
+
+
+def test_output_frequency_property(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    with_freq = make_item(f, _metadata(output_frequency="mon"), _ctx())
+    without = make_item(f, _metadata(), _ctx())
+    assert with_freq.properties["output_frequency"] == "mon"
+    assert "output_frequency" not in without.properties
+
+
+def test_multiple_variables_listed(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    variables = [{"name": "temp"}, {"name": "prec"}, {"name": "unknown"}, {}]
+    item = make_item(f, _metadata(variables=variables), _ctx())
+    assert item.properties["variables"] == ["temp", "prec"]
+
+
+def test_single_variable_no_variables_key(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(variables=[{"name": "temp"}]), _ctx())
+    assert "variables" not in item.properties
+
+
+def test_item_id_format(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(), _ctx())
+    assert re.fullmatch(r"temp\.echam\.000000\.[0-9a-f]{6}", item.id)
+
+
+def test_item_id_distinct_for_different_paths(tmp_path):
+    f1 = tmp_path / "a" / "temp.nc"
+    f2 = tmp_path / "b" / "temp.nc"
+    for f in (f1, f2):
+        f.parent.mkdir()
+        f.write_bytes(b"x")
+    id1 = make_item(f1, _metadata(), _ctx()).id
+    id2 = make_item(f2, _metadata(), _ctx()).id
+    assert id1 != id2
+
+
+def test_grib_media_type(tmp_path):
+    f = tmp_path / "temp.grb"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(format="grib"), _ctx())
+    assert item.assets["data"].media_type == "application/x-grib2"
+
+
+def test_to_href_bucket_protocol_uri():
+    p = UPath("memory://experiments/data/temp.nc")
+    assert _to_href(p) == "memory://experiments/data/temp.nc"

--- a/tests/test_esm_catalog/test_stac_item.py
+++ b/tests/test_esm_catalog/test_stac_item.py
@@ -10,7 +10,7 @@ from pystac import Item, STACError
 from upath import UPath
 
 from esm_catalog.context import CollectionContext
-from esm_catalog.item import _make_id, _to_href, make_item
+from esm_catalog.item import _to_href, make_item
 
 
 def _ctx():
@@ -205,3 +205,19 @@ def test_grib_media_type(tmp_path):
 def test_to_href_bucket_protocol_uri():
     p = UPath("memory://experiments/data/temp.nc")
     assert _to_href(p) == "memory://experiments/data/temp.nc"
+
+
+def test_item_id_defaults_to_unknown_variable(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    meta = _metadata()
+    del meta["variable"]
+    item = make_item(f, meta, _ctx())
+    assert re.fullmatch(r"unknown\.echam\.000000\.[0-9a-f]{6}", item.id)
+
+
+def test_netcdf_media_type_default(tmp_path):
+    f = tmp_path / "temp.nc"
+    f.write_bytes(b"x")
+    item = make_item(f, _metadata(), _ctx())
+    assert item.assets["data"].media_type == "application/x-netcdf"


### PR DESCRIPTION
The extra test coverage for #1504 we agreed on in Webex. Covers make_item edge cases (string/URI path inputs, naive-datetime normalization to UTC, open-ended ranges, the missing-datetime contract, item-id format and path-hash collision guard, media-type selection, variables/output_frequency filtering), collection extent behavior (first-bbox sentinel replacement, min/max merging, monotonic temporal growth), and production-context validation edges. Tests only, no source changes — 17 → 40 core tests.

One observation from probing (not enshrined in a test): an open-ended time range currently emits `start_datetime` without `end_datetime`, which the STAC spec recommends against. Happy to file it separately if you think it's worth tightening.