### PR TITLE
Add climberx component (CLIMBER-X / AWI climber-y variant)

### DIFF
--- a/configs/components/climberx/climberx.yaml
+++ b/configs/components/climberx/climberx.yaml
@@ -212,5 +212,6 @@ computer:
                 - load intel-oneapi-compilers/2024.0.0
                 - load netcdf-c/4.8.1-openmpi4.1.3-oneapi2022.1.0
                 - load netcdf-fortran/4.5.4-oneapi2022.1.0
-                - load udunits/2.2.28
                 - load python/3.10.4
+                # udunits/2.2.28 already loaded by Albedo's own machine
+                # defaults (configs/machines/albedo.yaml), no need to repeat it

--- a/configs/components/climberx/climberx.yaml
+++ b/configs/components/climberx/climberx.yaml
@@ -1,0 +1,196 @@
+climberx:
+    model: climberx
+
+    metadata:
+        Institute: Potsdam Institute for Climate Impact Research (PIK) / AWI Paleodynamics
+        Description: >-
+            Earth system Model of Intermediate Complexity (EMIC): semi-empirical
+            statistical-dynamical atmosphere (SESAM), 3-D frictional-geostrophic
+            ocean (GOLDSTEIN), dynamic-thermodynamic sea ice (SISIM), land model
+            with dynamic vegetation (PALADYN). Optional ocean biogeochemistry
+            (HAMOCC, private), ice sheets (Yelmo/SICOPOLIS) and solid-Earth
+            (VILMA, private) components are not covered by this standalone,
+            climate-only ("climber-clim") integration.
+        Authors: Matteo Willeit, Andrey Ganopolski, Neil R. Edwards, Alexander Robinson, Reinhard Calov, Ralf Greve
+        Publications:
+            - "Willeit et al. 2022, GMD 15, 5905-5948, https://doi.org/10.5194/gmd-15-5905-2022"
+            - "Willeit et al. 2023, GMD 16, 3501-3534, https://doi.org/10.5194/gmd-16-3501-2023"
+        License: GPLv3 (climber-x); climber-y is an AWI-internal variant, license per AWI Paleodynamics group
+
+    # `configme` (https://github.com/fesmc/configme) owns cloning/configuring the
+    # full dependency stack (fesm-utils: LIS+FFTW+utils, yelmo) for climber-x, so
+    # esm_master's own git-repository/branch clone is intentionally NOT used here.
+    # Instead comp_command drives configme itself against model_dir.
+    comp_command: |
+        pip install --quiet --upgrade "git+https://github.com/fesmc/configme"
+        configme install climber-x -m ${climberx_configme_machine} -c ${climberx_compiler} --dir ${model_dir} --overwrite
+        cd ${model_dir}
+        make clean
+        make ${climberx_flavor}
+    clean_command: |
+        cd ${model_dir}
+        make clean
+    install_bins: "."
+    executable: climber.x
+    nproc: 1
+
+    version: x
+    available_versions:
+        - x
+        - "1.3.0"
+        - "1.3.1"
+        - "1.4.0"
+        - "1.4.1"
+        - "1.4.2"
+        - "1.4.3"
+        - "1.5"
+        - "1.5.1"
+        - "1.5.2"
+        - "1.5.3"
+        - "1.5.4"
+        - y
+
+    # `x` tracks the upstream default branch; the numbered entries pin an
+    # official cxesmc/climber-x release tag; `y` points at the AWI-internal
+    # variant maintained by the Paleodynamics group. configme itself always
+    # clones from cxesmc/climber-x for every `x`-line version (that mapping
+    # lives in configme's own manifest, not here) - `branch` below only
+    # selects which ref configme checks out.
+    choose_version:
+        x:
+            configme_ref: main
+        "1.3.0":
+            configme_ref: v1.3.0
+        "1.3.1":
+            configme_ref: v1.3.1
+        "1.4.0":
+            configme_ref: v1.4.0
+        "1.4.1":
+            configme_ref: v1.4.1
+        "1.4.2":
+            configme_ref: v1.4.2
+        "1.4.3":
+            configme_ref: v1.4.3
+        "1.5":
+            configme_ref: v1.5
+        "1.5.1":
+            configme_ref: v1.5.1
+        "1.5.2":
+            configme_ref: v1.5.2
+        "1.5.3":
+            configme_ref: v1.5.3
+        "1.5.4":
+            configme_ref: v1.5.4
+        y:
+            configme_ref: main
+            # AWI-internal repo currently ships src/*.f90 only (no Makefile /
+            # configme manifest committed) - TODO once that's added upstream;
+            # until then this entry will fail configme install as-is.
+            git-repository: "git@gitlab.awi.de:paleodyn/models/climber-y.git"
+
+    # climber-clim: atmosphere + ocean + sea ice + land, no bgc/ice-sheet.
+    # Matches the default standalone scope agreed for this integration; the
+    # other three flavors (climber-clim-bgc / -ice / -bgc-ice) require the
+    # private bgc/vilma components and are out of scope for now.
+    climberx_flavor: climber-clim
+    # Albedo is the only esm-tools machine target for now. configme's machine
+    # naming doesn't match esm-tools' computer.name (esm-tools: "albedo" vs
+    # configme: "awi_albedo"), hence the separate variable instead of
+    # interpolating ${computer.name} directly.
+    climberx_configme_machine: awi_albedo
+    climberx_compiler: ifx
+
+    model_dir: "${general.esm_master.dir}/climberx-${version}"
+    bin_dir: "${model_dir}"
+
+    lresume: false
+
+    namelist_dir: "${model_dir}/nml"
+    namelists:
+        - control.nml
+        - atm_par.nml
+        - ocn_par.nml
+        - sic_par.nml
+        - lnd_par.nml
+        - geo_par.nml
+        - hosing.nml
+        - hyster_ctrl.nml
+
+    config_files:
+        control: control
+        atm_par: atm_par
+        ocn_par: ocn_par
+        sic_par: sic_par
+        lnd_par: lnd_par
+        geo_par: geo_par
+        hosing: hosing
+        hyster_ctrl: hyster_ctrl
+    config_sources:
+        control: "${namelist_dir}/control.nml"
+        atm_par: "${namelist_dir}/atm_par.nml"
+        ocn_par: "${namelist_dir}/ocn_par.nml"
+        sic_par: "${namelist_dir}/sic_par.nml"
+        lnd_par: "${namelist_dir}/lnd_par.nml"
+        geo_par: "${namelist_dir}/geo_par.nml"
+        hosing: "${namelist_dir}/hosing.nml"
+        hyster_ctrl: "${namelist_dir}/hyster_ctrl.nml"
+    config_in_work:
+        control: control.nml
+        atm_par: atm_par.nml
+        ocn_par: ocn_par.nml
+        sic_par: sic_par.nml
+        lnd_par: lnd_par.nml
+        geo_par: geo_par.nml
+        hosing: hosing.nml
+        hyster_ctrl: hyster_ctrl.nml
+
+    # Restart set for climber-clim (atmosphere/ocean/sea-ice/land only; no
+    # bgc_restart.nc/sed_restart.nc needed unless flag_bgc is enabled - add
+    # those back in if a bgc-capable flavor is wired up later).
+    restart_in_files:
+        atm: atm_restart
+        ocn: ocn_restart
+        sic: sic_restart
+        lnd: lnd_restart
+    restart_in_sources:
+        atm: "${restart_dir}/atm_restart.nc"
+        ocn: "${restart_dir}/ocn_restart.nc"
+        sic: "${restart_dir}/sic_restart.nc"
+        lnd: "${restart_dir}/lnd_restart.nc"
+    restart_in_in_work:
+        atm: atm_restart.nc
+        ocn: ocn_restart.nc
+        sic: sic_restart.nc
+        lnd: lnd_restart.nc
+
+    restart_out_files:
+        atm: atm_restart
+        ocn: ocn_restart
+        sic: sic_restart
+        lnd: lnd_restart
+    restart_out_sources:
+        atm: atm_restart.nc
+        ocn: ocn_restart.nc
+        sic: sic_restart.nc
+        lnd: lnd_restart.nc
+    restart_out_in_work:
+        atm: atm_restart.nc
+        ocn: ocn_restart.nc
+        sic: sic_restart.nc
+        lnd: lnd_restart.nc
+
+    bin_sources:
+        exec: "${bin_dir}/${executable}"
+
+    # TODO: input_dir/maps forcing paths depend on the (large, separate)
+    # climber-x-input data repo (gitlab.pik-potsdam.de/cxesmc/climber-x-input)
+    # - needs a real pool_dir location on Albedo before outdata_files/
+    # input_files can be filled in; not addressed by this standalone-build pass.
+
+computer:
+    add_module_actions:
+        - load intel-oneapi-compilers/2024.0.0
+        - load netcdf-c/4.8.1-openmpi4.1.3-oneapi2022.1.0
+        - load netcdf-fortran/4.5.4-oneapi2022.1.0
+        - load udunits/2.2.28
+        - load python/3.10.4

--- a/configs/components/climberx/climberx.yaml
+++ b/configs/components/climberx/climberx.yaml
@@ -17,13 +17,15 @@ climberx:
             - "Willeit et al. 2023, GMD 16, 3501-3534, https://doi.org/10.5194/gmd-16-3501-2023"
         License: GPLv3 (climber-x); climber-y is an AWI-internal variant, license per AWI Paleodynamics group
 
-    # `configme` (https://github.com/fesmc/configme) owns cloning/configuring the
-    # full dependency stack (fesm-utils: LIS+FFTW+utils, yelmo) for climber-x, so
-    # esm_master's own git-repository/branch clone is intentionally NOT used here.
-    # Instead comp_command drives configme itself against model_dir.
+    # esm_master clones climberx itself via git-repository/branch below, same
+    # as every other component. `configme` is only used at comp_command time
+    # to clone+configure+build the dependency stack (fesm-utils: LIS+FFTW+
+    # utils, yelmo) against that already-present checkout ("use-existing"
+    # mode) and to (re)generate the Makefile for the chosen machine/compiler -
+    # it does not re-clone climberx itself.
     comp_command: |
         pip install --quiet --upgrade "git+https://github.com/fesmc/configme"
-        configme install climber-x -m ${climberx_configme_machine} -c ${climberx_compiler} --dir ${model_dir} --overwrite
+        configme install climber-x -m ${climberx_configme_machine} -c ${climberx_compiler} --dir ${model_dir}
         cd ${model_dir}
         make clean
         make ${climberx_flavor}
@@ -51,54 +53,70 @@ climberx:
         - y
 
     # `x` tracks the upstream default branch; the numbered entries pin an
-    # official cxesmc/climber-x release tag; `y` points at the AWI-internal
-    # variant maintained by the Paleodynamics group. configme itself always
-    # clones from cxesmc/climber-x for every `x`-line version (that mapping
-    # lives in configme's own manifest, not here) - `branch` below only
-    # selects which ref configme checks out.
+    # official cxesmc/climber-x release tag (branch: is a tag name here); `y`
+    # points at the AWI-internal variant maintained by the Paleodynamics
+    # group. `git-repository`/`branch` here are esm_master's own clone of
+    # climberx into model_dir - configme never sees this repo URL, it just
+    # configures/builds against whatever is already checked out there.
     choose_version:
-        x:
-            configme_ref: main
+        x: &climberx_official_ref
+            git-repository: "https://github.com/cxesmc/climber-x.git"
+            branch: main
         "1.3.0":
-            configme_ref: v1.3.0
+            <<: *climberx_official_ref
+            branch: v1.3.0
         "1.3.1":
-            configme_ref: v1.3.1
+            <<: *climberx_official_ref
+            branch: v1.3.1
         "1.4.0":
-            configme_ref: v1.4.0
+            <<: *climberx_official_ref
+            branch: v1.4.0
         "1.4.1":
-            configme_ref: v1.4.1
+            <<: *climberx_official_ref
+            branch: v1.4.1
         "1.4.2":
-            configme_ref: v1.4.2
+            <<: *climberx_official_ref
+            branch: v1.4.2
         "1.4.3":
-            configme_ref: v1.4.3
+            <<: *climberx_official_ref
+            branch: v1.4.3
         "1.5":
-            configme_ref: v1.5
+            <<: *climberx_official_ref
+            branch: v1.5
         "1.5.1":
-            configme_ref: v1.5.1
+            <<: *climberx_official_ref
+            branch: v1.5.1
         "1.5.2":
-            configme_ref: v1.5.2
+            <<: *climberx_official_ref
+            branch: v1.5.2
         "1.5.3":
-            configme_ref: v1.5.3
+            <<: *climberx_official_ref
+            branch: v1.5.3
         "1.5.4":
-            configme_ref: v1.5.4
+            <<: *climberx_official_ref
+            branch: v1.5.4
         y:
-            configme_ref: main
+            git-repository: "git@gitlab.awi.de:paleodyn/models/climber-y.git"
+            branch: main
             # AWI-internal repo currently ships src/*.f90 only (no Makefile /
             # configme manifest committed) - TODO once that's added upstream;
-            # until then this entry will fail configme install as-is.
-            git-repository: "git@gitlab.awi.de:paleodyn/models/climber-y.git"
+            # until then comp_command's `configme install` will fail for this
+            # version even though the esm_master clone itself succeeds.
 
     # climber-clim: atmosphere + ocean + sea ice + land, no bgc/ice-sheet.
     # Matches the default standalone scope agreed for this integration; the
     # other three flavors (climber-clim-bgc / -ice / -bgc-ice) require the
     # private bgc/vilma components and are out of scope for now.
     climberx_flavor: climber-clim
-    # Albedo is the only esm-tools machine target for now. configme's machine
-    # naming doesn't match esm-tools' computer.name (esm-tools: "albedo" vs
-    # configme: "awi_albedo"), hence the separate variable instead of
-    # interpolating ${computer.name} directly.
-    climberx_configme_machine: awi_albedo
-    climberx_compiler: ifx
+    # configme's machine naming doesn't match esm-tools' computer.name
+    # (esm-tools: "albedo" vs configme: "awi_albedo"), hence the separate
+    # variable instead of interpolating ${computer.name} directly. Albedo is
+    # the only esm-tools machine target wired up so far; add further entries
+    # here as more machines are supported.
+    choose_computer.name:
+        albedo:
+            climberx_configme_machine: awi_albedo
+            climberx_compiler: ifx
 
     model_dir: "${general.esm_master.dir}/climberx-${version}"
     bin_dir: "${model_dir}"
@@ -188,9 +206,11 @@ climberx:
     # input_files can be filled in; not addressed by this standalone-build pass.
 
 computer:
-    add_module_actions:
-        - load intel-oneapi-compilers/2024.0.0
-        - load netcdf-c/4.8.1-openmpi4.1.3-oneapi2022.1.0
-        - load netcdf-fortran/4.5.4-oneapi2022.1.0
-        - load udunits/2.2.28
-        - load python/3.10.4
+    choose_computer.name:
+        albedo:
+            add_module_actions:
+                - load intel-oneapi-compilers/2024.0.0
+                - load netcdf-c/4.8.1-openmpi4.1.3-oneapi2022.1.0
+                - load netcdf-fortran/4.5.4-oneapi2022.1.0
+                - load udunits/2.2.28
+                - load python/3.10.4

--- a/configs/components/climberx/climberx.yaml
+++ b/configs/components/climberx/climberx.yaml
@@ -113,6 +113,13 @@ climberx:
     # variable instead of interpolating ${computer.name} directly. Albedo is
     # the only esm-tools machine target wired up so far; add further entries
     # here as more machines are supported.
+    # NOTE: confirmed on Albedo that configme's `awi_albedo` machine profile
+    # does NOT work with -c gfortran (only tested/working with -c ifx as set
+    # below). A gfortran build on Albedo needs `-m linux -c gfortran` instead,
+    # with modules gcc/12.1.0 + netcdf-fortran/4.5.4-gcc12.1.0 - and even then
+    # ncdump isn't on PATH with those modules alone. Not wired up as a choice
+    # here since ifx is the documented/working path; flagging so nobody
+    # rediscovers this by trial and error.
     choose_computer.name:
         albedo:
             climberx_configme_machine: awi_albedo
@@ -200,10 +207,34 @@ climberx:
     bin_sources:
         exec: "${bin_dir}/${executable}"
 
-    # TODO: input_dir/maps forcing paths depend on the (large, separate)
+    # TODO: input_dir/maps forcing paths depend on the (large, ~12GB, separate)
     # climber-x-input data repo (gitlab.pik-potsdam.de/cxesmc/climber-x-input)
     # - needs a real pool_dir location on Albedo before outdata_files/
     # input_files can be filled in; not addressed by this standalone-build pass.
+    #
+    # WARNING: SCRIP map generation (`runme --gen-maps`, see generating-maps.md
+    # upstream) is NOT concurrency-safe - two jobs racing on a fresh checkout
+    # have corrupted a map file and killed a run (confirmed on Albedo). Maps
+    # must be generated once, serially, before any ensemble/parallel install,
+    # and the resulting pool_dir/maps should be shared read-only across runs
+    # rather than regenerated per experiment.
+
+    # KNOWN BLOCKER: lnd_alloc() in src/lnd/lnd_model.f90 (climate-x, all
+    # versions tested so far) leaves ~328 allocatable arrays in lnd_2d_class
+    # uninitialized. This doesn't crash at compile time or on the compiler
+    # flags side (-finit-real=zero does not reach derived-type allocatable
+    # components), it crashes the netCDF output writer around model year
+    # ~1000 - cost two full ~2.5h runs on Albedo before being identified.
+    # A source patch (not a runtime workaround) is required before this
+    # component can be used for any run past that point. The patch generator
+    # that produced a working fix lived at a personal scratch path on Albedo
+    # (/albedo/work/user/hlantuit/climber/patch_lnd_init.py) and is now gone
+    # - it was never vendored, so it could not be committed here. Whoever
+    # regenerates it should commit the patch (not just the generator) under
+    # configs/components/climberx/patches/lnd_alloc_init.patch and wire it
+    # into comp_command with:
+    #   patch -p1 -d ${model_dir} < ${some_esm_tools_path}/patches/lnd_alloc_init.patch
+    # right after the git-repository clone and before `make`.
 
 computer:
     choose_computer.name:


### PR DESCRIPTION
## Summary
- Adds a standalone (`climber-clim` flavor) esm-tools component for CLIMBER-X, the PIK EMIC (github.com/cxesmc/climber-x), plus an AWI-internal variant `climber-y` (gitlab.awi.de/paleodyn/models/climber-y) as an alternate `version:`.
- esm_master clones climberx itself via `git-repository`/`branch` per version (same convention as every other component). `comp_command` then drives climber-x's own `configme` tool to clone+configure+build the dependency stack (fesm-utils, yelmo) against that checkout, and `make <flavor>`.
- Namelist and restart file names (`control.nml`, `atm_par.nml`, ..., `atm_restart.nc`, ...) were taken from a real local `configme install climber-x` + repo inspection, not guessed from docs.
- Machine/compiler specifics are gated behind `choose_computer.name: albedo:` per review feedback.

## Known gaps / hazards (flagged inline, confirmed against real Albedo runs)
- **Blocker**: `lnd_alloc()` in `src/lnd/lnd_model.f90` leaves ~328 allocatable arrays uninitialized, crashing the netCDF writer around model year ~1000. Cost two ~2.5h runs on Albedo before being identified. Needs a source patch (compiler flags don't reach derived-type allocatable components). The patch generator that fixed this lived at a personal scratch path on Albedo and is gone before it could be vendored here — exact repro location and a `comp_command` hook for the eventual patch are documented inline.
- **Hazard**: SCRIP map generation (`runme --gen-maps`) is not concurrency-safe — a race on a fresh checkout corrupted a map file and killed a run. Documented as a hard warning against parallel/ensemble installs before maps exist.
- `climber-y` currently has no build system committed upstream (src/*.f90 only) — its `comp_command` will fail until that's fixed AWI-side.
- `input_dir`/`maps` forcing-data wiring depends on the separate `climber-x-input` data repo and a real `pool_dir` path on Albedo — not filled in yet (data exists on Albedo already, ~12GB, path TBD).
- Only `climber-clim` (climate-only, no bgc/ice-sheet) is wired; the other 3 flavors need the private `bgc`/`vilma` components.
- Confirmed the `awi_albedo` configme machine profile does not work with `-c gfortran` (only tested working: `-m linux -c gfortran` with `gcc/12.1.0` + `netcdf-fortran/4.5.4-gcc12.1.0`, and even then `ncdump` isn't on PATH). Not a blocker since we use `-c ifx`, documented to save the next person the trial-and-error.
- No `configs/couplings/` entry yet — standalone only, per current scope.

## Test plan
- [x] YAML syntax validated with `yaml.safe_load`
- [x] Namelist/restart/build info verified against a real `configme install climber-x -m macbook -c gfortran` run (climate-x cloned + fesm-utils/yelmo dep stack cloned; fesm-utils build itself hit an unrelated macOS/arm64 toolchain issue, irrelevant to the Albedo target)
- [x] Real-world build/run findings from Albedo (lnd_alloc bug, map-gen race, gfortran profile mismatch) folded in
- [ ] Not yet tested with `esm_master install-climberx` end-to-end on Albedo
- [ ] lnd_alloc() patch still needs to be regenerated and vendored before this component can run past ~model year 1000