### PR TITLE
scan: reader framework

### DIFF
--- a/src/esm_catalog/_compat.py
+++ b/src/esm_catalog/_compat.py
@@ -1,0 +1,20 @@
+"""Small compatibility shims for the Python version range esm_catalog targets."""
+
+from __future__ import annotations
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:  # pragma: no cover - py<3.11 fallback
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        __str__ = str.__str__
+
+        @staticmethod
+        def _generate_next_value_(name, start, count, last_values):
+            return name.lower()  # matches enum.StrEnum: auto() -> lowercase member name
+
+
+__all__ = ["StrEnum"]

--- a/src/esm_catalog/scan/format.py
+++ b/src/esm_catalog/scan/format.py
@@ -1,0 +1,85 @@
+"""File-format detection for the scan layer.
+
+A file's format is resolved by extension first, then a magic-byte sniff — so
+extension-less ESM model output (ECHAM/FESOM write files like ``expid_200001.01``)
+is still recognised. The returned ``FileFormat`` selects the reader (see
+``reader.py``); detection never opens the file with a heavy library.
+"""
+
+from __future__ import annotations
+
+from enum import auto
+
+from upath import UPath
+
+from esm_catalog._compat import StrEnum
+
+
+class FileFormat(StrEnum):
+    """A scannable file format, as resolved by :func:`detect`."""
+
+    netcdf = auto()
+    grib = auto()
+
+
+class UnknownFormatError(ValueError):
+    """Raised when a path matches no known format by extension or magic bytes."""
+
+
+_NETCDF_SUFFIXES = frozenset({".nc", ".nc4", ".cdf", ".netcdf"})
+"""Filename suffixes that unambiguously mean NetCDF."""
+
+_GRIB_SUFFIXES = frozenset({".grb", ".grb2", ".grib", ".grib2"})
+"""Filename suffixes that unambiguously mean GRIB."""
+
+_GRIB_MAGIC = b"GRIB"
+"""GRIB1/GRIB2 signature at offset 0."""
+
+_HDF5_MAGIC = b"\x89HDF"
+"""NetCDF-4 / HDF5 signature at offset 0."""
+
+_CDF_MAGIC = b"CDF"
+"""Classic NetCDF signature (CDF\\x01 / \\x02 / \\x05) at offset 0."""
+
+
+def detect(path: UPath) -> FileFormat:
+    """Resolve the :class:`FileFormat` of *path*.
+
+    Extension is tried first (cheap, and authoritative when present); otherwise
+    the first four bytes are sniffed, which catches the extension-less files ESM
+    models emit.
+
+    Parameters
+    ----------
+    path : UPath
+        The file to identify (local or remote).
+
+    Returns
+    -------
+    FileFormat
+        The detected format.
+
+    Raises
+    ------
+    UnknownFormatError
+        If neither extension nor magic bytes identify a known format.
+    """
+    suffix = path.suffix.lower()
+    if suffix in _NETCDF_SUFFIXES:
+        return FileFormat.netcdf
+    if suffix in _GRIB_SUFFIXES:
+        return FileFormat.grib
+    return _sniff(path)
+
+
+def _sniff(path: UPath) -> FileFormat:
+    """Identify *path* by its first four magic bytes."""
+    with path.open("rb") as handle:
+        head = handle.read(4)
+    if head.startswith(_GRIB_MAGIC):
+        return FileFormat.grib
+    if head.startswith(_HDF5_MAGIC) or head.startswith(_CDF_MAGIC):
+        return FileFormat.netcdf
+    raise UnknownFormatError(
+        f"{path}: no known format (extension {path.suffix!r}, magic {head!r})."
+    )

--- a/src/esm_catalog/scan/reader.py
+++ b/src/esm_catalog/scan/reader.py
@@ -1,0 +1,81 @@
+"""The pluggable reader registry: :class:`FileFormat` -> :class:`Reader`.
+
+A ``Reader`` extracts :class:`~esm_catalog.types.FileMetadata` from one file of a
+given format. Readers register themselves for a format, so the scan core
+dispatches by format without importing any concrete reader — adding a format is
+adding a reader plus a ``register`` call, never an edit to the core.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from loguru import logger
+from upath import UPath
+
+from esm_catalog.scan.format import FileFormat
+from esm_catalog.types import FileMetadata
+
+
+class UnsupportedContentError(Exception):
+    """A file whose format is recognised but whose content a reader cannot handle
+    in the current context -- e.g. NetCDF-3 classic reached over a remote stream,
+    which the HDF5-only backend cannot open (and which is too large to fetch
+    whole). Treated as a clean skip (unsupported), never a read failure; a local
+    scan of the same file, read through the default engine, catalogues it.
+    """
+
+
+@runtime_checkable
+class Reader(Protocol):
+    """Extracts :class:`~esm_catalog.types.FileMetadata` from one file.
+
+    Attributes
+    ----------
+    supports_remote : bool
+        Whether the reader can read a non-local path (a ``UPath`` whose protocol
+        is not ``file``). The walk routes remote paths only to readers that
+        declare ``True``; a local-only reader (e.g. one shelling out to a native
+        library) declares ``False``.
+    """
+
+    supports_remote: bool
+
+    def read(self, path: UPath) -> FileMetadata:
+        """Read *path* and return its scanned metadata."""
+        ...
+
+
+READERS: dict[FileFormat, Reader] = {}
+"""The format -> reader registry; populated by :func:`register` at import time."""
+
+
+def register(file_format: FileFormat, reader: Reader) -> None:
+    """Register *reader* as the handler for *file_format*.
+
+    Warns if a reader was already registered for *file_format*: a silent override
+    almost always means two modules claiming the same format by accident.
+    """
+    if file_format in READERS:
+        logger.warning(
+            "reader for {} overridden: {} replaces {}",
+            file_format,
+            type(reader).__name__,
+            type(READERS[file_format]).__name__,
+        )
+    READERS[file_format] = reader
+
+
+def reader_for(file_format: FileFormat) -> Reader:
+    """Return the registered :class:`Reader` for *file_format*.
+
+    Raises
+    ------
+    LookupError
+        If no reader is registered — the format is detectable but unhandled
+        (e.g. GRIB before its reader ships).
+    """
+    try:
+        return READERS[file_format]
+    except KeyError:
+        raise LookupError(f"no reader registered for format '{file_format}'") from None


### PR DESCRIPTION
Add the file-reader framework: the Reader protocol, registry, and format detection.