### PR TITLE
Fix XIOS config for Fesom

### DIFF
--- a/namelists/fesom2/xios_xml/field_def_fesom.xml
+++ b/namelists/fesom2/xios_xml/field_def_fesom.xml
@@ -1,4 +1,4 @@
-<field_definition level="1" prec="4" enabled="true" operation="average" default_value="9.969209968386869e+36">
+<field_definition level="1" prec="4" enabled="true" operation="average" default_value="9.969209968386869e+36" detect_missing_value="true">
 
   <!-- Minimal FESOM-2 field definition: mirrors the 28 variables requested by
        the upstream default config/namelist.io on FESOM/fesom2:main (otracers

--- a/namelists/fesom2/xios_xml_cmip7/field_def_fesom.xml
+++ b/namelists/fesom2/xios_xml_cmip7/field_def_fesom.xml
@@ -1,4 +1,4 @@
-<field_definition level="1" prec="4" enabled="true" operation="average" default_value="9.969209968386869e+36">
+<field_definition level="1" prec="4" enabled="true" operation="average" default_value="9.969209968386869e+36" detect_missing_value="true">
 
   <!-- 2D fields on NODES -->
   <field_group id="fesom_2d_nod" grid_ref="grid_2d_nod" prec="4">


### PR DESCRIPTION
This PR fixes XIOS configuration for Fesom output.

It fixes the way missing values are treated by XIOS, if there are any. E.g. during regridding. If not set (default is false), missing values that have been set to have a certain fill value (e.g. 9.96921e+36) are treated as a real values, and not as missing values and will enter the data set during regridding calculations.
For Fesom this is more of an issue for 3D fields that treat values under the seafloor by filling in fillvalues. If following calculations are not aware of that 9.96921e+36 is a fill value, they will treat this as a real value.

Tested with a 1 year run. 
- It won't change output on native grid
- It fixed regridded output (`regrid_surface_output: true`)
- The error that this flag removes is more relevant for 3D variables and increases with depth.