### PR TITLE
esm-catalog/suppress-cftime-warning

### DIFF
--- a/src/esm_catalog/scan/readers/netcdf/open.py
+++ b/src/esm_catalog/scan/readers/netcdf/open.py
@@ -8,6 +8,8 @@ decoding is reopened with ``decode_times=False`` for hand-decoding downstream.
 
 from __future__ import annotations
 
+import warnings
+
 import xarray as xr
 from loguru import logger
 from upath import UPath
@@ -27,6 +29,13 @@ def _open_dataset(path: UPath) -> xr.Dataset:
     reopen with ``decode_times=False`` and decode the time coordinate by hand
     downstream. Each attempt opens a fresh handle, since a consumed remote stream
     cannot be re-read.
+
+    Dates outside ``datetime64[ns]`` range (routine for paleoclimate runs) do not
+    raise -- xarray decodes them to ``cftime`` objects instead and emits
+    ``SerializationWarning``. Expected and already handled downstream
+    (:mod:`esm_catalog.scan.readers.netcdf.timeaxis` accepts cftime objects same
+    as datetime64), so it is suppressed here rather than left to print on every
+    such file.
     """
     is_remote = bool(path.protocol) and path.protocol != "file"
     logger.debug("Opening NetCDF {} (remote={})", path, is_remote)
@@ -46,7 +55,9 @@ def _open_dataset(path: UPath) -> xr.Dataset:
             raise
 
     try:
-        return _open(decode_times=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=xr.SerializationWarning)
+            return _open(decode_times=True)
     except (ValueError, OSError) as error:
         if _is_time_decode_error(error):
             logger.debug("Time decode failed for {}; retrying undecoded", path)


### PR DESCRIPTION
Suppresses xarray's \`SerializationWarning\` — "Unable to decode time axis into full numpy.datetime64 objects, continuing using cftime.datetime objects instead, reason: dates out of range" — which fires on every paleoclimate file whose dates fall outside \`datetime64[ns]\` range.

It's a warning, not an exception: \`xr.open_dataset(..., decode_times=True)\` succeeds and falls back to cftime objects on its own. Downstream (\`timeaxis.py\`) already handles cftime objects the same as \`datetime64\` (\`_to_utc_datetime\` checks \`hasattr(value, "year")\`), so this was pure noise, not a functional gap — flagged by a human running \`esm-catalog scan\` on a real experiment tree and seeing it repeatedly.

Verified with a synthetic reproduction (a -0500, noleap-calendar dataset) before and after: 0 \`SerializationWarning\`s after the fix, cftime decoding still correct (\`cftime.DatetimeNoLeap\` objects, as expected).

Separate concern from #1580 (client_secret removal), split into its own branch/PR per house convention.