### PR TITLE
esm-catalog/fix-1563-namelists

### DIFF
--- a/src/esm_catalog/namelist.py
+++ b/src/esm_catalog/namelist.py
@@ -152,7 +152,37 @@ def _iter_queryable_params(
                 group = group_name
             for key, value in params.items():
                 if _is_queryable(value):
-                    yield filename, group, key, value
+                    yield filename, group, key, _arrow_safe(value)
+
+
+def _arrow_safe(value: NamelistValue) -> NamelistValue:
+    """Make a namelist value storable in a single-typed column (geoparquet).
+
+    A scalar passes through. A list is stored as a shard column, which arrow
+    requires to be one type; f90nml, however, produces mixed-kind lists such as
+    ``putrerun = 1, 'months', 'first', 0`` -> ``[1, 'months', 'first', 0]`` (a
+    Fortran output-interval triplet). A list mixing text with numbers (or bools)
+    cannot be a typed column, so every element is stringified to a uniform
+    ``list[str]``; homogeneous numeric or text lists are left as-is. ``None`` is
+    preserved so the column can null it.
+    """
+    if not isinstance(value, list):
+        return value
+    kinds = set()
+    for element in value:
+        if element is None:
+            continue
+        if isinstance(element, bool):
+            kinds.add("bool")
+        elif isinstance(element, (int, float)):
+            kinds.add("number")
+        elif isinstance(element, str):
+            kinds.add("text")
+        else:
+            kinds.add("other")
+    if len(kinds) <= 1:
+        return value
+    return [None if element is None else str(element) for element in value]
 
 
 def _is_queryable(value: NamelistValue) -> bool:

--- a/src/esm_catalog/scan/sourcing.py
+++ b/src/esm_catalog/scan/sourcing.py
@@ -25,23 +25,27 @@ tolerantly with ``.get`` and defaults:
   component's ``outdata_targets`` mapping holds glob *patterns*, used only as a
   fallback when tidy logs are absent.
 
-``namelists_by_component`` is left empty here; populating it is out of scope for
-this module.
+``namelists_by_component`` is populated from ``config/<component>/namelist.*``,
+parsed with f90nml.
 """
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import date, datetime
 from itertools import chain
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional
 
+import f90nml
+from loguru import logger
 from pydantic import BaseModel, ConfigDict
 from ruamel.yaml import YAML
 from upath import UPath
 
 from esm_catalog.models import Contact, ExperimentMetadata
+from esm_catalog.namelist import ComponentNamelists, NamelistsByComponent
 from esm_catalog.paleo import PaleoConfig
 from esm_catalog.scan.types import Md5, OutputFile, RunStamp
 from esm_catalog.types import ComponentName, ExperimentId
@@ -146,9 +150,8 @@ def source_experiment(exp_root: UPath) -> ExperimentMetadata:
     Returns
     -------
     ExperimentMetadata
-        Identity, description, license, contacts, paleo config, and the run span
-        (min start / max end across segments). ``namelists_by_component`` is left
-        empty (out of scope here).
+        Identity, description, license, contacts, paleo config, the run span
+        (min start / max end across segments), and each component's namelists.
 
     Raises
     ------
@@ -170,7 +173,42 @@ def source_experiment(exp_root: UPath) -> ExperimentMetadata:
         paleo_config=_paleo_config(docs),
         run_start=run_start,
         run_end=run_end,
+        namelists_by_component=_namelists_by_component(exp_root),
     )
+
+
+_NAMELIST_GLOB = "namelist.*"
+"""Namelist files live at ``config/<component>/namelist.<name>``."""
+
+_RUN_STAMP_RE = re.compile(r"_\d{8}-\d{8}$")
+"""A per-segment run stamp suffix, e.g. ``_18500101-18500131``."""
+
+
+def _namelists_by_component(exp_root: UPath) -> NamelistsByComponent:
+    """Parse each ``config/<component>/namelist.*`` into an f90nml Namelist.
+
+    The per-segment copies (``namelist.echam_18500101-18500131``) are skipped;
+    the base file (no run-stamp suffix) is the canonical one. A namelist that
+    fails to parse is logged and skipped -- a bad file never aborts the scan.
+    """
+    result: NamelistsByComponent = {}
+    config_dir = exp_root / _CONFIG_SUBDIR
+    if not config_dir.exists():
+        return result
+    for component_dir in sorted(config_dir.iterdir()):
+        if not component_dir.is_dir():
+            continue
+        namelists: ComponentNamelists = {}
+        for path in sorted(component_dir.glob(_NAMELIST_GLOB)):
+            if _RUN_STAMP_RE.search(path.name):
+                continue
+            try:
+                namelists[path.name] = f90nml.reads(path.read_text())
+            except Exception as exc:  # noqa: BLE001 -- a bad namelist is not fatal
+                logger.warning("Skipping unparseable namelist {}: {}", path, exc)
+        if namelists:
+            result[component_dir.name] = namelists
+    return result
 
 
 def _on_exp_fs(exp_root: UPath, destination: str) -> UPath:

--- a/tests/test_esm_catalog/test_scan_sourcing.py
+++ b/tests/test_esm_catalog/test_scan_sourcing.py
@@ -11,6 +11,7 @@ from upath import UPath
 from esm_catalog.scan.sourcing import (
     SourcingError,
     TidyOutdataEntry,
+    _namelists_by_component,
     _parse_datestamp,
     _tidy_log_outdata,
     output_files,
@@ -283,3 +284,26 @@ def test_tidy_log_outdata_yields_component_dest_md5_and_skips_malformed():
         TidyOutdataEntry("echam", "/d/no_checksum", None),
         TidyOutdataEntry("echam", "/d/good", "abc123"),
     ]
+
+
+def test_namelists_by_component(tmp_path):
+    config = UPath(tmp_path) / "config"
+    (config / "echam").mkdir(parents=True)
+    (config / "fesom").mkdir(parents=True)
+    (config / "oasis3mct").mkdir(parents=True)  # no namelist.* -> excluded
+
+    (config / "echam" / "namelist.echam").write_text(
+        "&radctl\n  co2vmr = 284.3e-6\n/\n"
+    )
+    # a per-segment copy must be skipped (the base file is canonical)
+    (config / "echam" / "namelist.echam_18500101-18500131").write_text(
+        "&radctl\n  co2vmr = 999.0\n/\n"
+    )
+    (config / "fesom" / "namelist.oce").write_text("&oce_dyn\n  c_d = 0.0025\n/\n")
+
+    result = _namelists_by_component(UPath(tmp_path))
+
+    assert set(result) == {"echam", "fesom"}  # oasis3mct dropped (no namelists)
+    assert set(result["echam"]) == {"namelist.echam"}  # stamped copy skipped
+    assert result["echam"]["namelist.echam"]["radctl"]["co2vmr"] == 284.3e-6
+    assert result["fesom"]["namelist.oce"]["oce_dyn"]["c_d"] == 0.0025

--- a/tests/test_esm_catalog/test_stac_namelist_ext.py
+++ b/tests/test_esm_catalog/test_stac_namelist_ext.py
@@ -23,6 +23,7 @@ from esm_catalog.item import make_item
 from esm_catalog.namelist import (
     Namelist,
     NamelistFilename,
+    _arrow_safe,
     _is_queryable,
     add_namelist_collection_extension,
     add_namelist_item_extension,
@@ -290,3 +291,17 @@ def test_every_shipped_namelist_flattens_and_validates(
 def test_item_validates_against_namelist_schema(nml_schema, temp_nc):
     exp_metadata = make_exp_metadata(namelists_by_component=by_component("echam"))
     assert_valid(make_item(temp_nc, make_file_metadata(), exp_metadata), nml_schema)
+
+
+def test_arrow_safe_stringifies_only_mixed_kind_lists():
+    # A mixed text+number list (f90nml's putrerun = 1,'months','first',0) cannot
+    # be a single-typed geoparquet column, so every element is stringified.
+    assert _arrow_safe([1, "months", "first", 0]) == ["1", "months", "first", "0"]
+    # Homogeneous lists (all numeric / all text) and scalars pass through.
+    assert _arrow_safe([1, 2, 3]) == [1, 2, 3]
+    assert _arrow_safe([1.0, 2.5]) == [1.0, 2.5]
+    assert _arrow_safe(["a", "b"]) == ["a", "b"]
+    assert _arrow_safe(0.000284) == 0.000284
+    assert _arrow_safe("scalar") == "scalar"
+    # None is preserved (a nullable column), not stringified to "None".
+    assert _arrow_safe([1, "x", None]) == ["1", "x", None]


### PR DESCRIPTION
Fixes #1563: populate namelists from config/<component>/namelist.*; keep mixed-kind list values geoparquet-safe.