### PR TITLE
esm-catalog/public-oidc-client

### DIFF
--- a/src/esm_catalog/auth.py
+++ b/src/esm_catalog/auth.py
@@ -199,11 +199,16 @@ def build_login_url(
 def _request_token(
     meta: OIDCMetadata, settings: Settings, data: dict[str, str]
 ) -> TokenSet:
-    """POST to the token endpoint with client-secret-basic auth; return a TokenSet."""
+    """POST to the token endpoint as a public client; return a TokenSet.
+
+    ``esm-catalog-dev`` is registered with Helmholtz AAI as a public client
+    (confirmed with HIFIS support, 2026-09-07): PKCE alone authenticates the
+    authorization-code exchange (RFC 7636), no client secret involved, so
+    ``client_id`` goes in the body rather than an HTTP Basic auth header.
+    """
     resp = httpx.post(
         meta.token_endpoint,
-        data=data,
-        auth=(settings.client_id, settings.client_secret.get_secret_value()),
+        data={"client_id": settings.client_id, **data},
         timeout=15,
         verify=settings.verify_tls,
     )

--- a/src/esm_catalog/cli.py
+++ b/src/esm_catalog/cli.py
@@ -14,10 +14,10 @@ and which files have been scanned, for incremental re-scans). ``push`` bulk-load
 new shards into the server's pgstac, which stac-fastapi-pgstac then serves to the
 web viewer.
 
-Configuration (identity-provider settings, ``client_secret``, a default
-``server_url``) comes from environment variables prefixed ``ESM_CATALOG_`` or
-from a config file — run ``esm-catalog status`` to see what is currently
-resolved and where the config file would live.
+Configuration (identity-provider settings, a default ``server_url``) comes
+from environment variables prefixed ``ESM_CATALOG_`` or from a config file —
+run ``esm-catalog status`` to see what is currently resolved and where the
+config file would live.
 """
 
 from __future__ import annotations
@@ -32,10 +32,10 @@ import rich_click as click
 from esm_catalog import __version__
 
 _CONFIG_EPILOG = (
-    "Configuration (identity-provider settings, client_secret, a default "
-    "server_url) comes from environment variables prefixed 'ESM_CATALOG_' "
-    "(e.g. ESM_CATALOG_SERVER_URL) or a config file — run 'esm-catalog status' "
-    "to see what is currently resolved and where the config file would live."
+    "Configuration (identity-provider settings, a default server_url) comes "
+    "from environment variables prefixed 'ESM_CATALOG_' (e.g. "
+    "ESM_CATALOG_SERVER_URL) or a config file — run 'esm-catalog status' to "
+    "see what is currently resolved and where the config file would live."
 )
 
 
@@ -171,8 +171,8 @@ def auth_login(server_url: str, open_browser: bool, insecure: bool) -> None:
     overwrite the first's token). SERVER_URL only labels which server this
     token is for — it is not itself contacted for login. The identity provider
     (who actually issues the token) is a separate system, configured via
-    oidc_discovery_url/client_id/client_secret (env or config file); see
-    'esm-catalog status' or the config file for what is currently resolved.
+    oidc_discovery_url/client_id (env or config file); see 'esm-catalog
+    status' or the config file for what is currently resolved.
     """
     from esm_catalog import auth as _auth
     from esm_catalog.config import Settings

--- a/src/esm_catalog/config.py
+++ b/src/esm_catalog/config.py
@@ -3,24 +3,19 @@
 Resolution order (highest precedence first):
 
 1. explicit keyword arguments (e.g. ``--server`` on the CLI),
-2. environment variables prefixed ``ESM_CATALOG_`` (e.g. ``ESM_CATALOG_CLIENT_SECRET``),
+2. environment variables prefixed ``ESM_CATALOG_``,
 3. the YAML config file at ``$XDG_CONFIG_HOME/esm-catalog/config.yaml``.
 
-Only ``server`` and OIDC client credentials are needed to push. A minimal
-``config.yaml`` looks like::
+Only ``server`` is needed to push — the OIDC client id already defaults to the
+registered public client. A minimal ``config.yaml`` looks like::
 
     server_url: https://stac-dev.dmawi.de
-    oidc_discovery_url: https://login-dev.helmholtz.de/oauth2/.well-known/openid-configuration
-    client_id: esm-catalog-dev
-    client_secret: "…"          # or set ESM_CATALOG_CLIENT_SECRET
-    redirect_uri: https://stac-dev.dmawi.de
 """
 
 from __future__ import annotations
 
 from typing import Optional
 
-from pydantic import SecretStr
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -73,11 +68,9 @@ class Settings(BaseSettings):
     #: OIDC discovery document URL (the identity provider, e.g. Helmholtz AAI).
     oidc_discovery_url: Url = DEFAULT_DISCOVERY_URL
 
-    #: OAuth client id registered with the IdP for this catalog.
+    #: OAuth client id registered with the IdP for this catalog. Public client
+    #: (PKCE-only, no secret) — confirmed with HIFIS support, 2026-09-07.
     client_id: ClientId = DEFAULT_CLIENT_ID
-
-    #: OAuth client secret. Prefer ``ESM_CATALOG_CLIENT_SECRET`` over the file.
-    client_secret: SecretStr = SecretStr("")
 
     #: Redirect URI registered with the IdP; the login code lands here.
     redirect_uri: Url = DEFAULT_REDIRECT_URI

--- a/tests/test_esm_catalog/test_auth.py
+++ b/tests/test_esm_catalog/test_auth.py
@@ -186,10 +186,3 @@ def test_verify_tls_from_env(monkeypatch):
     assert Settings().verify_tls is False
     monkeypatch.setenv("ESM_CATALOG_VERIFY_TLS", "true")
     assert Settings().verify_tls is True
-
-
-def test_secret_not_leaked_in_repr(monkeypatch):
-    monkeypatch.setenv("ESM_CATALOG_CLIENT_SECRET", "supersecret")
-    s = Settings()
-    assert "supersecret" not in repr(s)
-    assert s.client_secret.get_secret_value() == "supersecret"


### PR DESCRIPTION
Drops \`client_secret\` from the OIDC client — \`esm-catalog-dev\` is registered as a **public** client on Helmholtz ID (confirmed with HIFIS support, 2026-09-07). PKCE alone authenticates the authorization-code exchange; a secret was never needed, and distributing one to every CLI user's machine defeated the point of using PKCE at all.

Verified empirically before making the change: POSTed to the token endpoint with \`client_id\` only (no secret) and a deliberately-invalid auth code — got \`invalid_grant\` ("wrong code"), not \`invalid_client\`/\`unauthorized_client\`. Confirms the IdP accepts client-auth-free requests for this \`client_id\`.

- \`auth.py\`: \`_request_token\` sends \`client_id\` in the body, drops HTTP Basic auth entirely
- \`config.py\`: \`Settings.client_secret\` removed
- \`cli.py\`: docstring/epilog mentions updated
- \`test_auth.py\`: removed the now-meaningless secret-not-leaked test

Full suite run against this + against unmodified \`prep-release\` for baseline comparison: same 5 pre-existing failures both sides (macOS \`platformdirs\`/XDG env-var quirk, unrelated), zero new failures from this change.