### PR TITLE
refactor(esm_catalog): one type system — pydantic for the record voca…

### DIFF
--- a/src/esm_catalog/datacube.py
+++ b/src/esm_catalog/datacube.py
@@ -58,13 +58,14 @@ def add_datacube_item_extension(item: pystac.Item, file_metadata: FileMetadata) 
     file_metadata : FileMetadata
         The file's scanned metadata. No-op when it carries no dimensions.
     """
-    dimensions = file_metadata.get("dimensions", {})
+    file_metadata = FileMetadata.model_validate(file_metadata)
+    dimensions = file_metadata.dimensions
     if not dimensions:
         return
 
     item.properties["cube:dimensions"] = dimensions
 
-    cube_variables = _to_cube_variables(file_metadata.get("variables", []))
+    cube_variables = _to_cube_variables(file_metadata.variables)
     if cube_variables:
         item.properties["cube:variables"] = cube_variables
 
@@ -90,15 +91,16 @@ def _to_cube_variables(variables: list[ScannedVariable]) -> CubeVariables:
     """
     cube_variables: CubeVariables = {}
     for variable in variables:
-        name = variable.get("name")
+        name = variable.name
         if not name:
             continue
-        entry: CubeVariable = {"dimensions": variable.get("dimensions", [])}
-        if "units" in variable:
-            entry["unit"] = variable["units"]
+        entry: CubeVariable = {"dimensions": variable.dimensions}
+        if variable.units:
+            entry["unit"] = variable.units
         for description_key in ("description", "long_name", "standard_name"):
-            if description_key in variable:
-                entry["description"] = variable[description_key]
+            value = getattr(variable, description_key)
+            if value:
+                entry["description"] = value
                 break
         cube_variables[name] = entry
     return cube_variables

--- a/src/esm_catalog/item.py
+++ b/src/esm_catalog/item.py
@@ -48,16 +48,16 @@ def make_item(
 
     dt_start, dt_end, item_datetime = _build_datetime(file_metadata)
     item_id = _build_id(
-        file_metadata.get("variable", "unknown"),
-        file_metadata.get("component", "unknown"),
-        file_metadata.get("datetime_str", "000000"),
+        file_metadata.variable or "unknown",
+        file_metadata.component or "unknown",
+        file_metadata.datetime_str or "000000",
         path,
     )
 
     item = Item(
         id=item_id,
-        geometry=file_metadata.get("geometry"),
-        bbox=file_metadata.get("bbox"),
+        geometry=file_metadata.geometry,
+        bbox=file_metadata.bbox,
         datetime=item_datetime,
         properties=_build_properties(file_metadata, exp_metadata),
         start_datetime=dt_start,
@@ -127,18 +127,18 @@ def _build_properties(
     """
 
     properties: dict = {
-        "variable": file_metadata.get("variable", "unknown"),
+        "variable": file_metadata.variable or "unknown",
         "experiment": exp_metadata.experiment_id,
-        "component": file_metadata.get("component", "unknown"),
-        "format": file_metadata.get("format", "unknown"),
+        "component": file_metadata.component or "unknown",
+        "format": file_metadata.format or "unknown",
     }
-    if file_metadata.get("output_frequency"):
-        properties["output_frequency"] = file_metadata["output_frequency"]
+    if file_metadata.output_frequency:
+        properties["output_frequency"] = file_metadata.output_frequency
 
     variable_names = [
-        variable["name"]
-        for variable in file_metadata.get("variables", [])
-        if variable.get("name") and variable["name"] != "unknown"
+        variable.name
+        for variable in file_metadata.variables
+        if variable.name and variable.name != "unknown"
     ]
     if len(variable_names) > 1:
         properties["variables"] = variable_names
@@ -164,8 +164,8 @@ def _build_datetime(
         ``(dt_start, dt_end, item_datetime)``. ``item_datetime`` is set only for
         a single-time file (start == end, or no end), otherwise None.
     """
-    dt_start = file_metadata.get("datetime_start")
-    dt_end = file_metadata.get("datetime_end")
+    dt_start = file_metadata.datetime_start
+    dt_end = file_metadata.datetime_end
     if dt_start and dt_start.tzinfo is None:
         dt_start = dt_start.replace(tzinfo=timezone.utc)
     if dt_end and dt_end.tzinfo is None:
@@ -196,7 +196,7 @@ def _build_data_asset(path: Path | UPath, file_metadata: FileMetadata) -> Asset:
     pystac.Asset
         The file's data asset.
     """
-    file_format = file_metadata.get("format", "")
+    file_format = file_metadata.format or ""
     media_type = (
         "application/x-grib2" if file_format == "grib" else "application/x-netcdf"
     )

--- a/src/esm_catalog/paleo.py
+++ b/src/esm_catalog/paleo.py
@@ -27,8 +27,10 @@ The values come from the ``general.paleo`` config section (see
 
 from __future__ import annotations
 
+from typing import Optional
+
 import pystac
-from typing_extensions import TypedDict  # pydantic needs this flavor as a model field
+from pydantic import BaseModel, ConfigDict
 
 from esm_catalog.registry import Extension
 from esm_catalog.stac_ext import apply_extension
@@ -41,22 +43,24 @@ PaleoLabel = str
 """A free-text label for a paleo interval, e.g. 'LGM' (not a controlled vocabulary)."""
 
 
-class PaleoConfig(TypedDict, total=False):
-    """The ``general.paleo`` config section — every key optional.
+class PaleoConfig(BaseModel):
+    """The ``general.paleo`` config section — every field optional.
 
     A time-slice run sets ``datetime``; a transient run sets ``start_datetime``
     and ``end_datetime``; ``label`` is an optional free-text name.
     """
 
-    datetime: PaleoDatetime
-    start_datetime: PaleoDatetime
-    end_datetime: PaleoDatetime
-    label: PaleoLabel
+    model_config = ConfigDict(extra="allow")
+
+    datetime: Optional[PaleoDatetime] = None
+    start_datetime: Optional[PaleoDatetime] = None
+    end_datetime: Optional[PaleoDatetime] = None
+    label: Optional[PaleoLabel] = None
 
 
 # The config keys map 1:1 onto the paleo: fields — derived from PaleoConfig so
 # the two never drift.
-_KEYS = tuple(PaleoConfig.__annotations__)
+_KEYS = tuple(PaleoConfig.model_fields)
 
 
 def _to_paleo_props(paleo_config: PaleoConfig | None) -> dict:
@@ -73,8 +77,12 @@ def _to_paleo_props(paleo_config: PaleoConfig | None) -> dict:
         The ``paleo:*`` properties; empty when the config is None or sets no
         paleo fields (i.e. not a paleo run).
     """
-    cfg = paleo_config or {}
-    return {f"paleo:{key}": cfg[key] for key in _KEYS if cfg.get(key) is not None}
+    if paleo_config is None:
+        return {}
+    # Accept a dict or a PaleoConfig; normalize to the model at this boundary.
+    paleo_config = PaleoConfig.model_validate(paleo_config)
+    fields_set = paleo_config.model_dump(exclude_none=True)
+    return {f"paleo:{key}": fields_set[key] for key in _KEYS if key in fields_set}
 
 
 def add_paleo_item_extension(

--- a/src/esm_catalog/types.py
+++ b/src/esm_catalog/types.py
@@ -9,7 +9,9 @@ on IDE hover wherever it is used.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TypedDict
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
 
 ExperimentId = str
 """An experiment identifier, e.g. 'PI-CTRL'."""
@@ -34,36 +36,43 @@ BBox = list[float]
 """A bounding box, [west, south, east, north]."""
 
 
-class ScannedVariable(TypedDict, total=False):
+class ScannedVariable(BaseModel):
     """One entry in a scanner's ``variables`` list, before datacube mapping.
 
-    Every key is optional; ``name`` identifies the variable, the rest are the
-    CF-style attributes a scanner may extract.
+    Every field is optional; ``name`` identifies the variable, the rest are the
+    CF-style attributes a scanner may extract. ``extra="allow"`` lets a scanner
+    attach attributes not enumerated here.
     """
 
-    name: VariableName
-    units: str
-    dimensions: list[str]
-    description: str
-    long_name: str
-    standard_name: str
+    model_config = ConfigDict(extra="allow")
+
+    name: Optional[VariableName] = None
+    units: Optional[str] = None
+    dimensions: list[str] = []
+    description: Optional[str] = None
+    long_name: Optional[str] = None
+    standard_name: Optional[str] = None
 
 
-class FileMetadata(TypedDict, total=False):
+class FileMetadata(BaseModel):
     """The metadata a scanner (scan_netcdf/scan_grib) produces for one file.
 
-    Every key is optional — a scanner fills what it can extract. ``dimensions``
-    is a STAC datacube Dimensions object, forwarded verbatim (opaque here).
+    A scanner fills what it can extract; every field is optional and
+    ``extra="allow"`` permits keys not enumerated here. Validated at the scan
+    boundary, so a malformed reader output is caught where it is produced.
+    ``dimensions`` is a STAC datacube Dimensions object, forwarded verbatim.
     """
 
-    variable: str
-    variables: list[ScannedVariable]
-    component: ComponentName
-    format: str
-    dimensions: dict
-    datetime_start: datetime
-    datetime_end: datetime
-    datetime_str: str
-    output_frequency: str
-    geometry: dict
-    bbox: BBox
+    model_config = ConfigDict(extra="allow")
+
+    variable: Optional[str] = None
+    variables: list[ScannedVariable] = []
+    component: Optional[ComponentName] = None
+    format: Optional[str] = None
+    dimensions: dict = {}
+    datetime_start: Optional[datetime] = None
+    datetime_end: Optional[datetime] = None
+    datetime_str: Optional[str] = None
+    output_frequency: Optional[str] = None
+    geometry: Optional[dict] = None
+    bbox: Optional[BBox] = None

--- a/tests/test_esm_catalog/helpers.py
+++ b/tests/test_esm_catalog/helpers.py
@@ -32,15 +32,15 @@ def make_exp_metadata(**kwargs) -> ExperimentMetadata:
 
 
 def make_file_metadata(**kwargs) -> FileMetadata:
-    """Default scan metadata for one file; override any key via kwargs."""
-    return {
+    """Default scan metadata for one file; override any field via kwargs."""
+    defaults = {
         "variable": "temp",
         "component": "echam",
         "format": "netcdf",
         "datetime_start": datetime(2000, 1, 1, tzinfo=timezone.utc),
         "datetime_end": datetime(2000, 1, 1, tzinfo=timezone.utc),
-        **kwargs,
     }
+    return FileMetadata(**{**defaults, **kwargs})
 
 
 def assert_valid(obj, schema) -> None:

--- a/tests/test_esm_catalog/test_stac_item.py
+++ b/tests/test_esm_catalog/test_stac_item.py
@@ -207,8 +207,7 @@ def test_to_href_bucket_protocol_uri():
 
 
 def test_item_id_defaults_to_unknown_variable(temp_nc):
-    file_metadata = make_file_metadata()
-    del file_metadata["variable"]
+    file_metadata = make_file_metadata(variable=None)
     item = make_item(temp_nc, file_metadata, make_exp_metadata())
     assert re.fullmatch(r"unknown\.echam\.000000\.[0-9a-f]{6}", item.id)
 


### PR DESCRIPTION
…bulary

Draft (parked for later integration). Unifies the domain vocabulary on pydantic instead of the TypedDict/pydantic split: the records a scanner produces or a config supplies are now pydantic BaseModels, validated at the boundary where they enter the program.

- types.py: FileMetadata, ScannedVariable -> BaseModel (extra="allow", all fields optional — mirrors the old total=False; borrows the stac-pydantic ItemProperties(extra="allow") idiom).
- paleo.py: PaleoConfig -> BaseModel.
- item.py / datacube.py: consumers switch from fm.get("x") to attribute access.
- datacube/paleo entry points coerce their input via model_validate, so a dict or a model both work (validate-at-boundary); item.py passes real models.
- ExperimentMetadata was already pydantic.
- Benchmark that motivated the old split was bogus: 393k FileMetadata objects cost pydantic ~+1.1s / +315MB total vs plain dicts — noise against an I/O-bound scan; the 393k figure was one large example run, not typical.

Deliberately NOT converted (open call for review): CubeVariable and StacContact are emitted STAC-JSON shapes (serialization output written into item.properties / to_stac()), not ingested records, so they stay TypedDict. Decide later whether to model these too.

Foundation only. The scan readers on esm-catalog/cli-scan build FileMetadata as plain dicts and return them; when this lands there, read() must construct FileMetadata(...) (model_validate already accepts their dict, so the change is small). 423 catalog tests green.

Refs: #1531
Specified-by: Paul Gierz <paul.gierz@awi.de>
Generated-by: Claude Opus 4.8 <noreply@anthropic.com>

- - - - -

I have read and understand this code, it can be merged. 

- - - - -