### PR TITLE
esm-catalog/fix-1562-component-relpath

### DIFF
--- a/configs/stac-extensions/namelist/v1.0.0/schema.json
+++ b/configs/stac-extensions/namelist/v1.0.0/schema.json
@@ -25,7 +25,7 @@
   },
   "oneOf": [
     {
-      "$comment": "Item: nml:{component}:{file}:{group}:{key} live in properties.",
+      "$comment": "Item: nml__{component}__{file}__{group}__{key} live in properties.",
       "type": "object",
       "required": [
         "type",
@@ -69,11 +69,11 @@
         },
         "nml:parameters": {
           "title": "Flattened namelist parameters",
-          "description": "Maps 'component:file:group:key' to the parameter's value (a repeated group is indexed as 'group[N]'), for CQL2 filtering. Component-qualified so two components sharing a filename cannot collide.",
+          "description": "Maps 'component__file__group__key' to the parameter's value (a repeated group is indexed as 'group_N'), for CQL2 filtering. Component-qualified so two components sharing a filename cannot collide. Keys are JSON-path-safe (only [A-Za-z0-9_]) so pgstac can filter them without queryables registration.",
           "type": "object",
           "propertyNames": {
-            "$comment": "Exactly four colon-separated, non-empty segments: component:file:group:key. Assumes colon-free components and filenames (basenames such as 'namelist.echam').",
-            "pattern": "^[^:]+:[^:]+:[^:]+:[^:]+$"
+            "$comment": "A flattened key: word characters and the '__' segment separator only; every other character in a segment is sanitised to '_'.",
+            "pattern": "^[A-Za-z0-9_]+$"
           },
           "additionalProperties": {
             "$ref": "#/definitions/queryable_value"
@@ -110,14 +110,14 @@
     },
     "item_fields": {
       "title": "Namelist item fields",
-      "description": "STAC Item properties: every 'nml:{component}:{file}:{group}:{key}' key maps to a queryable value; foreign (non-nml:) core properties are unconstrained.",
+      "description": "STAC Item properties: every 'nml__{component}__{file}__{group}__{key}' key maps to a queryable value; foreign (non-nml__) core properties are unconstrained.",
       "type": "object",
       "propertyNames": {
-        "$comment": "Foreign props pass; nml: keys must have exactly four colon-separated tail segments (component:file:group:key).",
-        "pattern": "^(?!nml:)|^nml:[^:]+:[^:]+:[^:]+:[^:]+$"
+        "$comment": "Foreign props pass; nml__ keys are JSON-path-safe (word characters and the '__' separator only).",
+        "pattern": "^(?!nml__)|^nml__[A-Za-z0-9_]+$"
       },
       "patternProperties": {
-        "^nml:[^:]+:[^:]+:[^:]+:[^:]+$": {
+        "^nml__[A-Za-z0-9_]+$": {
           "$ref": "#/definitions/queryable_value"
         }
       }

--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -331,10 +331,38 @@ def push(paths: tuple[Path, ...], server: Optional[str], insecure: bool) -> None
         f"pushed {summary.collections} collection(s), {summary.items} item(s) "
         f"from {summary.shards} shard(s)"
     )
+
+    # If a pushed catalog carries queryables the server has not registered, tell
+    # the operator how to register them (filtering already works; this only
+    # surfaces the fields in the STAC Browser filter UI).
+    for directory in (p for p in paths if p.is_dir()):
+        delta = pushmod.queryable_delta(directory, api_url, settings.verify_tls)
+        if delta is not None:
+            _report_new_queryables(delta, settings.server_url)
+
     if summary.errors:
         for err in summary.errors:
             click.secho(f"  ! {err}", fg="red", err=True)
         raise click.ClickException(f"{len(summary.errors)} path(s) failed.")
+
+
+def _report_new_queryables(delta_path: Path, server_url: Optional[str]) -> None:
+    """Print the operator recipe for registering new queryables."""
+    import json as _json
+
+    count = len(_json.loads(delta_path.read_text()).get("properties", {}))
+    host = (server_url or "<pgstac-host>").split("://", 1)[-1].rstrip("/")
+    click.secho(
+        f"\n{count} new queryable field(s) are not yet registered.", fg="yellow"
+    )
+    click.echo(
+        "Filtering already works without this — registration only makes these\n"
+        "fields appear in the STAC Browser filter UI. A privileged operator runs:\n"
+    )
+    click.secho(
+        f"  ssh {host} sudo -u stac esm-catalog-load-queryables - < {delta_path}\n",
+        fg="cyan",
+    )
 
 
 @contextmanager

--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -360,8 +360,10 @@ def _report_new_queryables(delta_path: Path, server_url: Optional[str]) -> None:
         "fields appear in the STAC Browser filter UI. A privileged operator runs\n"
         "on the pgstac host (adjust the ssh name if it differs from the API host):\n"
     )
+    # Absolute path: sudo's secure_path need not include /usr/local/bin.
     click.secho(
-        f"  ssh {host} sudo -u stac esm-catalog-load-queryables - < {delta_path}\n",
+        f"  ssh {host} sudo -u stac /usr/local/bin/esm-catalog-load-queryables "
+        f"- < {delta_path}\n",
         fg="cyan",
     )
 

--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -357,7 +357,8 @@ def _report_new_queryables(delta_path: Path, server_url: Optional[str]) -> None:
     )
     click.echo(
         "Filtering already works without this — registration only makes these\n"
-        "fields appear in the STAC Browser filter UI. A privileged operator runs:\n"
+        "fields appear in the STAC Browser filter UI. A privileged operator runs\n"
+        "on the pgstac host (adjust the ssh name if it differs from the API host):\n"
     )
     click.secho(
         f"  ssh {host} sudo -u stac esm-catalog-load-queryables - < {delta_path}\n",

--- a/src/esm_catalog/namelist.py
+++ b/src/esm_catalog/namelist.py
@@ -2,20 +2,30 @@
 
 Collection level (``collection.extra_fields``)::
 
-    nml:files       - "component:file" namelist filenames
+    nml:files       - "component__file" namelist filenames
     nml:groups      - namelist groups across all files
-    nml:parameters  - flattened "component:file:group:key" -> value, for CQL2
+    nml:parameters  - flattened "component__file__group__key" -> value, for CQL2
                       filtering (component-qualified so two components sharing a
                       filename cannot collide)
 
 Item level (``item.properties``), one entry per parameter across all
 components::
 
-    nml:{component}:{file}:{group}:{key} -> value
+    nml__{component}__{file}__{group}__{key} -> value
+
+The flattened keys use ``__`` as the separator and sanitise every other
+character to ``_``. This is deliberate: pgstac builds an (unquoted) JSON-path
+from an unregistered property name, so a name containing ``:`` (the STAC
+namespace idiom), ``.`` (from a filename like ``namelist.echam``) or ``[]``
+(a repeated-group index) yields a broken path and the CQL2 filter silently
+matches nothing. A ``[A-Za-z0-9_]``-only key resolves like any plain property
+(``component``, ``variable``), so namelist params are filterable with no
+queryables registration at all.
 """
 
 from __future__ import annotations
 
+import re
 from collections import Counter
 from typing import Iterator, Union
 
@@ -25,6 +35,22 @@ import pystac
 from esm_catalog.registry import Extension
 from esm_catalog.stac_ext import apply_extension
 from esm_catalog.types import ComponentName
+
+#: Separator between the segments of a flattened namelist key.
+_KEY_SEP = "__"
+
+#: The item-property prefix marking a flattened namelist parameter.
+_ITEM_PREFIX = "nml"
+
+
+def _flatten(*parts: str) -> str:
+    """Join *parts* into a JSON-path-safe flat key.
+
+    Every character outside ``[A-Za-z0-9_]`` is replaced with ``_`` (so a
+    filename's ``.`` or a repeated-group ``[N]`` can never reach the key), and
+    the sanitised parts are joined with :data:`_KEY_SEP`.
+    """
+    return _KEY_SEP.join(re.sub(r"[^0-9A-Za-z_]", "_", part) for part in parts)
 
 NamelistFilename = str
 """A namelist filename, e.g. 'namelist.echam'."""
@@ -36,8 +62,8 @@ ParameterName = str
 """A namelist parameter key, e.g. 'delta_time'."""
 
 FlatKey = str
-"""A flattened 'component:file:group:key' identifier, e.g.
-'echam:namelist.echam:runctl:delta_time'."""
+"""A flattened 'component__file__group__key' identifier, e.g.
+'echam__namelist_echam__runctl__delta_time'."""
 
 Namelist = f90nml.Namelist
 """A parsed Fortran namelist (group -> parameters; nested groups are Namelists)."""
@@ -77,12 +103,12 @@ def add_namelist_collection_extension(
         for file_groups in namelists.values():
             groups.update(file_groups)
     parameters: dict[FlatKey, NamelistValue] = {
-        f"{component}:{filename}:{group}:{key}": value
+        _flatten(component, filename, group, key): value
         for component, namelists in namelists_by_component.items()
         for filename, group, key, value in _iter_queryable_params(namelists)
     }
     collection.extra_fields["nml:files"] = sorted(
-        f"{component}:{filename}"
+        _flatten(component, filename)
         for component, namelists in namelists_by_component.items()
         for filename in namelists
     )
@@ -107,7 +133,7 @@ def add_namelist_item_extension(
         parameter.
     """
     props: dict[str, NamelistValue] = {
-        f"nml:{component}:{filename}:{group}:{key}": value
+        _flatten(_ITEM_PREFIX, component, filename, group, key): value
         for component, namelists in namelists_by_component.items()
         for filename, group, key, value in _iter_queryable_params(namelists)
     }
@@ -146,7 +172,9 @@ def _iter_queryable_params(
         for group_name, params in group_entries:
             if counts[group_name] > 1:
                 index = next_index.get(group_name, 0)
-                group = f"{group_name}[{index}]"
+                # '_N', not '[N]': brackets are JSON-path array syntax and would
+                # break the flattened key's resolution (see module docstring).
+                group = f"{group_name}_{index}"
                 next_index[group_name] = index + 1
             else:
                 group = group_name

--- a/src/esm_catalog/namelist.py
+++ b/src/esm_catalog/namelist.py
@@ -120,7 +120,7 @@ def add_namelist_collection_extension(
 def add_namelist_item_extension(
     item: pystac.Item, namelists_by_component: NamelistsByComponent
 ) -> None:
-    """Set item-level nml:{component}:{file}:{group}:{key} from the given namelists.
+    """Set item-level nml__{component}__{file}__{group}__{key} from the namelists.
 
     No-op when no queryable parameters are found.
 
@@ -141,6 +141,43 @@ def add_namelist_item_extension(
         return
     item.properties.update(props)
     apply_extension(item, Extension.namelist)
+
+
+def _json_type(value: NamelistValue) -> str:
+    """The JSON-Schema ``type`` for a queryable definition of *value*.
+
+    ``bool`` is checked before ``int`` (it subclasses it). Mixed lists have
+    already been stringified by :func:`_arrow_safe`, so a list is always
+    ``array``. The types drive pgstac's CQL2 casting (``integer``/``number`` ->
+    numeric comparison; ``array`` -> text array; everything else -> text).
+    """
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, list):
+        return "array"
+    return "string"
+
+
+def namelist_queryables(
+    namelists_by_component: NamelistsByComponent,
+) -> dict[str, dict[str, str]]:
+    """Map each item-level ``nml__`` key to a JSON-Schema queryable definition.
+
+    The result is the ``properties`` body of a ``pypgstac load-queryables`` file:
+    ``{name: {"type": <json-type>}}``, one entry per item-level namelist property.
+    Empty when there are no namelists.
+    """
+    return {
+        _flatten(_ITEM_PREFIX, component, filename, group, key): {
+            "type": _json_type(value)
+        }
+        for component, namelists in namelists_by_component.items()
+        for filename, group, key, value in _iter_queryable_params(namelists)
+    }
 
 
 def _iter_queryable_params(

--- a/src/esm_catalog/push.py
+++ b/src/esm_catalog/push.py
@@ -25,7 +25,7 @@ from stac_geoparquet.arrow import stac_table_to_items
 from upath import UPath
 
 from esm_catalog.client import CollectionId, StacClient, StacObject
-from esm_catalog.scan.workspace import STATE_FILENAME
+from esm_catalog.scan.workspace import QUERYABLES_FILENAME, STATE_FILENAME
 from esm_catalog.storage.geoparquet import read_shard
 
 #: Items per bulk_items request. pgstac loads each batch server-side.
@@ -35,6 +35,9 @@ CHUNK_SIZE = 500
 PathKind = Literal["collection", "item", "shard", "unknown"]
 
 _SHARD_SUFFIXES = {".parquet", ".geoparquet"}
+
+#: Catalog sidecars that are not STAC objects and must never be pushed.
+_SKIP_FILES = {STATE_FILENAME, QUERYABLES_FILENAME}
 
 
 class PushSummary(BaseModel):
@@ -83,8 +86,9 @@ def expand_paths(paths: Iterable[Path]) -> list[Path]:
 
     Directories are searched **recursively** — the scanner writes shards under
     ``items/`` while ``collection.json`` sits at the catalog root — and the
-    ``esm-catalog.json`` workspace-state file is skipped (it is bookkeeping, not
-    a STAC object, so it must not count as a failed push).
+    catalog sidecars (the ``esm-catalog.json`` workspace state and the
+    ``queryables.json`` file) are skipped: they are bookkeeping, not STAC
+    objects, so they must not count as failed pushes.
     """
     files: list[Path] = []
     for path in paths:
@@ -92,7 +96,7 @@ def expand_paths(paths: Iterable[Path]) -> list[Path]:
             candidates = sorted(path.rglob("*.json"))
             for suffix in _SHARD_SUFFIXES:
                 candidates += sorted(path.rglob(f"*{suffix}"))
-            files.extend(f for f in candidates if f.name != STATE_FILENAME)
+            files.extend(f for f in candidates if f.name not in _SKIP_FILES)
         else:
             files.append(path)
     # Stable-sort files so collections precede items precede shards.
@@ -160,3 +164,46 @@ def _push_shard(path: Path, client: StacClient, progress: ProgressHook) -> int:
             pushed += len(batch)
             progress(len(batch), f"{path.name} -> {collection_id} ({pushed})")
     return pushed
+
+
+#: The delta sidecar naming queryables present in the catalog but not yet
+#: registered on the server (a ``pypgstac load-queryables`` file).
+QUERYABLES_DELTA_FILENAME = "queryables-delta.json"
+
+
+def registered_queryables(api_url: str, verify_tls: bool) -> set[str]:
+    """The property names the server currently advertises as queryables."""
+    import httpx
+
+    resp = httpx.get(f"{api_url}/queryables", verify=verify_tls, timeout=30)
+    resp.raise_for_status()
+    return set(resp.json().get("properties", {}))
+
+
+def queryable_delta(
+    catalog_dir: Path, api_url: str, verify_tls: bool
+) -> Optional[Path]:
+    """Diff the catalog's ``queryables.json`` against the server; write the delta.
+
+    Returns the path to a written ``queryables-delta.json`` (its ``properties``
+    are the queryables present in the catalog but not yet registered on the
+    server), or ``None`` when there is nothing to register. If the server cannot
+    be reached for the diff, the *full* set is emitted so registration is never
+    silently skipped.
+    """
+    source = catalog_dir / QUERYABLES_FILENAME
+    if not source.exists():
+        return None
+    properties = json.loads(source.read_text()).get("properties", {})
+    if not properties:
+        return None
+    try:
+        already = registered_queryables(api_url, verify_tls)
+    except Exception:  # noqa: BLE001 — unreachable server -> emit the full set
+        already = set()
+    new = {name: definition for name, definition in properties.items() if name not in already}
+    if not new:
+        return None
+    delta_path = catalog_dir / QUERYABLES_DELTA_FILENAME
+    delta_path.write_text(json.dumps({"properties": new}, indent=2))
+    return delta_path

--- a/src/esm_catalog/scan/ingest.py
+++ b/src/esm_catalog/scan/ingest.py
@@ -43,6 +43,7 @@ from esm_catalog.scan.types import (
     ScanReport,
 )
 from esm_catalog.scan.workspace import (
+    QUERYABLES_FILENAME,
     WorkspaceState,
     catalog_dir,
     load_state,
@@ -208,6 +209,7 @@ def scan_experiment(
         exp_metadata.experiment_id,
     )
     _write_failures(catalog, failures)
+    _write_queryables(catalog, exp_metadata)
     save_state(catalog, state)
 
     if strict and failures:
@@ -235,6 +237,25 @@ def _write_catalog(
     write_shard(fx_items, items_dir / fx_shard_name(experiment_id))
     collection_path = catalog / "collection.json"
     collection_path.write_text(json.dumps(collection.to_dict(), indent=2))
+
+
+def _write_queryables(catalog, exp_metadata: ExperimentMetadata) -> None:
+    """Write (or clear) the queryables sidecar for this experiment's namelists.
+
+    Its ``properties`` are the item-level ``nml__`` keys and their JSON types --
+    the exact file ``pypgstac load-queryables`` consumes. ``push`` diffs it
+    against the server's registered queryables to tell an operator which (if
+    any) are new.
+    """
+    from esm_catalog.namelist import namelist_queryables
+
+    path = catalog / QUERYABLES_FILENAME
+    properties = namelist_queryables(exp_metadata.namelists_by_component)
+    if not properties:
+        if path.exists():
+            path.unlink()
+        return
+    path.write_text(json.dumps({"properties": properties}, indent=2))
 
 
 def _write_failures(catalog, failures) -> None:

--- a/src/esm_catalog/scan/sourcing.py
+++ b/src/esm_catalog/scan/sourcing.py
@@ -249,12 +249,18 @@ def _walk_outdata(
         return
     fs = outdata.fs
     base = outdata.path.rstrip("/")
+    # The component is the first path segment below outdata/. Split on the
+    # outdata boundary rather than slicing by len(base): fs.walk may return
+    # absolute roots even when base is relative (e.g. exp_root='.'), and a bare
+    # root[len(base):] would then strip the wrong prefix -- a '/albedo/...' root
+    # under a 7-char base 'outdata' famously yields the component 'work'.
+    marker = "/" + _OUTDATA_SUBDIR + "/"
     count = 0
     for root, _dirs, files in fs.walk(base):
-        rel = root[len(base) :].lstrip("/")
-        if not rel:
+        after = root.rsplit(marker, 1)
+        if len(after) < 2 or not after[1]:
             continue  # files sitting directly in outdata/ have no component
-        component = rel.split("/", 1)[0]
+        component = after[1].split("/", 1)[0]
         for name in sorted(files):
             count += 1
             if on_file is not None:

--- a/src/esm_catalog/scan/workspace.py
+++ b/src/esm_catalog/scan/workspace.py
@@ -26,6 +26,10 @@ CATALOG_DIRNAME = "catalog"
 STATE_FILENAME = "esm-catalog.json"
 """The workspace-state file inside the catalog directory."""
 
+QUERYABLES_FILENAME = "queryables.json"
+"""The catalog's namelist queryables (a ``pypgstac load-queryables`` file), so
+an operator can register them for the STAC Browser filter UI."""
+
 ScannedPath = str
 """A scanned output file's path (as text) — the key its catalogued md5 is stored under."""
 

--- a/tests/test_esm_catalog/test_push.py
+++ b/tests/test_esm_catalog/test_push.py
@@ -6,6 +6,7 @@ reader roundtrips through the scanner's own writer.
 
 import json
 from datetime import datetime, timezone
+from pathlib import Path
 
 import httpx
 import pystac
@@ -215,3 +216,99 @@ def test_upsert_reports_redirect_actionably():
     assert exc.value.status == 308
     msg = str(exc.value).lower()
     assert "redirect" in msg and "https" in msg
+
+
+# --------------------------------------------------------------------------- #
+# Queryables delta (conditional registration).
+# --------------------------------------------------------------------------- #
+
+
+def _write_queryables(catalog: Path, properties: dict) -> None:
+    (catalog).mkdir(parents=True, exist_ok=True)
+    (catalog / "queryables.json").write_text(json.dumps({"properties": properties}))
+
+
+def test_queryable_delta_only_new_keys(tmp_path, monkeypatch):
+    catalog = tmp_path / "catalog"
+    _write_queryables(
+        catalog,
+        {
+            "nml__echam__namelist_echam__radctl__co2vmr": {"type": "number"},
+            "nml__echam__namelist_echam__radctl__yr_perp": {"type": "integer"},
+        },
+    )
+    # server already has co2vmr registered -> only yr_perp is new
+    import esm_catalog.push as p
+
+    monkeypatch.setattr(
+        p, "registered_queryables", lambda url, verify: {"nml__echam__namelist_echam__radctl__co2vmr", "datetime"}
+    )
+    delta = p.queryable_delta(catalog, "https://host/api", True)
+    assert delta is not None and delta.name == "queryables-delta.json"
+    written = json.loads(delta.read_text())["properties"]
+    assert set(written) == {"nml__echam__namelist_echam__radctl__yr_perp"}
+
+
+def test_queryable_delta_none_when_all_registered(tmp_path, monkeypatch):
+    catalog = tmp_path / "catalog"
+    _write_queryables(catalog, {"nml__a__b__c__d": {"type": "number"}})
+    import esm_catalog.push as p
+
+    monkeypatch.setattr(p, "registered_queryables", lambda url, verify: {"nml__a__b__c__d"})
+    assert p.queryable_delta(catalog, "https://host/api", True) is None
+    assert not (catalog / "queryables-delta.json").exists()
+
+
+def test_queryable_delta_full_set_when_server_unreachable(tmp_path, monkeypatch):
+    catalog = tmp_path / "catalog"
+    _write_queryables(catalog, {"nml__a__b__c__d": {"type": "number"}})
+    import esm_catalog.push as p
+
+    def _boom(url, verify):
+        raise RuntimeError("unreachable")
+
+    monkeypatch.setattr(p, "registered_queryables", _boom)
+    delta = p.queryable_delta(catalog, "https://host/api", True)
+    assert delta is not None  # emits the full set rather than skipping silently
+    assert set(json.loads(delta.read_text())["properties"]) == {"nml__a__b__c__d"}
+
+
+def test_queryable_delta_absent_when_no_sidecar(tmp_path, monkeypatch):
+    import esm_catalog.push as p
+
+    monkeypatch.setattr(p, "registered_queryables", lambda url, verify: set())
+    assert p.queryable_delta(tmp_path, "https://host/api", True) is None
+
+
+def test_registered_queryables_parses_properties():
+    def handler(request):
+        return httpx.Response(200, json={"properties": {"a": {}, "b": {}, "datetime": {}}})
+
+    import esm_catalog.push as p
+
+    # patch httpx.get used inside registered_queryables via a MockTransport client
+    import httpx as _httpx
+
+    real_get = _httpx.get
+
+    def fake_get(url, **kw):
+        return httpx.Response(200, json={"properties": {"a": {}, "b": {}}}, request=httpx.Request("GET", url))
+
+    _httpx.get = fake_get
+    try:
+        assert p.registered_queryables("https://host/api", True) == {"a", "b"}
+    finally:
+        _httpx.get = real_get
+
+
+def test_expand_paths_skips_queryables_sidecar(tmp_path):
+    catalog = tmp_path / "catalog"
+    catalog.mkdir()
+    (catalog / "collection.json").write_text(json.dumps({"type": "Collection", "id": "c"}))
+    (catalog / "queryables.json").write_text(json.dumps({"properties": {}}))
+    (catalog / "esm-catalog.json").write_text(json.dumps({"scanned": {}}))
+
+    names = [p.name for p in pushmod.expand_paths([catalog])]
+    assert "collection.json" in names
+    assert "queryables.json" not in names
+    assert "esm-catalog.json" not in names

--- a/tests/test_esm_catalog/test_scan_sourcing.py
+++ b/tests/test_esm_catalog/test_scan_sourcing.py
@@ -14,6 +14,7 @@ from esm_catalog.scan.sourcing import (
     _namelists_by_component,
     _parse_datestamp,
     _tidy_log_outdata,
+    _walk_outdata,
     output_files,
     source_experiment,
 )
@@ -307,3 +308,34 @@ def test_namelists_by_component(tmp_path):
     assert set(result["echam"]) == {"namelist.echam"}  # stamped copy skipped
     assert result["echam"]["namelist.echam"]["radctl"]["co2vmr"] == 284.3e-6
     assert result["fesom"]["namelist.oce"]["oce_dyn"]["c_d"] == 0.0025
+
+
+def test_walk_outdata_component_from_boundary(tmp_path):
+    outdata = UPath(tmp_path) / "outdata"
+    (outdata / "fesom").mkdir(parents=True)
+    (outdata / "echam").mkdir(parents=True)
+    (outdata / "fesom" / "MLD1.fesom.1850.nc").write_text("x")
+    (outdata / "echam" / "tas.nc").write_text("x")
+
+    def components(root: UPath) -> dict[str, str]:
+        return {cp.path.name: cp.component for cp in _walk_outdata(root, None)}
+
+    # Absolute exp_root: component is the outdata subdir.
+    assert components(UPath(tmp_path)) == {
+        "MLD1.fesom.1850.nc": "fesom",
+        "tas.nc": "echam",
+    }
+    # Relative exp_root must give the same result. Regression: a len(base) slice
+    # stripped an absolute walk-root prefix and mislabelled the component (a
+    # '/albedo/...' root under 'outdata' produced 'work').
+    import os
+
+    cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        assert components(UPath(".")) == {
+            "MLD1.fesom.1850.nc": "fesom",
+            "tas.nc": "echam",
+        }
+    finally:
+        os.chdir(cwd)

--- a/tests/test_esm_catalog/test_stac_namelist_ext.py
+++ b/tests/test_esm_catalog/test_stac_namelist_ext.py
@@ -94,15 +94,15 @@ def test_collection_noop_without_namelists(collection):
 def test_collection_flattens_parameters(collection):
     add_namelist_collection_extension(collection, by_component("echam"))
     params = collection.extra_fields["nml:parameters"]
-    assert params["echam:namelist.echam:runctl:delta_time"] == 450
-    assert params["echam:namelist.echam:runctl:lcouple"] is True
+    assert params["echam__namelist_echam__runctl__delta_time"] == 450
+    assert params["echam__namelist_echam__runctl__lcouple"] is True
 
 
 def test_collection_lists_files_and_groups(collection):
     add_namelist_collection_extension(collection, by_component("echam", "jsbach"))
     assert collection.extra_fields["nml:files"] == [
-        "echam:namelist.echam",
-        "jsbach:namelist.jsbach",
+        "echam__namelist_echam",
+        "jsbach__namelist_jsbach",
     ]
     assert collection.extra_fields["nml:groups"] == ["jsbach_ctl", "runctl"]
     assert NAMELIST_URL in collection.stac_extensions
@@ -125,24 +125,24 @@ def test_collection_component_qualified_keys_avoid_filename_collision(collection
         },
     )
     params = collection.extra_fields["nml:parameters"]
-    assert params["echam:namelist.io:runctl:delta_time"] == 450
-    assert params["jsbach:namelist.io:jsbach_ctl:use_dynveg"] is True
+    assert params["echam__namelist_io__runctl__delta_time"] == 450
+    assert params["jsbach__namelist_io__jsbach_ctl__use_dynveg"] is True
     assert collection.extra_fields["nml:files"] == [
-        "echam:namelist.io",
-        "jsbach:namelist.io",
+        "echam__namelist_io",
+        "jsbach__namelist_io",
     ]
 
 
 def test_collection_indexes_repeated_group(collection):
     # A group repeated in a file (an f90nml Cogroup) must not collapse onto one
-    # key; each occurrence gets an [index] array suffix, so both values survive.
+    # key; each occurrence gets a '_index' suffix, so both values survive.
     add_namelist_collection_extension(
         collection, {"bgc": {"namelist.bgc": read_nml("repeated_group")}}
     )
     params = collection.extra_fields["nml:parameters"]
-    assert params["bgc:namelist.bgc:rep[0]:x"] == 1
-    assert params["bgc:namelist.bgc:rep[1]:x"] == 2
-    assert params["bgc:namelist.bgc:solo:y"] == 9
+    assert params["bgc__namelist_bgc__rep_0__x"] == 1
+    assert params["bgc__namelist_bgc__rep_1__x"] == 2
+    assert params["bgc__namelist_bgc__solo__y"] == 9
 
 
 def test_collection_drops_non_json_scalar(collection):
@@ -152,8 +152,8 @@ def test_collection_drops_non_json_scalar(collection):
         collection, {"echam": {"namelist.echam": read_nml("with_complex")}}
     )
     params = collection.extra_fields["nml:parameters"]
-    assert params["echam:namelist.echam:runctl:delta_time"] == 450
-    assert "echam:namelist.echam:runctl:phase" not in params
+    assert params["echam__namelist_echam__runctl__delta_time"] == 450
+    assert "echam__namelist_echam__runctl__phase" not in params
 
 
 def test_collection_flattens_shipped_namelist(collection):
@@ -161,8 +161,8 @@ def test_collection_flattens_shipped_namelist(collection):
     amip = f90nml.read(esm_tools.get_namelist_filepath("amip/namelist.amip"))
     add_namelist_collection_extension(collection, {"amip": {"namelist.amip": amip}})
     params = collection.extra_fields["nml:parameters"]
-    assert params["amip:namelist.amip:namamip:runlengthsec"] == 86400
-    assert params["amip:namelist.amip:namamip:startyear"] == 1850
+    assert params["amip__namelist_amip__namamip__runlengthsec"] == 86400
+    assert params["amip__namelist_amip__namamip__startyear"] == 1850
 
 
 # --- add_namelist_item_extension (item-level, all components) ---
@@ -176,14 +176,16 @@ def test_item_noop_without_namelists(item):
 
 def test_item_flattens_one_component(item):
     add_namelist_item_extension(item, by_component("echam"))
-    assert item.properties["nml:echam:namelist.echam:runctl:co2vmr"] == 0.000284
+    assert item.properties["nml__echam__namelist_echam__runctl__co2vmr"] == 0.000284
     assert NAMELIST_URL in item.stac_extensions
 
 
 def test_item_covers_all_components(item):
     add_namelist_item_extension(item, by_component("echam", "jsbach"))
-    assert item.properties["nml:echam:namelist.echam:runctl:delta_time"] == 450
-    assert item.properties["nml:jsbach:namelist.jsbach:jsbach_ctl:use_dynveg"] is True
+    assert item.properties["nml__echam__namelist_echam__runctl__delta_time"] == 450
+    assert (
+        item.properties["nml__jsbach__namelist_jsbach__jsbach_ctl__use_dynveg"] is True
+    )
 
 
 # --- schema validation ---
@@ -195,24 +197,26 @@ def test_collection_validates_against_namelist_schema(nml_schema):
 
 
 def test_collection_rejects_malformed_parameter_key(nml_schema):
-    # nml:parameters keys must be exactly 'component:file:group:key' (four
-    # colon-separated segments); the propertyNames rule must reject anything else.
+    # Flattened keys are JSON-path-safe: only [A-Za-z0-9_]. A key carrying a
+    # forbidden character (here a ':') must be rejected by propertyNames. (The
+    # '__' format cannot regex-enforce a segment count, since segments contain
+    # underscores; the guarantee it does enforce is character-safety.)
     exp_metadata = make_exp_metadata(namelists_by_component=by_component("echam"))
     col_dict = make_collection(exp_metadata).to_dict()
-    col_dict["nml:parameters"]["missing_group_and_key"] = 1  # only one segment
+    col_dict["nml:parameters"]["has:a:colon"] = 1  # forbidden character
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=col_dict, schema=nml_schema)
 
 
 def test_item_rejects_malformed_nml_key_but_keeps_foreign_props(item, nml_schema):
-    # nml: keys must be nml:component:file:group:key; a short nml: key is
-    # rejected, while foreign core props (datetime, etc.) pass untouched.
+    # nml__ keys must be JSON-path-safe; one carrying a ':' is rejected, while
+    # foreign core props (datetime, etc.) pass untouched.
     add_namelist_item_extension(item, by_component("echam"))
     # well-formed item (carrying a core datetime prop) validates
     jsonschema.validate(instance=item.to_dict(), schema=nml_schema)
-    # a truncated nml: key must be rejected
+    # an nml__ key with a forbidden character must be rejected
     bad = item.to_dict()
-    bad["properties"]["nml:echam:runctl"] = 1  # missing file+key segments
+    bad["properties"]["nml__echam__bad:key"] = 1  # colon not allowed
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(instance=bad, schema=nml_schema)
 


### PR DESCRIPTION
Fixes #1562: derive walk component from the outdata boundary, not len(base); stable under relative exp_root.