### PR TITLE
feat(esm_catalog): CLI entry point and command scaffold

### DIFF
--- a/.github/workflows/esm-catalog-tests.yml
+++ b/.github/workflows/esm-catalog-tests.yml
@@ -37,7 +37,7 @@ jobs:
           # pytest; the base pins pytest==7.1.2, which predates 3.12 support).
           pip install -e . --no-deps
           # setuptools<81 still bundles pkg_resources (removed in 81), which esm_tools imports.
-          pip install -U "pytest>=7.4" click loguru pystac shapely universal-pathlib jsonschema \
+          pip install -U "pytest>=7.4" "rich-click>=1.7" loguru pystac shapely universal-pathlib jsonschema \
             "setuptools<81" pyyaml colorama f90nml "pydantic>=2" typing_extensions \
             "paleodatetime @ git+https://github.com/pgierz/paleodatetime.git"
       - name: Run esm_catalog tests

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
             "f90nml>=1.4",
             "jsonschema>=4.0",
             "pydantic>=2",
+            "rich-click>=1.7",
         ],
     },
     install_requires=requirements,

--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -1,20 +1,101 @@
 """esm-catalog command-line interface.
 
-A scaffold group carrying only ``--version`` for now; the scan/serve
-subcommands are not yet registered.
+Workflow for one experiment::
+
+    esm-catalog auth login https://stac.awi.de   # once; token cached locally
+    esm-catalog init  <exp_root>                 # set up <exp_root>/catalog/
+    esm-catalog scan                             # write stac-geoparquet shards
+    esm-catalog push                             # ship new shards -> pgstac
+
+On disk, ``<exp_root>/catalog/`` holds the catalog PFS-friendly: one
+``collection.json`` plus sharded stac-geoparquet (a handful of files, never one
+JSON per item), and an ``esm-catalog.json`` workspace-state file (server,
+catalog id, which shards are already pushed). ``push`` bulk-loads new shards into
+the server's pgstac, which stac-fastapi-pgstac then serves to the web viewer.
 """
 
 from __future__ import annotations
 
-import click
+from pathlib import Path
+
+import rich_click as click
 
 from esm_catalog import __version__
+
+
+def _not_implemented(command: str) -> None:
+    """Fail cleanly: *command* is scaffolded but its logic is not written yet."""
+    raise click.ClickException(f"'{command}' is not implemented yet.")
 
 
 @click.group()
 @click.version_option(version=__version__, prog_name="esm-catalog")
 def main() -> None:
     """ESM-Tools simulation catalog."""
+
+
+@main.group()
+def auth() -> None:
+    """Authenticate against a STAC server (token cached locally)."""
+
+
+@auth.command("login")
+@click.argument("server_url")
+def auth_login(server_url: str) -> None:
+    """Log in to SERVER_URL and cache a token for later push."""
+    _not_implemented("auth login")
+
+
+@auth.command("logout")
+def auth_logout() -> None:
+    """Discard the cached token."""
+    _not_implemented("auth logout")
+
+
+@main.command()
+@click.argument("exp_root", type=click.Path(file_okay=False, path_type=Path))
+@click.option("--server", help="Target STAC server, recorded for later push.")
+def init(exp_root: Path, server: str | None) -> None:
+    """Set up <EXP_ROOT>/catalog/ (collection.json + workspace state)."""
+    _not_implemented("init")
+
+
+@main.command()
+@click.option(
+    "--exp-root",
+    type=click.Path(file_okay=False, path_type=Path),
+    help="Experiment root; defaults to the inited workspace.",
+)
+def scan(exp_root: Path | None) -> None:
+    """Walk the experiment and write stac-geoparquet item shards."""
+    _not_implemented("scan")
+
+
+@main.command()
+def push() -> None:
+    """Ship not-yet-pushed shards to the server's pgstac."""
+    _not_implemented("push")
+
+
+@main.command()
+@click.argument("file", type=click.Path(path_type=Path))
+def add(file: Path) -> None:
+    """Add one file's Item to the current shard."""
+    _not_implemented("add")
+
+
+@main.command()
+@click.argument("file", type=click.Path(path_type=Path))
+def rm(file: Path) -> None:
+    """Remove one file's Item from the catalog."""
+    _not_implemented("rm")
+
+
+@main.command()
+@click.argument("target")
+def edit(target: str) -> None:
+    """Edit a Collection's or Item's metadata (TARGET)."""
+    _not_implemented("edit")
 
 
 if __name__ == "__main__":

--- a/tests/test_esm_catalog/test_cli.py
+++ b/tests/test_esm_catalog/test_cli.py
@@ -1,0 +1,44 @@
+"""CLI scaffold tests: every command is registered and shows help, and the
+not-yet-implemented stubs return an error. Per-command behavior is tested as
+each command is built.
+"""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from esm_catalog.cli import main
+
+
+def test_help_lists_all_commands():
+    result = CliRunner().invoke(main, ["--help"])
+    assert result.exit_code == 0
+    for command in ("auth", "init", "scan", "push", "add", "rm", "edit"):
+        assert command in result.output
+
+
+def test_auth_subcommands_registered():
+    result = CliRunner().invoke(main, ["auth", "--help"])
+    assert result.exit_code == 0
+    assert "login" in result.output
+    assert "logout" in result.output
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["auth", "login", "https://stac.awi.de"],
+        ["auth", "logout"],
+        ["init", "/tmp/exp"],
+        ["scan"],
+        ["push"],
+        ["add", "/tmp/f.nc"],
+        ["rm", "/tmp/f.nc"],
+        ["edit", "collection"],
+    ],
+)
+def test_stub_commands_report_not_implemented(argv):
+    result = CliRunner().invoke(main, argv)
+    assert result.exit_code != 0
+    assert "not implemented" in result.output

--- a/tests/test_esm_catalog/test_cli.py
+++ b/tests/test_esm_catalog/test_cli.py
@@ -11,15 +11,20 @@ from click.testing import CliRunner
 from esm_catalog.cli import main
 
 
-def test_help_lists_all_commands():
-    result = CliRunner().invoke(main, ["--help"])
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def test_help_lists_all_commands(runner):
+    result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
     for command in ("auth", "init", "scan", "push", "add", "rm", "edit"):
         assert command in result.output
 
 
-def test_auth_subcommands_registered():
-    result = CliRunner().invoke(main, ["auth", "--help"])
+def test_auth_subcommands_registered(runner):
+    result = runner.invoke(main, ["auth", "--help"])
     assert result.exit_code == 0
     assert "login" in result.output
     assert "logout" in result.output
@@ -38,7 +43,7 @@ def test_auth_subcommands_registered():
         ["edit", "collection"],
     ],
 )
-def test_stub_commands_report_not_implemented(argv):
-    result = CliRunner().invoke(main, argv)
+def test_stub_commands_report_not_implemented(runner, argv):
+    result = runner.invoke(main, argv)
     assert result.exit_code != 0
     assert "not implemented" in result.output


### PR DESCRIPTION
Adds the `esm-catalog` command-line entry point
(`esm-catalog = esm_catalog.cli:main`) and a click command scaffold. Most
commands are stubs that raise "not implemented"; implementations land in
follow-up PRs.

Commands:
- `esm-catalog auth login` / `auth logout`
- `esm-catalog init`
- `esm-catalog scan`
- `esm-catalog push`
- `esm-catalog add` / `rm`
- `esm-catalog edit`

Tests: tests/test_esm_catalog/test_cli.py (10).

Stack: base of the catalog CLI series. esm-catalog/cli-scan implements `scan`
on top of this branch and targets it, not release.

Refs: #1530
