### PR TITLE
esm-catalog/fix-1564-datacube-elem-index

### DIFF
--- a/src/esm_catalog/scan/readers/netcdf/dimensions.py
+++ b/src/esm_catalog/scan/readers/netcdf/dimensions.py
@@ -24,7 +24,10 @@ def _extract_dimensions(dataset: xr.Dataset) -> CubeDimensions:
     dimensions: CubeDimensions = {}
     for name in dataset.sizes:
         coord = dataset.coords.get(name)
-        entry: CubeDimension = {"type": "spatial", "extent": [None, None]}
+        # No default type: a dimension is only 'spatial'/'temporal' if CF axis
+        # detection says so. An unidentified dimension (e.g. FESOM's unstructured
+        # 'elem') is a bare index — it carries an extent but no misleading type.
+        entry: CubeDimension = {"extent": [None, None]}
         if coord is not None:
             values = coord.values
             entry["extent"] = [_to_python(values.min()), _to_python(values.max())]

--- a/tests/test_esm_catalog/test_scan_netcdf_units.py
+++ b/tests/test_esm_catalog/test_scan_netcdf_units.py
@@ -321,3 +321,20 @@ def test_to_python_unwraps_numpy_scalar():
     assert result == 3.5
     assert isinstance(result, float)
     assert _to_python("plain") == "plain"
+
+
+def test_unidentified_dimension_has_no_type():
+    # A dimension with no CF axis (e.g. FESOM's unstructured 'elem') is a bare
+    # index: it keeps its extent but must NOT be labelled 'spatial'/'temporal'.
+    dataset = xr.Dataset(
+        coords={
+            "time": ("time", pd.date_range("1850-03-31", periods=1)),
+            "elem": ("elem", np.arange(0, 100)),
+        }
+    )
+    dataset["time"].attrs["standard_name"] = "time"
+
+    dims = _extract_dimensions(dataset)
+    assert dims["time"]["type"] == "temporal"
+    assert dims["elem"]["extent"] == [0, 99]
+    assert "type" not in dims["elem"]


### PR DESCRIPTION
Fixes #1564: stop labelling unidentified cube dimensions 'spatial'.