### PR TITLE
chore: consolidate StrEnum shim, Optional annotations, style doc

### DIFF
--- a/src/esm_catalog/paleo.py
+++ b/src/esm_catalog/paleo.py
@@ -27,6 +27,8 @@ The values come from the ``general.paleo`` config section (see
 
 from __future__ import annotations
 
+from typing import Optional
+
 import pystac
 from typing_extensions import TypedDict  # pydantic needs this flavor as a model field
 
@@ -59,7 +61,7 @@ class PaleoConfig(TypedDict, total=False):
 _KEYS = tuple(PaleoConfig.__annotations__)
 
 
-def _to_paleo_props(paleo_config: PaleoConfig | None) -> dict:
+def _to_paleo_props(paleo_config: Optional[PaleoConfig]) -> dict:
     """Return the ``paleo:*`` fields set by *paleo_config*.
 
     Parameters
@@ -78,7 +80,7 @@ def _to_paleo_props(paleo_config: PaleoConfig | None) -> dict:
 
 
 def add_paleo_item_extension(
-    item: pystac.Item, paleo_config: PaleoConfig | None = None
+    item: pystac.Item, paleo_config: Optional[PaleoConfig] = None
 ) -> None:
     """Set the ``paleo:*`` geological time on *item* from *paleo_config*.
 
@@ -99,7 +101,7 @@ def add_paleo_item_extension(
 
 
 def add_paleo_collection_extension(
-    collection: pystac.Collection, paleo_config: PaleoConfig | None = None
+    collection: pystac.Collection, paleo_config: Optional[PaleoConfig] = None
 ) -> None:
     """Summarize the ``paleo:*`` geological time on *collection* from *paleo_config*.
 

--- a/src/esm_catalog/registry.py
+++ b/src/esm_catalog/registry.py
@@ -1,25 +1,15 @@
 """Extension registry — the single source of truth for STAC extensions.
 
-`Extension` is a StrEnum of every extension esm_catalog can attach; EXTENSION_URLS
+``Extension`` is a StrEnum of every extension esm_catalog can attach; EXTENSION_URLS
 is keyed by it, so a schema URL can never reference a name the type system does
 not know, and every call site is checked against the enum rather than a bare str.
 """
 
 from __future__ import annotations
 
-import sys
-from enum import Enum, auto
+from enum import auto
 
-if sys.version_info >= (3, 11):
-    from enum import StrEnum
-else:  # pragma: no cover - py<3.11 fallback
-
-    class StrEnum(str, Enum):
-        __str__ = str.__str__
-
-        @staticmethod
-        def _generate_next_value_(name, start, count, last_values):
-            return name.lower()  # matches enum.StrEnum: auto() -> the member name
+from esm_catalog._compat import StrEnum
 
 
 class Extension(StrEnum):


### PR DESCRIPTION
Move the StrEnum shim into _compat, switch remaining annotations to Optional[...], and add the esm_catalog style doc.